### PR TITLE
Correct foreign_key creation for payment_method reference on Source

### DIFF
--- a/db/migrate/20160830061749_create_solidus_paypal_braintree_sources.rb
+++ b/db/migrate/20160830061749_create_solidus_paypal_braintree_sources.rb
@@ -6,9 +6,11 @@ class CreateSolidusPaypalBraintreeSources < ActiveRecord::Migration
       t.string :payment_type
       t.integer :user_id, index: true
       t.references :customer, index: true
-      t.references :payment_method, foreign_key: { to_table: :spree_payment_method }, index: { name: 'index_braintree_source_payment_method' }
+      t.references :payment_method, index: true
 
       t.timestamps null: false
     end
+
+    add_foreign_key :solidus_paypal_braintree_sources, :spree_payment_methods, column: :payment_method_id
   end
 end


### PR DESCRIPTION
The to_table option doesn't seem to be picked up by the MySQL engine, which was resulting in errors when running this migration. Extracting out foreign key creation works correctly.
