### PR TITLE
Correctly parse error message for failure response

### DIFF
--- a/app/models/solidus_paypal_braintree/response.rb
+++ b/app/models/solidus_paypal_braintree/response.rb
@@ -34,8 +34,8 @@ module SolidusPaypalBraintree
       end
 
       def build_failure(result)
-        transaction = result.transaction
-        new(false, transaction.status, {}, {})
+        msg = result.errors.map { |e| "#{e.message} (#{e.code})" }.join(" ")
+        new(false, msg)
       end
     end
   end

--- a/spec/models/solidus_paypal_braintree/response_spec.rb
+++ b/spec/models/solidus_paypal_braintree/response_spec.rb
@@ -2,15 +2,16 @@ require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::Response do
   let(:error_result) do
-    transaction = instance_double(
-      'Braintree::Transaction',
-      status: 'error'
+    error = instance_double(
+      'Braintree::ValidationError',
+      code: '12345',
+      message: "Cannot refund a transaction unless it is settled."
     )
 
     instance_double(
       'Braintree::ErrorResult',
       success?: false,
-      transaction: transaction
+      errors: [error]
     )
   end
 
@@ -50,6 +51,18 @@ RSpec.describe SolidusPaypalBraintree::Response do
   describe '#success?' do
     it { expect(error_response.success?).to be false }
     it { expect(successful_response.success?).to be true }
+  end
+
+  describe "#message" do
+    context "with a success response" do
+      subject { successful_response.message }
+      it { is_expected.to eq "ok" }
+    end
+
+    context "with an error response" do
+      subject { error_response.message }
+      it { is_expected.to eq "Cannot refund a transaction unless it is settled. (12345)" }
+    end
   end
 
   describe '#authorization' do


### PR DESCRIPTION
The previous implementation of build_failure did not correctly retrieve
errors from Braintree responses, resulting in exceptions when attempting
to build the failure response.
