### PR TITLE
Support tokens without specifying payment_method

### DIFF
--- a/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
+++ b/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
@@ -11,9 +11,11 @@ module SolidusPaypalBraintree
     private
 
     def load_gateway
-      @gateway = ::SolidusPaypalBraintree::Gateway.
-        where(active: true).
-        find(params[:payment_method_id])
+      if params[:payment_method_id]
+        @gateway = ::SolidusPaypalBraintree::Gateway.find_by!(id: params[:payment_method_id])
+      else
+        @gateway = ::SolidusPaypalBraintree::Gateway.find_by!(active: true)
+      end
     end
   end
 end

--- a/spec/controllers/solidus_paypal_braintree/client_tokens_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/client_tokens_controller_spec.rb
@@ -9,16 +9,32 @@ describe SolidusPaypalBraintree::ClientTokensController do
 
     before { user.generate_spree_api_key! }
 
-    subject(:response) do
-      post :create, payment_method_id: gateway.id, token: user.spree_api_key
-    end
+    context 'with a payment method id' do
+      subject(:response) do
+        post :create, token: user.spree_api_key
+      end
 
-    it "returns a client token", aggregate_failures: true do
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq "application/json"
-      expect(json["client_token"]).to be_present
-      expect(json["client_token"]).to be_a String
-      expect(json["payment_method_id"]).to eq gateway.id
+      it "returns a client token", aggregate_failures: true do
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq "application/json"
+        expect(json["client_token"]).to be_present
+        expect(json["client_token"]).to be_a String
+        expect(json["payment_method_id"]).to eq gateway.id
+      end
+
+      context 'with a payment method id' do
+        before do
+          create_gateway id: 3
+        end
+
+        subject(:response) do
+          post :create, token: user.spree_api_key, payment_method_id: 3
+        end
+
+        it 'uses the selected gateway' do
+          expect(json["payment_method_id"]).to eq 3
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Its way more hassle to have to specify a payment method id, which most
stores won't want to do.
