### PR TITLE
Add actions, can_*? predicate methods to Source

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -9,4 +9,20 @@ class SolidusPaypalBraintree::Source < ApplicationRecord
   def imported
     false
   end
+
+  def actions
+    %w[capture void credit]
+  end
+
+  def can_capture?(payment)
+    payment.pending? || payment.checkout?
+  end
+
+  def can_void?(payment)
+    !payment.failed? && !payment.void?
+  end
+
+  def can_credit?(payment)
+    payment.completed? && payment.credit_allowed > 0
+  end
 end


### PR DESCRIPTION
These are used to determine which buttons are shown in the admin
payments interface, e.g. for capturing payments on an order.

Pulled from `Spree::CreditCard`'s implementation.
