### PR TITLE
Register gateway with Solidus

### DIFF
--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -9,6 +9,10 @@ module SolidusPaypalBraintree
       g.test_framework :rspec
     end
 
+    initializer "register_solidus_paypal_braintree_gateway", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)


### PR DESCRIPTION
Otherwise, admins can't select this as a payment method.
