### PR TITLE
Add option to send extra options to Braintree

### DIFF
--- a/spec/fixtures/cassettes/braintree/authorize.yml
+++ b/spec/fixtures/cassettes/braintree/authorize.yml
@@ -8,114 +8,11 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount>10.0</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
-          <options>
-            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
-          </options>
-          <type>sale</type>
-        </transaction>
-    headers:
-      Accept-Encoding:
-      - gzip
-      Accept:
-      - application/xml
-      User-Agent:
-      - Braintree Ruby Gem 2.66.0
-      X-Apiversion:
-      - '4'
-      Authorization:
-      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
-      Content-Type:
-      - application/xml
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Fri, 02 Sep 2016 22:37:08 GMT
-      Content-Type:
-      - application/xml; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      X-Frame-Options:
-      - SAMEORIGIN
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Authentication:
-      - basic_auth
-      X-User:
-      - 3v249hqtptsg744y
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Etag:
-      - W/"a85394242d425cac7884c1f46aee6514"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - bd7d3219-5e82-4d47-ad73-ee20429ae9a7
-      X-Runtime:
-      - '0.346961'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIABT/yVcAA+xYS3PbNhC+51d4dIcpyXrZIzOPsZtxJ4dOEx/aiwckliJq
-        EmABUJby67sgSIoUwdidyaGH3sTdDwvsA7sftH1/yLOLPSjNpbidzC6nkwsQ
-        sWRc7G4nj99+IZvJ+/Dd1igqNI0NosJ3FxdbzsIiOS5okh62AX5YmTbUlDqk
-        pUml4t+BbYNaZLXmWECoaQbboPppZXGpFO52JFxLgptC+Pj1bhsMxRZMc1kK
-        E86ml9PpNqi/rCIHFadUGELj2AoJnkcbyCOZmW3g01anLSPi0V0Int1OjCph
-        EjjrFG2pN0GlYoj0KGIF1AAj1FxY328nDD8Nz2ESzqezFZlek+n823x+c7W+
-        mW7+xAi0C6r1ZcH+3frTgjrO2kj0wH645M2uN+vZerpukofShCttiKA5nJ8f
-        lRkd18UyL6g4ejSQU5555C8QaW58topUCp88oYdBVIOuW9uIZxkWbeuiz8jP
-        91AbBYBFwZgCrX0hOBgQzKZiFJLJmGbc+Mwr2OGN88VJ4tXKqsvhPS9WqDqO
-        u+PUdjWhWZHS+ZtQV6+hRInZ4PEwU53koE9JKZjvmrQaXZc5VYoee0oMZKcV
-        +YwUVBmOodFgTAY54FXtr/AZP/Ws18x3zEbUxKkXk/Ki+L8W/6O12M1O3RlJ
-        wiFjuq6FvSaglFQEY1RIocHrWoXruN5Hhw84on4IaEz0s+a38kNM5cZ+P1w5
-        FFroDgfDCz2i5i9wVY6zRg8Tuy2UjHE3jENzO2gF9wbjBO7vOJvaYT2mHVlp
-        sFDDjwVq9pZEjCGqCDLG7akwxkPY4JR7yWObhwTziyuwRCJQQ19KO+pxFzfP
-        R1CGHogjIV4VHCAvmnEdSZkBFZMwoZm2BKgFNPQAvSAxVc0sNvIZRLh4+b56
-        fkF49eU0EfddwaphLHxXAm0SewhvOyi4cjnNpTBpuA0GogHyCFT1gZWk3q0e
-        yMS2EePvFvZEqcyqyPpbAs/pDkipsjA1ptA3QUA1tl19GSnKhb0KdQ1fYi8M
-        Cnq03fgpByxS9pTJnQxK8Szki7gsxO49iD1XUljMraaCRdIy1naLuoUpKCgy
-        oUe30NacEzh1CjQzKZ4cToiOzIEYRNyc9O6zVpUK84aFtyszy8s6qHNN2+Qt
-        4cQ5doJ2ZPWh6VHJrINoBHUYtS6xzeGYEs8nTE/ab5syIVZLRQzdXYfKJmaS
-        lXHFpztha2UOVAr+dwn1HUIxZoFjsx1cJ3s5QeSSaPY8cmlafU3++pemfn2Q
-        lGMJqmNvxrfzsUIAGqoTY28asmhU5MUbmXWLby388NlTIcZeLi5CGglsW9kf
-        moeLrW3k8boh7faoHWaiJTYpCGnB8UhDuXM4OPe4ldRRcu0uo36mU0Y6VrwY
-        ZUIdfducKppHCpy8khEkG8TG05PsMyQeSxkvFo98to/t+QTbu4fGMa6revXq
-        wFmRTbMa6T5jLxBsFsOz9Y0iRbJPV/RrpIRbvWv7+J4UMLSKOd/bOZUAjE0Y
-        u618IS6bAy2GISqVdiyVgcFHmG46UU/lz02H4vq372MGr/U3wuFgA4BtWPmP
-        Yek+VioSM5/BMo49DBYzMuK79bwoDfhKox4hhAskWqV7Mti/KFBe0OypfvFv
-        gzFcn8Z0fO2znS6TGQW9bqviPq/ZagmSSbGrELxhtvQAj55Iz5PJ+vkq9UAY
-        9vDqTR9Wvz/AARthBq5XddXtAhcvFv728Q+yitYLgNkS5utkOaNsuVkvV5vV
-        VSewzdjoM04Uf/345Z7QZBVdLSBasWQxgyXFXnqO+1kMwoXk7QQCp325swe4
-        u//0+Jmw6ZzSTby5vr6OKirglKc4Ahn7b6T7IvG1pyrKLqL3vz893JFkuqGr
-        2YIl8Xx5tV7Om0z09lPk9OAMf5WpaFAdcRfdvkDDOwkN9iRsbnWWoRgr0dRP
-        iXrw3X95+Pzw6cs9Nu8xSEMGC1OVpc/V0T8KzmbheJ/0AN/SrZqu7iGw26C5
-        LL25G777BwAA//8DANMsoGFJFQAA
-    http_version: 
-  recorded_at: Fri, 02 Sep 2016 22:37:08 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <transaction>
           <amount>10.00</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
+          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>
     headers:
@@ -137,7 +34,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 06 Sep 2016 21:24:41 GMT
+      - Tue, 06 Sep 2016 22:00:26 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -158,52 +55,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"4a40831a6e4a256dcfa5ffc65f0d98e7"
+      - W/"9c6175b1dda34c0adbd771dfdf536548"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 175767db-9c2a-4903-a6d3-f1e4b07b0b6e
+      - 1bb7b319-415b-43f7-b94e-984ee04503bf
       X-Runtime:
-      - '0.301923'
+      - '0.302415'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIABk0z1cAA+xYS3PbNhC+51d4dIdJPSw/hmYeYzfjTg6dJj60Fw9IrkTU
-        IMACoCzl13dBkBQpgrE7k0MPvYm7HxbYB3Y/KHq/L/jZDpRmUtzO5ufh7AxE
-        KjMmtrezx2+/kKvZ+/hdZBQVmqYGUfG7s7OIZXEiyjzT+TYK8MPKtKGm0jGt
-        TC4V+w5ZFDQiqzWHEmJNOURB/dPK0kop3O1AmJYEN4X48etdFIzFFkwLWQkT
-        z8PzMIyC5ssqClBpToUhNE2tkOB5tIEikdxEgU9bn7ZKiEd3Jhi/nRlVwSxw
-        1inaUm+CSpUh0qNIFVADGaHmzPp+O8vw07ACZvEinK9JeE3C9bfF/GaxulnN
-        /8QIdAvq9VWZ/bv1xwVNnLWR6IH9cMm7ug5Xl1cXYZs8lG6Y0oYIWsDp+VHJ
-        6bQulUVJxcGjgYIy7pG/QKKZ8dkqcyl88g3dj6Ia9N2KEsY5Fm3nos/Iz/dQ
-        GwWARZFlCrT2hWBvQGQ2FZMQLlPKmfGZV7DFG+eLk8SrxevL4T0vVqg6TLvj
-        1HY1obzM6eJNqOVrKFFhNlg6zlQvOejTphKZ75p0Gt2UOVWKHgZKDGSvFfmM
-        lFQZhqHRYAyHAvCqDlf4jB971mvme2YTatLci8lZWf5fi//RWuxnp+mMZMOA
-        Z7qphZ0moJRUBGNUSqHB61qN67k+RMcPOKJ+CGhNDLPmt/JDTO3GbjdeORZa
-        6BYHwws9oOYvcFWOs0aPExuVSqa4G8ahvR20hnuDcQQPd5yHdlhPaSdWGizU
-        +GOJmp0lEVOIOoJZxuypMMZj2OiUO8lSm4cN5hdXYIkkoMa+VHbU4y5unk+g
-        DN0TR0K8KthDUbbjOpGSAxWzeEO5tgSoA7T0AL0gKVXtLDbyGUS8NodrvUB4
-        /eU0CfNdwbphrHxXAm0SewhvOyiZcjktpDB5HAUj0Qh5AKqGwFrS7NYMZGLb
-        iPF3C3uiXPI6sv6WwAq6BVIpHufGlPomCKjGtqvPE0WZsFehqeFz7IVBSQ+2
-        Gz8VgEWaPXG5lUElnoV8Eeel2L4HsWNKCou51VRkidwj6em2aFqYgpIiE3p0
-        C23NOYFT50C5yfHkcET0ZA6UQcLMUe8+G1WlMG9YeNuKW17WQ51quiZvCSfO
-        sSO0J2sOTQ9K8h6iFTRh1LrCNodjSjwfMQPpsG3KDbFaKlLo7zpWtjGTWZXW
-        fLoXtk7mQJVgf1fQ3CEUYxYYNtvRdbKXE0Qhic6eJy5Np2/I3/DSNK8PkjMs
-        QXUYzPhuPtYIQENNYuxNQxaNiqJ8I7Pu8J2FHz57asTUy8VFSCOB7Sr7Q/tw
-        sbWNPF63pN0etcdMtMQmBTEtGR5pLHcOB6ced5ImSq7dcepnOlWiU8XKSSbU
-        03fNqaZ5pMTJKzOCZIPYeHqSfYLEYynjxeKRT/axPZ9ge/fQuIzpul69OnBW
-        ZNusJrrP1AsEm8X4bEOjSJHs0xX9mijhTu/aPr4nBYytYs53dk5tAKYmjN1W
-        vhCXzZEWw5BUSjuWmoHBR5huO9FA5c9Nj+L6tx9iRq/1N8JhbwOAbVj5j2Hp
-        PlYqEjOfwSpNPQwWMzLhu/W8rAz4SqMZIYQJJFqVezLYvyhQXlL+1Lz4o2AK
-        N6QxPV+HbKfPZCZBr9uquc9rtjqCZHLsKgRvmC09wKNvpOfJZP18lXogDHt4
-        /aaP698fYI+NkIPrVX11t8DFK4t/+/gHSUNYrFbJfAnXF6t5tswu6DqE9boX
-        2HZsDBknir9+/HJPYLm4WGySq3kIV5friyX20lPcz2IQLiRvJxA47autPcDd
-        /afHzyTdhIvlJb2cQwo1FXDKYxyBTP030n+R+NpTHWUX0fvfnx7uyDJZzDfL
-        Zbqml9frZHXVZmKwnyLHB2f8q8xFi+qJ++juBRrfSWixR2F7qzlHMVaiaZ4S
-        zeC7//Lw+eHTl3ts3lOQlgyWpi5Ln6uTfxSczMLpPukBvqVbtV3dQ2CjoL0s
-        g7kbv/sHAAD//wMAZRnnq0kVAAA=
+        H4sIAHo8z1cAA+xYS3PbNhC+51d4dIdJybYke2g6ydjNuJNDp4kP7cUDEisR
+        MQiwAChL/fVd8CXSBG13JoceehN3PyywD+x+UHSzz8XJDrThSl7P5qfh7ARk
+        qhiX2+vZw/dfyHp2E3+IrKbS0NQiKv5wchJxFmt6tr4sfmRRgB9OZiy1pYlp
+        aTOl+d/AoqAROa09FBAbKiAKqp9OlpZa424Hwo0iuCnED99uo2AsdmCaq1La
+        eB6ehmEUNF9OkYNOMyotoWnqhATPYyzkiRI2Cnza6rRlQjy6E8nF9czqEmZB
+        bZ2iLf0uqNIMkR5FqoFaYITaE+f79Yzhp+U5zOJFOF+S8JKEy++LxVUYXi2W
+        f2IEugXV+rJg/279cUETZ2MVeuA+6uTNz9fnF+vVuk0eSjdcG0skzeHl+VEp
+        6LQuVXlB5cGjgZxy4ZE/Q2K49dkqMiV98g3dj6Ia9N2KEi4EFm3nos/Iz/fQ
+        WA2ARcGYBmN8IdhbkMylYhIiVEoFtz7zGrZ443xxUni1RHU5vOfFCtWHaXdq
+        tVtNqCgyungX6uwtlCwxGzwdZ6qXHPRpU0rmuyadxjRlTrWmh4ESA9lrRT4j
+        BdWWY2gMWCsgB7yqwxU+48ee9Zb5ntmE2jTzYjJeFP/X4n+0FvvZaToj2XAQ
+        zDS1sDMEtFaaYIwKJQ14XatwPdeH6PgeR9SrgNbEMGt+K69iKjd2u/HKsdBB
+        tzgYnukBNT+grnKcNWac2KjQKsXdMA7t7aAV3BuMI3i44zx0w3pKO7HSYqHG
+        nwrU7ByJmEJUEWSMu1NhjMew0Sl3iqcuDxvML67AEklAj30p3ajHXep5PoGy
+        dE9qEuJVwR7yoh3XiVICqJzFGyqMI0AdoKUH6AVJqW5nsVVPIOOzZL8/aIRX
+        X7Um4b4rWDWMc9+VQJvEHcLbDgqu65zmStosjoKRaIQ8ANVDYCVpdmsGMnFt
+        xPq7hTtRpkQVWX9L4DndAim1iDNrC3MVBNRg2zWniaZcuqvQ1PAp9sKgoAfX
+        jR9zwCJlj0JtVVDKJ6me5Wkhtzcgd1wr6TDXhkqWqD2Snm6LpoVpKCgyoYd6
+        oau5WlCrM6DCZnhyOCJ6shrEIOH2qK8/G1WpMW9YeNtSOF7WQ73UdE3eEU6c
+        Y0doT9Ycmh60Ej1EK2jCaEyJbQ7HlHw6YgbSYdtUG+K0VKbQ33WsbGOmWJlW
+        fLoXtk5Wg0rJ/yqhuUMoxixwbLaj6+QuJ8hcEcOeJi5Np2/I3/DSNK8PknEs
+        QX0YzPhuPlYIQENNYtxNQxaNirx4J7Pu8J2FV589FWLq5VJHyCCB7Sr7Y/tw
+        cbWNPN60pN0dtcdMjMImBTEtOB5pLK8dDl563EmaKNXtTlA/0ykTk2peTDKh
+        nr5rThXNIwVOXsUIkg3i4ulJ9gskHktbLxaP/GIf1/MJtncPjWPcVPXq1UFt
+        RbXNaqL7TL1AsFmMzzY0ihTJPV3Rr4kS7vR128f3pISxVcz5zs2pDcDUhHHb
+        qmdSZ3OkxTAkpTY1S2Vg8RFm2k40UPlz06O4/u2HmNFr/Z1w2LsAYBvW/mM4
+        uo+VisTMZ7BMUw+DxYxM+O48L0oLvtJoRgjhEolWWT8Z3F8UKC+oeGxe/FEw
+        hRvSmJ6vQ7bTZzKToLdtVdznLVsdQbIZdhWCN8yVHuDRN8rzZHJ+vkk9EIY9
+        vHrTx9Xvj7DHRiig7lV9dbegjheLf/v0B2Gr+WKxCSksF8tlmC5WZ4zN5+es
+        F9h2bAwZJ4q/ffp6R1brMLxYXcI5wOXlxRleqBHuZzGIOiTvJxA47cutO8Dt
+        3eeHL+RyntD1PF2erVe0ogK18hhHIFP/jfRfJL72VEW5jujd74/3tzii2JLN
+        KdusF7C8YKs2E4P9NDk+OONfVSZbVE/cR3cv0PhWQYs9CttbLQSKsRJt85Ro
+        Bt/d1/sv95+/3mHznoK0ZLCwVVn6XJ38o+DFLJzukx7ge7pV29U9BDYK2ssy
+        mLvxh38AAAD//wMANGaxaUkVAAA=
     http_version: 
-  recorded_at: Tue, 06 Sep 2016 21:24:41 GMT
+  recorded_at: Tue, 06 Sep 2016 22:00:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/braintree/payment.yml
+++ b/spec/fixtures/cassettes/braintree/payment.yml
@@ -8,118 +8,13 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">5500</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
-          <options>
-            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
-            <submit-for-settlement type="boolean">true</submit-for-settlement>
-          </options>
-          <type>sale</type>
-        </transaction>
-    headers:
-      Accept-Encoding:
-      - gzip
-      Accept:
-      - application/xml
-      User-Agent:
-      - Braintree Ruby Gem 2.66.0
-      X-Apiversion:
-      - '4'
-      Authorization:
-      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
-      Content-Type:
-      - application/xml
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Fri, 02 Sep 2016 22:36:03 GMT
-      Content-Type:
-      - application/xml; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      X-Frame-Options:
-      - SAMEORIGIN
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Authentication:
-      - basic_auth
-      X-User:
-      - 3v249hqtptsg744y
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Etag:
-      - W/"1fca2063410b600590b2ad423e4ed3c9"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - f311b38c-7db3-4213-b2b8-cf0c0dc98643
-      X-Runtime:
-      - '0.430471'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIANP+yVcAA+xYS2/bOBC+91cEvjOSn4kLR23aZIsseija5rB7CShpZHEj
-        kSpJOXZ//Q5FSZYsqskCXaDA7s2e+fiYB2e+0ebNPs/OdiAVE/xqMj33J2fA
-        IxEzvr2a3H/9jVxO3gSvNlpSrmikERW8OjvbsDi4+PY9PCxns42Hf4xMaapL
-        FSjQOsPlG68WGJ0+FBAomsHGq34aWVRKiWcdCFOC4JEQ3H+52XhDsQHTXJRc
-        B8ul75/7/sar/xtVDjJKKdeERpEREryP0pCHItMbz6WtbluGxKE74yy7mmhZ
-        wsSzu1PcS74IKmSMSIcikkA1xITqM2P91STGv5rlMAlm/nRF/DXxZ19ns9fz
-        1Wt//if6oF1QrS+L+J+tPy6oPa20QAvMHxu86WK5WK8uLprgoTRhUmnCaQ6n
-        90dlRsd1kcgLyg8ODeSUZQ75E4SKaddeRSq4S57Q/cCrXtesTcgyk3Wtia5N
-        fr6FSksATIo4lqCUywV7DTw2oRiFZCKiGdOu7SVs8cW5/CTwcWXV83DeFzNU
-        HsbNsWqzmtCsSOnsRaj5cyheYjRYNIxUJzhoU1Ly2PVMWo2q05xKSQ89JTqy
-        U4pcmxRUaoauqcoQ5IBPtb/CtTktdSok+/789p1tQ6qj1IlJWVH8n4u/aC52
-        o1NXRpIwyGJV58JOEZBSSII+KgRX4DStwnVM76ODO2xRPwQ0W/Sj5t7lh5jK
-        jN1uuHIoNNAtNoYnekDNX2CzHHuNGgZ2U0gR4Wnoh+Z10ArudMYR3D9x6ptm
-        PaYdWakxUYPrAjU7iJ2rK0TlwThm5lbo4yFscMudYJGJQ4LxxRWYIiHIoS2l
-        afV4iu3nIyhN98SSEKcK9pAXTbsOhciA8kmQ0EwZCtQCGnqAVpCIyqYXa/EI
-        PFiv4l3yhPDqn9WEzPUEq4KxcD0J3JOYSzjLQcGkjWkuuE6DjTcQDZAHoLIP
-        rCT1aXVDJqaMaHe1MDdKRVZ51l0SWE63QEqZBanWhXrteVRh2VXnoaSMm6dQ
-        5/A51kKvoAdTjR9ywCSNHzKxFV7JH7l44ucF374BvmNScIO5UpTHodgj6WmP
-        qEuYhIIiE7q3C03OWYFVp0AzneLN4YjoyCwohpDpo97+rVWlxLhh4m3LzPCy
-        DupU0xZ5Qzixjx2hHVl9aXqQIusgGkHtRqVKLHPYpvjjEdOT9sumSIjRUh5B
-        99ShsvGZiMuo4tMdt7UyCyo5+1ZC/YZQjFFgWGwHz8k8TuC5ICp+HHk0rb4m
-        f/1HU08fJGWYgvLQ6/Ftf6wQgBvVgTEvDVk0KvLihcy6xbc71FPOkUJ0B58K
-        MT67WB8ppLBtbr9tRheT3cjkVUPbzWU73EQJLFMQ0ILhpYZya7I3tPlfdgOO
-        VTnTmMkPiZAPR7b033aKYyT+1ZzQSuoXZFthRt0suAxVJFkxypI7+rZxVSMA
-        KZCViZggESXGn45CcILEa0ntxOKVT84xfIBg63dQ/JipqpY5dWB3EU0jG+lM
-        Y9MpNpLh3fqbIn02HzbQrpHy1uotJUgp5zDcFWO+MxwmARhjH+ZY8URsNAda
-        dENYSmUnmBg0Duiq6VI9lTs2nfHHfXwfM/iW80I47I0DsEVL9zXMKIiZiqTd
-        tWEZRY7pBiMyYruxvCg1uFKjpheEcSThpR0nzQcslBc0e6i/Bm28MVyf4nZs
-        7TPhxQlPHgU+v1/Fjd8LjhNm3qfPo+iKtKZYYgg+N5OHgHYkwjFbG6Of5agI
-        w2ZfffwJqt9vYY9VMQNbuLrqdoF1Xhx8uv6DLNeLJY0uljP/YnYxny0u5uv1
-        ZTj3O15u+EV/NEHxl+uPt8SPFtPlPPHjZJXMo/UaC+sp7mdRTeuSlzNNpIXl
-        1lzg5vbd/Qfi+7CMkssVLC+XFWe0yqMfgYx9ROuOrq5aVXnZevT288PdDVlE
-        8WwVLhJYzabh5XzVRKJ3niTHLxPB7yLlDaoj7qLbTxXBjYAGexQ2TzzLUIyZ
-        qOuZs+6Dtx/vPty9+3iLlXwM0kwNha7SMg7eX3/6ev/5Fi1CEngUNx8pRj4u
-        nfTIY/0MsPNO+42yo3SvHPly/TysyYG2aQ2LVPPGetsFr/4GAAD//wMA6r76
-        k6kXAAA=
-    http_version: 
-  recorded_at: Fri, 02 Sep 2016 22:36:03 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <transaction>
           <amount>55.00</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
+          <order-id>ORDER0-PAYMENT0</order-id>
+          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>
     headers:
@@ -141,7 +36,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 06 Sep 2016 21:24:39 GMT
+      - Tue, 06 Sep 2016 23:37:41 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -162,54 +57,54 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d17407559e70c2a4571b2169312b0f02"
+      - W/"47b63c0e1e18ba52b8c427c007fdebec"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 81b08d09-28d1-43be-9b22-f1e1a8746e23
+      - 4baf0024-2cde-4990-8ace-67fe43640c68
       X-Runtime:
-      - '0.449204'
+      - '0.559611'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIABc0z1cAA+xYS2/bOBC+91cEvjOSX4lTOErTJltk0UPRJofdS0CJI4uN
-        RGpJyrH763eolyWLarJAFyiwe7NnPj7mwZlvtL7aZenJFpTmUlxOpqf+5ARE
-        JBkXm8vJw/1vZDW5Ct6sjaJC08ggKnhzcrLmLFjE85nKvum1h3+sTBtqCh1o
-        MCbF5WuvFlid2ecQaJrC2it/WllUKIVn7QnXkuCREDx8vVl7Q7EF00wWwgTL
-        5anvr736n1VkoKKECkNoFFkhwdtoA1koU7P2XNryrkVIHLoTwdPLiVEFTLxq
-        d4p7qVdBpWKIdCgiBdQAI9ScWNsvJwz/Gp7BJJj50zPiXxD/7H42fTtbvJ1f
-        /IkeaBeU64uc/bP1hwW1n7WRaIH9U4Xu7GxxPvXnyyZ0KI250oYImsHx/VGZ
-        0nFdJLOcir1DAxnlqUP+DKHmxrVXnkjhksd0N/Cq1zVrHfLU5lxromuTn2+h
-        NgoAk4IxBVq7XLAzIJgNxSgklRFNuXFtr2CD783lJ4lPKy0fh/O+mKFqP25O
-        pbarCU3zhM5ehZq/hBIFRoNHw0h1goM2xYVgrmfSanSd5lQpuu8p0ZGdQuTa
-        JKfKcHRNWYQgA3yq/RWuzWlhEqn495e372wbUhMlTkzC8/z/XPxFc7Ebnboy
-        kphDynSdC1tNQCmpCPool0KD07QS1zG9jw7usEX9ENBs0Y+ae5cfYkozttvh
-        yqHQQjfYGJ7pHjXfoMpy7DV6GNh1rmSEp6EfmtdBS7jTGQdw/8Spb5v1mHZk
-        pcFEDa5z1GyBOVeXiNKDjHF7K/TxEDa45VbyyMYhxvjiCkyRENTQlsK2ejyl
-        6ucjKEN3pCIhThXsIMubdh1KmQIVkyCmqbYEqAU09ACtIBFVTS828glEED9v
-        V+cZwst/lSbkridYFoyF60ngnsRewlkOcq6qmGZSmCRYewPRALkHqvrAUlKf
-        VjdkYsuIcVcLe6NEpqVn3SWBZ3QDpFBpkBiT67eeRzWWXX0aKsqFfQp1Dp9i
-        LfRyurfV+DEDTFL2mMqN9ArxJOSzOM3F5grElispLOZSU8FCuUPS0x5RlzAF
-        OUUm9FAttDlXCSp1AjQ1Cd4cDoiOrAIxCLk56Ku/tapQGDdMvE2RWl7WQR1r
-        2iJvCSf2sQO0I6svTfdKph1EI6jdqHWBZQ7blHg6YHrSftmUMbFaKiLonjpU
-        Nj6TrIhKPt1xWyurQIXgfxVQvyEUYxQ4FtvBc7KPE0QmiWZPI4+m1dfkr/9o
-        6tmDJBxTUO17Pb7tjyUCcKM6MPalIYtGRZa/klm3+HaHesY5UIju2FMixiaX
-        ykMaCWyb2e+awcXmNvJ43ZB2e9UOM9ESixQENOd4paG8MtgbWvwvOwGHqowb
-        zOPHWKrHA1f6L7vEMQz/Wi5oJfXbqZpgSt38twh1pHg+yo87+rZlleSf5MjH
-        JCNIQYn1pqMEHCHxWso4sXjlo3MsEyDY9B3knnFdVjGnDqpdZNPCRnrS2FyK
-        LWR4t/6mSJztBw20a6SwtfqKDCRUCBjuijHfWvYSA4zxDnusfCZVNAdadENY
-        KF3NLgwMjua66U89lTs2ncHHfXwfM/iG80o47KwDsDkr9zXsEIiZinTdtWER
-        RY65BiMyYru1PC8MuFKjJhaEC6TfRTVI2g9XKM9p+lh/B1p7Y7g+ue3Y2ufA
-        iyOGPAp8eb+SFX+QAmfLrE+cR9ElXU2wxBB8bjYPAe2IpWOqtka/yE4Rhm2+
-        /OwTlL/fwQ5rYgpV4eqq2wWV81jw+foPEl6cscX5cjEPp6toHvur5Xx14Ydx
-        x8sNs+gPJSj+ev3ploQRrr6YzqJoGs4X8ykW1mPczyKZlUtezzGREBYbe4Gb
-        2/cPH8l0OYtXND734RxKtlgpD34EMvb5rDu0umpV6eXKo7dfHu9uiD87j9iS
-        zX3G2GrhsyYSvfMUOXyTCH6XiWhQHXEX3X6kCG4kNNiDsHniaYpizERTT5t1
-        F7z9dPfx7v2nW6zkY5BmXshNmZYs+HD9+f7hyy1ahPTvIG4+T4x8VjrqkYf6
-        Gfin/rTfKDtK98qRL9Yvw5ocaJvWsEg1b6y3XfDmbwAAAP//AwAGkG44oRcA
-        AA==
+        H4sIAEVTz1cAA+xYS3PbNhC+51d4dIdJmXpEGZmJE6sZd9I249iH9OIByaWI
+        mgQYAJSl/vou+BIpgrEP6Uxm2pu0+2GBXSx2v+X67T5Lz3YgFRP8cjI9dydn
+        wEMRMb69nNzf/UJeT976r9ZaUq5oqBHlvzo7W7PI//bk0dVyelg7+MfIlKa6
+        UL4CrVNcvnZqgdHpQw6+oimsnfKnkYWFlLjXgTAlCG4J/v2X67UzFBswzUTB
+        tT+fn7vu2qn/GUUGMkwo14SGoRESPI3SkAUi1WvHpi3PWgTEojvjLL2caFnA
+        xKmsU7QlXwQVMkIk2v/j9npz65LPV19/2/x+h6dtNaXXEqiGiFB9ZiJxOYnw
+        r2YZTPwLd7og7oq4i7sL7423fDNz/8R4tAvK9UUevXz9FNcfF9RRV1qgP+ZP
+        dZHe6rW7mM+WzUWiNGZSacJpBqduojKl47pQZDnlB4sGMspSi/wJAsW0zVae
+        CG6Tx3Q/CL7TdWsdsNRkYOuizciP91BpCYApEkUSlLKFYK+BR+YqRiGpCGnK
+        tM28hC2+PlucBD60tHwq1vNivsrDuDuV2qwmNM0TevEilPccihd4Gywc3lTn
+        ctCnuOCR7TW1GlWnOZWSHnpKDGSnLNmM5FRqhqEpSxJkgA+3v8JmnBY6EZL9
+        /bz5jtmA6jCxYhKW5//n4k+ai93bqSsjiRmkkapzYacISCkkwRjlgiuwulbi
+        Oq730f4NNqzvAhoT/VuzW/kupnRjtxuuHAoNdIuN4YkeUPMXVFmOvUYNL3ad
+        SxHibhiH5nXQEm4NxhHc33HqmtY9ph1ZqTFR/ascNTuIrKtLRBnBKGLmVBjj
+        IWxwyp1gobmHGO8XV2CKBCCHvhSm8eMuVQ8fQWm6JxUlsapgD1netOtAiBQo
+        n/gxTZWhQy2goQfoBQmpbHqxFo/A/TlfqkgivPxXaQJme4JlwZjZngTaJOYQ
+        1nKQM1ndaSa4Tvy1MxANkAegsg8sJfVudUMmpoxoe7UwJ0pEWkbWXhJYRrdA
+        Cpn6ida5euM4VGHZVeeBpIybp1Dn8DnWQienB1ONHzLAJI0eUrEVTsEfuXji
+        5znfvgW+Y1Jwg7lUlEeB2CPpabeoS5iEnCITuq8WmpyrBJU6AZrqBE8OR0RH
+        VoEiCJg+6qu/taqQeG+YeNsiNbysgzrVtEXe0E/sY0doR1Yfmh6kSDuIRlCH
+        UakCyxy2Kf54xPSk/bIpYmK0lIfQ3XWobGImoiIs2XUnbK2sAhWcfSugfkMo
+        xltgWGwHz8k8TuCZICp6HHk0rb4mf/1HU08iJGGYgvLQ6/FtfywRgIbqizEv
+        DVk0KrL8hcy6xbcW6onnSCG6Q1CJGJtjqggpJLBtZr9rxhiT28jjVUPazVE7
+        zEQJLFLg05zhkYbyymFn6PG/HAQcsTKmMY8fYiEfjlzpvxwSy2j8c4WgldRv
+        p2qCKbXz3yJQoWT5KD/u6NuWVZJ/kiMfExFBCkpMNC0l4ASJx5LaisUjn+xj
+        mADBpm8h9xFTZRWz6qCyIpoWNtKTxuZSbCHDs/WNInE2nzfQr5HC1uorMpBQ
+        zmFoFe98Z9hLDDDGO8y24olUtznQYhiCQqpqdolA42iumv7UU9nvpjP42Lfv
+        YwZfdF4Ih70JADZnaT+GGQIxU5Gu2wwWYWiZa/BGRnw3nueFBltq1MSCMI70
+        u6gGSfMZC+U5TR/qr0JrZwzXJ7cdX/sceHbCkEeBz9srWfEHwXG2zPrEeRRd
+        0tUESwzB52byENCPWFimauP0s+wUYdjmy88+fvn7HeyxJqZQFa6uul1QBS/y
+        P199JXN3tfLoEtzZYhHQi/nC9YLYKwN0BFYr+0MJir9cfdqQ6TJ4PV/MvIvp
+        gsLCi7GwnuJ+FMmsQvJyjomEsNiaA1xv3t9/JLNptJx6cehdrKKSLVbKYxyB
+        jH0+6w6ttlpVRrmK6Ob24eaaLJdhMJutlisvjuaxR5ub6O0nyfGbhP+rSHiD
+        6oi76PYjhX8toMEehc0TT1MUYybqetqsu+Dm083Hm/efNljJxyDNvJDrMi0j
+        /8PV57v72w16hPTvKG4+T4x8Vjrpkcf66bvn7rTfKDtK+8qR79fPw5ocaJvW
+        sEg1b6xnzn/1DwAAAP//AwAU76XzrxcAAA==
     http_version: 
-  recorded_at: Tue, 06 Sep 2016 21:24:39 GMT
+  recorded_at: Tue, 06 Sep 2016 23:37:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/braintree/purchase.yml
+++ b/spec/fixtures/cassettes/braintree/purchase.yml
@@ -8,118 +8,12 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount>10.0</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
-          <options>
-            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
-            <submit-for-settlement type="boolean">true</submit-for-settlement>
-          </options>
-          <type>sale</type>
-        </transaction>
-    headers:
-      Accept-Encoding:
-      - gzip
-      Accept:
-      - application/xml
-      User-Agent:
-      - Braintree Ruby Gem 2.66.0
-      X-Apiversion:
-      - '4'
-      Authorization:
-      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
-      Content-Type:
-      - application/xml
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Fri, 02 Sep 2016 22:36:05 GMT
-      Content-Type:
-      - application/xml; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      X-Frame-Options:
-      - SAMEORIGIN
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Authentication:
-      - basic_auth
-      X-User:
-      - 3v249hqtptsg744y
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Etag:
-      - W/"5818840e848777fb85174c5d4be0db9f"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4afef4aa-3a2b-4605-8d99-f2220a0e86c0
-      X-Runtime:
-      - '0.530645'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIANX+yVcAA+xYS2/bOBC+91cEvjOSn40LR23aZIsseija5rB7CShpZLGR
-        SJWkHLu/vkNRkiWLarJAFyiwe7NnPj7mwZlvtHm9z7OzHUjFBL+cTM/9yRnw
-        SMSMby8nd1/+IBeT18GLjZaUKxppRAUvzs42LA7m33b8a/T95cbDP0amNNWl
-        ChRoneHyjVcLjE4fCggUzWDjVT+NLCqlxLMOhClB8EgI7j5fb7yh2IBpLkqu
-        g6l/7vsbr/5nFDnIKKVcExpFRkjwNkpDHopMbzyXtrprGRKH7oyz7HKiZQkT
-        z+5OcS/5LKiQMSIdikgC1RATqs+M7ZeTGP9qlsMkmPnTFfHXxJ99mc1ezVev
-        /OXf6IF2QbW+LOJ/tv64oPaz0gItMH9s6JYvF+vZ3F82oUNpwqTShNMcTu+P
-        yoyO6yKRF5QfHBrIKcsc8kcIFdOuvYpUcJc8ofuBV72uWZuQZSbnWhNdm/x6
-        C5WWAJgUcSxBKZcL9hp4bEIxCslERDOmXdtL2OJ7c/lJ4NPKqsfhvC9mqDyM
-        m2PVZjWhWZHS2bNQ86dQvMRosGgYqU5w0Kak5LHrmbQaVac5lZIeekp0ZKcQ
-        uTYpqNQMXVMVIcgBn2p/hWtzWupUSPb96e0724ZUR6kTk7Ki+D8Xf9Nc7Ean
-        rowkYZDFqs6FnSIgpZAEfVQIrsBpWoXrmN5HB7fYon4KaLboR829y08xlRm7
-        3XDlUGigW2wMj/SAmq9gsxx7jRoGdlNIEeFp6IfmddAK7nTGEdw/ceqbZj2m
-        HVmpMVGDqwI1O4idqytE5cE4ZuZW6OMhbHDLnWCRiUOC8cUVmCIhyKEtpWn1
-        eIrt5yMoTffEkhCnCvaQF027DoXIgPJJkNBMGQLUAhp6gFaQiMqmF2vxADxY
-        rPfpI7Io+89qQuZ6glXBWLieBO5JzCWc5aBg0sY0F1ynwcYbiAbIA1DZB1aS
-        +rS6IRNTRrS7WpgbpSKrPOsuCSynWyClzIJU60K98jyqsOyq81BSxs1TqHP4
-        HGuhV9CDqcb3OWCSxveZ2Aqv5A9cPPLzgm9fA98xKbjBXCrK41DskfS0R9Ql
-        TEJBkQnd2YUm56zAqlOgmU7x5nBEdGQWFEPI9FFv/9aqUmLcMPG2ZWZ4WQd1
-        qmmLvCGc2MeO0I6svjQ9SJF1EI2gdqNSJZY5bFP84YjpSftlUyTEaCmPoHvq
-        UNn4TMRlVPHpjttamQWVnH0roX5DKMYoMCy2g+dkHifwXBAVP4w8mlZfk7/+
-        o6lnD5IyTEF56PX4tj9WCMCN6sCYl4YsGhV58Uxm3eLbHeoZ50ghumNPhRib
-        XKyHFBLYNrPfNIOLyW3k8aoh7eaqHWaiBBYpCGjB8EpDuTXYG1r8LzsBh6qc
-        aczj+0TI+yNX+i+7xDEM/14uaCX127FNMKNu/luGKpKsGOXHHX3bsiryTwrk
-        YyImSEGJ8aajBJwg8VpSO7F45ZNzDBMg2PQd5D5mqqpiTh3YXUTTwkZ60thc
-        ii1keLf+pkiczQcNtGuksLV6SwZSyjkMd8WY7wx7SQDGeIc5VjwSG82BFt0Q
-        llLZ2SUGjaO5avpTT+WOTWfwcR/fxwy+4TwTDnvjAGzO0n0NMwRipiJdd21Y
-        RpFjrsGIjNhuLC9KDa7UqIkFYRzpd2kHSfPhCuUFze7r70AbbwzXJ7cdW/sc
-        eHHCkEeBT+9XseJ3guNsmfeJ8yi6oqsplhiCz83kIaAdiXBM1cboJ9kpwrDN
-        V599gur3G9hjTczAFq6uul1gnRcHH6/+IvM50GWSXNCVf7FeQrSeLRbrFYQd
-        LzfMoj+UoPjz1Ycbsl6uVvPZbBWu6SJcJmssrKe4X0UyrUuezzGREJZbc4Hr
-        m7d37wldXMwuomgd08WyYotWefQjkLHPZ92h1VWrKi9bj958ur+9JtOLuT+f
-        XfhLP5rGyZI2keidJ8nxm0Twp0h5g+qIu+j2I0VwLaDBHoXNE88yFGMm6nra
-        rLvgzYfb97dvP9xgJR+DNPNCoau0jIN3Vx+/3H26QYuQ/h3FzeeJkc9KJz3y
-        WD8D7LzTfqPsKN0rR75YPw1rcqBtWsMi1byx3nbBix8AAAD//wMA7brPu6EX
-        AAA=
-    http_version: 
-  recorded_at: Fri, 02 Sep 2016 22:36:05 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <transaction>
           <amount>10.00</amount>
-          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
+          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>
     headers:
@@ -141,7 +35,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 06 Sep 2016 21:24:41 GMT
+      - Tue, 06 Sep 2016 22:00:26 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -162,54 +56,53 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d5fe945c7f350eedae079317ab17d8d8"
+      - W/"7d7db0b7b0d9411f9411eef65a5e12d8"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ddbfcda4-f7b1-40b2-b5f8-5131933c0564
+      - a8d5a2aa-4665-464b-a153-89c415f14ea7
       X-Runtime:
-      - '0.388879'
+      - '0.443621'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIABk0z1cAA+xYS3PbNhC+51d4dIcpyXrYGZmJE7sZd3zIJPGhvXhAYiki
-        JgEWAGWpv74LgqRIE4x9SGcy096k3Q+PfWD3W27e7fPsZAdKcykuJ7PT6eQE
-        RCwZF9vLyf2338j55F34ZmMUFZrGBlHhm5OTDWfh9yc6nR+2602Af6xMG2pK
-        HWowJsPlm6AWWJ05FBBqmsEmqH5aWVwqhWcdCNeS4JEQ3n+93gRDsQXTXJbC
-        hLPp6XS6Cep/VpGDilMqDKFxbIUEb6MN5JHMzCbwaau7lhHx6E4Ezy4nRpUw
-        CdzuFPdSr4JKxRDpUcQKqAFGqDmxtl9OGP41PIdJOJ/OVmR6Qaarb/PZ2/ni
-        7WL6J3qgXVCtLwv2+vUzXH9cUPtZG4kW2D8udGeLi/nifD1tQofShCttiKA5
-        PL8/KjM6rotlXlBx8GggpzzzyJ8g0tz49ipSKXzyhO4HXg26Zm0intmca030
-        bfLzLdRGAWBSMKZAa58L9gYEs6EYhWQyphk3vu0VbPG9+fwk8Wll1ePw3hcz
-        VB3GzXFqu5rQrEjp/FWos5dQosRo8HgYqU5w0KakFMz3TFqNrtOcKkUPPSU6
-        slOIfJsUVBmOrqmKEOSAT7W/wrc5LU0qFf/75e0720bUxKkXk/Ki+D8Xf9Fc
-        7Eanrowk4ZAxXefCThNQSiqCPiqk0OA1rcJ1TO+jw1tsUT8ENFv0o+bf5YeY
-        yozdbrhyKLTQLTaGJ3pAzXdwWY69Rg8DuymUjPE09EPzOmgF9zrjCO6fOJva
-        Zj2mHVlpMFHDqwI1O2De1RWi8iBj3N4KfTyEDW65kzy2cUgwvrgCUyQCNbSl
-        tK0eT3H9fARl6J44EuJVwR7yomnXkZQZUDEJE5ppS4BaQEMP0AoSU9X0YiMf
-        QYSRWsZmhfDqn9NE3PcEq4Kx8D0J3JPYS3jLQcGVi2kuhUnDTTAQDZAHoKoP
-        rCT1aXVDJraMGH+1sDdKZVZ51l8SeE63QEqVhakxhX4bBFRj2dWnkaJc2KdQ
-        5/Ap1sKgoAdbjR9ywCRlD5ncyqAUj0I+idNCbN+B2HElhcVcaipYJPdIetoj
-        6hKmoKDIhO7dQptzTuDUKdDMpHhzOCI6MgdiEHFz1Lu/tapUGDdMvG2ZWV7W
-        QT3XtEXeEk7sY0doR1Zfmh6UzDqIRlC7UesSyxy2KfF4xPSk/bIpE2K1VMTQ
-        PXWobHwmWRlXfLrjtlbmQKXgf5VQvyEUYxQ4FtvBc7KPE0QuiWaPI4+m1dfk
-        r/9o6tmDpBxTUB16Pb7tjxUCcKM6MPalIYtGRV68kpm3+HaHesY5Uoju2FMh
-        xiYX5yGNBLbN7PfN4GJzG3m8bki7vWqHmWiJRQpCWnC80lDuDA6GFv/LTsCh
-        KucG8/ghkerhyJX+yy7xDMO/lgtaSf12XBPMqJ//lpGOFS9G+XFH37asivyT
-        AvmYZAQpKLHe9JSAZ0i8ljJeLF752TmWCRBs+h5yz7iuqphXB24X2bSwkZ40
-        NpdiCxnerb8pEmf7QQPtGilsrd6RgZQKAcNdMeY7y14SgDHeYY+VT8RFc6BF
-        N0Sl0m52YWBwNNdNf+qp/LHpDD7+4/uYwTecV8Jhbx2AzVn5r2GHQMxUpOu+
-        Dcs49sw1GJER263lRWnAlxo1sSBcIP0u3SBpP1yhvKDZQ/0daBOM4frktmNr
-        nwMvnjHkUeDL+1Ws+KMUOFvmfeI8iq7oaoolhuBzs3kIaEciPVO1NfpFdoow
-        bPPVZ5+w+v0e9lgTM3CFq6tuFzjnsfDz1R9kFV/M1hfLdbKaJcvl2QJmC7Y6
-        O2cdLzfMoj+UoPjr1d0NWdDVekXP1nQ9YwmFBRbW57ifRTKdS17PMZEQllt7
-        geubD/efyDLBW8J6uZyfRxVbdMqjH4GMfT7rDq2+WlV52Xn05svD7TWB8/V6
-        yWZ0OWfL9XSxaiLRO0+R4zeJ8HeZigbVEXfR7UeK8FpCgz0KmyeeZSjGTDT1
-        tFl3wZu720+3H+5usJKPQZp5oTBVWrLw49Xnb/dfbtAipH9HcfN5YuSz0rMe
-        eayfIXbeWb9RdpT+lSNfrF+GNTnQNq1hkWreWG+78M0/AAAA//8DAGEOrXOh
-        FwAA
+        H4sIAHo8z1cAA+xYUW/bNhB+768I/M5IthM3KRy1aZMVGfpQtM3D9hJQ0sni
+        IpEcSTn2fv2OoiRLFtVkQAcU2AA/WHcfj7zj8e4j1293ZXGyBaWZ4Fez+Wk4
+        OwGeiJTxzdXs/tsv5GL2Nnq1NopyTRODqOjVycmapRFfPm7CS8nXAX5YmTbU
+        VDrSYEyBw9dBI7A6s5cQaVrAOqj/WllSKYVz7QnTguCUEN1/vVkHY7EF01JU
+        3ETz8DQM10HzZRUlqCSn3BCaJFZIcDXaQBmLwqwDn7ZeaxUTj+6Es+JqZlQF
+        s8BZp2hLvQgqVIpIjyJRQA2khJoT6/vVLMVPw0qYRYtwviLhJQlX3xaLN2H4
+        ZnH+O0agG1CPr2T6z8YfBjRx1kagB/bDbd1yfrZazi8u2q1DacaUNoTTEo7X
+        j8qCTusSUUrK9x4NlJQVHvkTxJoZny2ZC+6TZ3Q3imrQd2sds8LmXOeiz8iP
+        91AbBYBJkaYKtPaFYGeAp3YrJiGFSGjBjM+8gg2eN1+cBB6toj4c3vVihqr9
+        tDtObUcTWsicLl6EWj6H4hXuBkvGO9XbHPQpq3jqOyadRjdpTpWi+4ESA9kr
+        RD4jkirDMDR1EYIS8KgOR/iM08rkQrG/njffMxtTk+ReTM6k/D8Xf9Jc7O9O
+        UxlJxqBIdZMLW01AKaEIxkgKrsHrWo3ruT5ER3fYor4LaE0Md81v5buY2o3t
+        djxyLLTQDTaGJ7pHzR/gshx7jR5v7FoqkeBsGIf2dNAa7g3GATyccR7aZj2l
+        nRhpMFGja4maLaTe0TWijmCaMrsqjPEYNlrlVrDE7kOG+4sjMEViUGNfKtvq
+        cRbXzydQhu6IIyFeFeyglG27joUogPJZlNFCWwLUAVp6gF6QhKq2FxvxCDy6
+        lInUJcLrL6eJme8I1gXjzHck0Caxi/CWA8mU29NScJNH62AkGiH3QNUQWEua
+        2ZqGTGwZMf5qYVeUi6KOrL8ksJJugFSqiHJjpH4TBFRj2dWnsaKM26PQ5PAp
+        1sJA0r2txg8lYJKmD4XYiKDij1w88VPJN2+Bb5kS3GKuNOVpLHZIeropmhKm
+        QFJkQvduoM05J3DqHGhhclw5HBA9mQOlEDNz0LvPRlUp3DdMvE1VWF7WQx1r
+        uiJvCSf2sQO0J2sWTfdKFD1EK2jCqHWFZQ7bFH88YAbSYdkUGbFayhPozzpW
+        tjETaZXUfLoXtk7mQBVnf1bQnCEU4y4wLLaj42QPJ/BSEJ0+ThyaTt+Qv+Gh
+        ae4eJGeYgmo/6PFdf6wRgIaajbEnDVk0Kkr5Qmbd4TsLzR3nQCH6154aMXVz
+        cRHSSGC7zH7XXlxsbiOP1y1pt0vtMRMtsEhBRCXDJY3lzuFg7PG/HAS8VJXM
+        YB4/ZEI9HLjSfzkknsvwzxWCTtKcHdcEC+rnv1WsE8XkJD/u6buWVZN/IpGP
+        iZQgBSU2mp4ScITEZSnjxeKSj+axTIBg0/eQ+5Tpuop5deCsiLaFTfSkqXsp
+        tpDx2oZGkTjbBw30a6KwdXpHBnLKOYyt4p5vLXvJAKZ4h51WPBG3myMthiGu
+        lHZ3lxQMXs11258GKv/e9C4+/umHmNEbzgvhsLMBwOas/Muwl0DMVKTrPoNV
+        knjuNbgjE75bz2VlwJcaDbEgjCP9rtxF0j5coVzS4qF5B1oHU7ghue35OuTA
+        Z0cMeRL4vL2aFX8QHO+W5ZA4T6JruppjiSF43GweAvqRCc+t2jr9LDtFGLb5
+        +tknqv+/gx3WxAJc4eqruwEueGn0+fo3cg5nl3G4yOgyXFyuwiw5X84Bf70o
+        t8xieClB8dfrT7ckS7KLdLWicRgjAYMVFtZj3I8imS4kL+eYuJ5qYxdwc/v+
+        /iNZvKZn58ny9RwWlzVbdMpDHIFMPZ/1L62+WlVH2UX09svD3Q1J4zhewutk
+        NT9fnl/Qi3YnBvMpcniTiH4VOW9RPXEf3T1SRDcCWuxB2B7xokAxZqJpbptN
+        F7z9dPfx7v2nW6zkU5D2viBNnZZp9OH687f7L7foEdK/g7h9nph4VjrqkYf6
+        GWHnnQ8bZU/pHznxYv08rM2BrmmNi1R7xgbmold/AwAA//8DADnQOGmhFwAA
     http_version: 
-  recorded_at: Tue, 06 Sep 2016 21:24:41 GMT
+  recorded_at: Tue, 06 Sep 2016 22:00:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -17,14 +17,21 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
   describe 'making a payment on an order', vcr: cassette_options do
     include_context 'order ready for payment'
 
-    it 'can complete an order' do
-      expect(order.total).to eq 55
+    before do
+      order.update(number: "ORDER0")
+      payment.update(number: "PAYMENT0")
+    end
 
-      payment = order.payments.create!(
+    let(:payment) do
+      order.payments.create!(
         payment_method: gateway,
         source: source,
         amount: 55
       )
+    end
+
+    it 'can complete an order' do
+      expect(order.total).to eq 55
 
       expect(payment.capture_events.count).to eq 0
 


### PR DESCRIPTION
We'll be able to use this to send along the device data for fraud prevention. (As well as slowly build it out to support other Braintree options.)
