### PR TITLE
Default to US country code

### DIFF
--- a/app/models/solidus_paypal_braintree/transaction_address.rb
+++ b/app/models/solidus_paypal_braintree/transaction_address.rb
@@ -3,11 +3,16 @@ require 'active_model'
 module SolidusPaypalBraintree
   class TransactionAddress
     include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
 
     attr_accessor :country_code, :last_name, :first_name,
       :city, :zip, :state_code, :address_line_1, :address_line_2
 
     validates :first_name, :last_name, :address_line_1, :city, :zip,
-      :state_code, :country_code, presence: true
+      :state_code, presence: true
+
+    before_validation do
+      self.country_code = country_code.presence || "us"
+    end
   end
 end

--- a/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe SolidusPaypalBraintree::TransactionAddress do
   describe "#valid?" do
-    subject { described_class.new(valid_attributes).valid? }
+    let(:address) { described_class.new(valid_attributes) }
+
+    subject { address.valid? }
 
     let(:valid_attributes) do
       {
@@ -50,7 +52,13 @@ describe SolidusPaypalBraintree::TransactionAddress do
 
     context "no country_code" do
       let(:valid_attributes) { super().except(:country_code) }
-      it { is_expected.to be false }
+
+      it { is_expected.to be true }
+
+      it "defaults to the US" do
+        subject
+        expect(address.country_code).to eq "us"
+      end
     end
   end
 end


### PR DESCRIPTION
There's an issue with Apple Pay in which they won't send us a country if a customer decides to use an existing address. As a semi-elegant solution, we assume that the customer is from the USA.

This allows us to continue as if nothing went wrong for all of those customers. And any not from the USA will see the same error they saw before. (Due to whatever state they specified not being valid for the USA.)
