### PR TITLE
Map country names to ISO codes

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
@@ -161,6 +161,7 @@ window.SolidusPaypalBraintree = {
 
   buildAddress: function(shippingContact) {
     var addressHash = {
+      country_name:   shippingContact.country,
       country_code:   shippingContact.countryCode,
       first_name:     shippingContact.givenName,
       last_name:      shippingContact.familyName,

--- a/app/models/solidus_paypal_braintree/transaction_address.rb
+++ b/app/models/solidus_paypal_braintree/transaction_address.rb
@@ -4,6 +4,7 @@ module SolidusPaypalBraintree
   class TransactionAddress
     include ActiveModel::Model
     include ActiveModel::Validations::Callbacks
+    include SolidusPaypalBraintree::CountryMapper
 
     attr_accessor :country_code, :last_name, :first_name,
       :city, :zip, :state_code, :address_line_1, :address_line_2
@@ -17,6 +18,15 @@ module SolidusPaypalBraintree
 
     validates :spree_country, presence: true
     validates :spree_state, presence: true, if: :should_match_state_model?
+
+    def initialize(attributes = {})
+      country_name = attributes.delete(:country_name) || ""
+      if attributes[:country_code].blank?
+        attributes[:country_code] = iso_from_name(country_name)
+      end
+
+      super(attributes)
+    end
 
     def spree_country
       country_code && (@country ||= Spree::Country.find_by(iso: country_code.upcase))

--- a/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
+++ b/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
@@ -7,7 +7,7 @@ class SolidusPaypalBraintree::TransactionsController < Spree::StoreController
     :phone,
     :email,
     address_attributes: [
-      :country_code, :last_name, :first_name,
+      :country_code, :country_name, :last_name, :first_name,
       :city, :zip, :state_code, :address_line_1, :address_line_2
     ]
   ]

--- a/lib/solidus_paypal_braintree.rb
+++ b/lib/solidus_paypal_braintree.rb
@@ -1,5 +1,6 @@
 require 'solidus_core'
 require 'solidus_paypal_braintree/engine'
+require 'solidus_paypal_braintree/country_mapper'
 
 module SolidusPaypalBraintree
   def self.table_name_prefix

--- a/lib/solidus_paypal_braintree/country_mapper.rb
+++ b/lib/solidus_paypal_braintree/country_mapper.rb
@@ -1,0 +1,35 @@
+module SolidusPaypalBraintree
+  module CountryMapper
+    extend ActiveSupport::Concern
+
+    USA_VARIANTS = [
+      "the united states of america",
+      "united states of america",
+      "the united states",
+      "united states",
+      "us of a",
+      "u.s.a.",
+      "usa",
+      "u.s.",
+      "us"
+    ]
+
+    CANADA_VARIANTS = [
+      "canada",
+      "ca"
+    ]
+
+    # Generates a hash mapping each variant of the country name to the same ISO
+    # ie: { "usa" => "US", "united states" => "US", "canada" => "CA", ... }
+    COUNTRY_MAP = {
+      USA_VARIANTS => "US",
+      CANADA_VARIANTS => "CA"
+    }.flat_map { |variants, iso| variants.map { |v| [v, iso] } }.to_h
+
+    included do
+      def iso_from_name(country_name)
+        COUNTRY_MAP[country_name.downcase.strip]
+      end
+    end
+  end
+end

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
         end
       end
 
+      context "and no country ISO was provided" do
+        before do
+          params[:transaction][:address_attributes][:country_code] = ""
+          params[:transaction][:address_attributes][:country_name] = "United States"
+        end
+
+        it "creates a new address, looking up the ISO by country name" do
+          order
+          expect { post_create }.to change { Spree::Address.count }.by(1)
+          expect(Spree::Address.last.country.iso).to eq "US"
+        end
+      end
+
       context "and the transaction does not have an address" do
         before { params[:transaction].delete(:address_attributes) }
 

--- a/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
@@ -72,6 +72,37 @@ describe SolidusPaypalBraintree::TransactionAddress do
     end
   end
 
+  describe "#attributes=" do
+    subject { described_class.new(attrs) }
+
+    context "when an ISO code is provided" do
+      let(:attrs) { { country_code: "US" } }
+
+      it "uses the ISO code provided" do
+        expect(subject.country_code).to eq "US"
+      end
+    end
+
+    context "when the ISO code is blank" do
+      context "and a valid country name is provided" do
+        let!(:canada) { create :country, name: "Canada", iso: "CA" }
+        let(:attrs) { { country_name: "Canada" } }
+
+        it "looks up the ISO code by the country name" do
+          expect(subject.country_code).to eq "CA"
+        end
+      end
+
+      context "and no valid country name is provided" do
+        let(:attrs) { { country_name: "Neverland" } }
+
+        it "leaves the country code blank" do
+          expect(subject.country_code).to be_nil
+        end
+      end
+    end
+  end
+
   describe '#spree_country' do
     subject { described_class.new(country_code: country_code).spree_country }
 


### PR DESCRIPTION
Apple doesn't guarantee that the ISO code will be present and recommended to match country names against common spellings instead. This will use the country code if it's provided, but otherwise attempt to map the country name to the corresponding ISO code.