### PR TITLE
Only prompt for email for not logged in users

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
@@ -37,7 +37,14 @@ window.SolidusPaypalBraintree = {
 
   initializeApplePaySession: function(applePayInstance, storeName, paymentRequest, sessionCallback) {
 
-    paymentRequest['requiredShippingContactFields'] = ['postalAddress', 'phone', 'email']
+    var requiredFields = ['postalAddress', 'phone'];
+    var currentUserEmail = document.querySelector("#transaction_email").value;
+
+    if (!currentUserEmail) {
+      requiredFields.push('email');
+    }
+
+    paymentRequest['requiredShippingContactFields'] = requiredFields
     var paymentRequest = applePayInstance.createPaymentRequest(paymentRequest);
 
     var session = new ApplePaySession(SolidusPaypalBraintree.APPLE_PAY_API_VERSION, paymentRequest);
@@ -96,7 +103,9 @@ window.SolidusPaypalBraintree = {
     }
 
     document.querySelector("#transaction_phone").value = appleContact.phoneNumber;
-    document.querySelector("#transaction_email").value = appleContact.emailAddress;
+    if (appleContact.emailAddress) {
+      document.querySelector("#transaction_email").value = appleContact.emailAddress;
+    }
   },
 
   submitBraintreePayload: function(payload) {

--- a/lib/views/frontend/solidus_paypal_braintree/_transaction_form.html.erb
+++ b/lib/views/frontend/solidus_paypal_braintree/_transaction_form.html.erb
@@ -3,7 +3,7 @@
   <%= f.hidden_field :payment_type %>
   <%= hidden_field_tag :payment_method_id, payment_method.id %>
   <%= f.hidden_field :phone %>
-  <%= f.hidden_field :email %>
+  <%= f.hidden_field :email, value: try_spree_current_user.try!(:email) %>
 
   <%= f.fields_for :address, SolidusPaypalBraintree::TransactionAddress.new do |fa| %>
     <% [:country_code, :last_name, :first_name,


### PR DESCRIPTION
If the user is logged in we should already have an email and do not need to ask for it again in the ApplePay prompt. However, if the contact details returned in the `onpaymentauthorized` callback contain an email, that means we prompted for it and we should update the transaction form with that email.
