### PR TITLE
Add Braintree configuration to Spree::Store model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ bundle
 bundle exec rails g solidus_paypal_braintree:install
 ```
 
+Store Configuration
+-------------------
+
+This gem adds a configuration model - `SolidusPaypalBraintree::Configuration` -
+that belongs to `Spree::Store` as `braintree_configuration`. In multi-store
+Solidus applications, this model allows admins to enable/disable payment types
+on a per-store basis.
+
+The migrations for this gem will add a default configuration to all stores that
+has each payment type disabled. It also adds a `before_create` callback to
+`Spree::Store` that builds a default configuration. You can customize the
+default configuration that gets created by overriding the private
+`build_default_configuration` method on `Spree::Store`.
+
+A view override is provided that adds a `Braintree` tab to the admin settings
+submenu. Admins can go here to edit the configuration for each store.
+
 Testing
 -------
 

--- a/app/helpers/solidus_paypal_braintree/routes_helper.rb
+++ b/app/helpers/solidus_paypal_braintree/routes_helper.rb
@@ -1,0 +1,15 @@
+module SolidusPaypalBraintree
+  module RoutesHelper
+    def method_missing(method_sym, *arguments, &block)
+      if spree.respond_to?(method_sym)
+        spree.send(method_sym, arguments)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_sym, include_private = false)
+      spree.respond_to?(method_sym) || super
+    end
+  end
+end

--- a/app/models/solidus_paypal_braintree/configuration.rb
+++ b/app/models/solidus_paypal_braintree/configuration.rb
@@ -1,0 +1,5 @@
+class SolidusPaypalBraintree::Configuration < ApplicationRecord
+  belongs_to :store, class_name: 'Spree::Store'
+
+  validates :store, presence: true
+end

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,0 +1,11 @@
+Spree::Store.class_eval do
+  has_one :braintree_configuration, class_name: "SolidusPaypalBraintree::Configuration"
+
+  before_create :build_default_configuration
+
+  private
+
+  def build_default_configuration
+    build_braintree_configuration
+  end
+end

--- a/app/overrides/admin_navigation_menu.rb
+++ b/app/overrides/admin_navigation_menu.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(
+  virtual_path: "spree/admin/shared/_settings_sub_menu",
+  name: "solidus_paypal_braintree_admin_navigation_configuration",
+  insert_bottom: "[data-hook='admin_settings_sub_tabs']",
+  partial: "solidus_paypal_braintree/configurations/admin_tab"
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  spree:
+    admin:
+      tab:
+        braintree: Braintree
   solidus_paypal_braintree:
     nonce: Nonce
     token: Token
@@ -7,5 +11,6 @@ en:
       pay_pal_account: PayPal
     configurations:
       title: Braintree Configurations
+      tab: Braintree
       update_success: Successfully updated Braintree configurations.
       update_error: An error occurred while updating Braintree configurations.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,7 @@ en:
     payment_type:
       apple_pay_card: Apple Pay
       pay_pal_account: PayPal
+    configurations:
+      title: Braintree Configurations
+      update_success: Successfully updated Braintree configurations.
+      update_error: An error occurred while updating Braintree configurations.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ SolidusPaypalBraintree::Engine.routes.draw do
   resource :checkout, only: [:update, :edit]
   resource :client_token, only: [:create], format: :json
   resource :transactions, only: [:create]
+
+  resources :configurations, only: []
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,10 @@ SolidusPaypalBraintree::Engine.routes.draw do
   resource :client_token, only: [:create], format: :json
   resource :transactions, only: [:create]
 
-  resources :configurations, only: []
+  resources :configurations do
+    collection do
+      get :list
+      post :update
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
-Rails.application.routes.draw do
-  namespace :solidus_paypal_braintree do
-    resource :checkout, only: [:update, :edit]
-    resource :client_token, only: [:create], format: :json
-    resource :transactions, only: [:create]
-  end
+SolidusPaypalBraintree::Engine.routes.draw do
+  resource :checkout, only: [:update, :edit]
+  resource :client_token, only: [:create], format: :json
+  resource :transactions, only: [:create]
 end

--- a/db/migrate/20161114231422_create_solidus_paypal_braintree_configurations.rb
+++ b/db/migrate/20161114231422_create_solidus_paypal_braintree_configurations.rb
@@ -1,0 +1,11 @@
+class CreateSolidusPaypalBraintreeConfigurations < ActiveRecord::Migration
+  def change
+    create_table :solidus_paypal_braintree_configurations do |t|
+      t.boolean :paypal,    null: false, default: false
+      t.boolean :apple_pay, null: false, default: false
+      t.integer :store_id,  null: false, index: true, foreign_key: { references: :spree_stores }
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20161125172005_add_braintree_configuration_to_stores.rb
+++ b/db/migrate/20161125172005_add_braintree_configuration_to_stores.rb
@@ -1,0 +1,9 @@
+class AddBraintreeConfigurationToStores < ActiveRecord::Migration
+  def up
+    Spree::Store.all.each(&:create_braintree_configuration)
+  end
+
+  def down
+    SolidusPaypalBraintree::Configuration.joins(:store).destroy_all
+  end
+end

--- a/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
+++ b/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
@@ -1,4 +1,30 @@
 module SolidusPaypalBraintree
   class ConfigurationsController < Spree::Admin::BaseController
+    helper RoutesHelper
+
+    def list
+      authorize! :list, SolidusPaypalBraintree::Configuration
+
+      @configurations = Spree::Store.all.map(&:braintree_configuration)
+    end
+
+    def update
+      authorize! :update, SolidusPaypalBraintree::Configuration
+
+      params = configurations_params[:configuration_fields]
+      if SolidusPaypalBraintree::Configuration.update(params.keys, params.values)
+        flash[:success] = t('update_success', scope: 'solidus_paypal_braintree.configurations')
+      else
+        flash[:error] = t('update_error', scope: 'solidus_paypal_braintree.configurations')
+      end
+      redirect_to action: :list
+    end
+
+    private
+
+    def configurations_params
+      params.require(:configurations).
+        permit(configuration_fields: [:paypal, :apple_pay])
+    end
   end
 end

--- a/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
+++ b/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
@@ -1,0 +1,4 @@
+module SolidusPaypalBraintree
+  class ConfigurationsController < Spree::Admin::BaseController
+  end
+end

--- a/lib/generators/solidus_paypal_braintree/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_braintree/install/install_generator.rb
@@ -18,6 +18,12 @@ module SolidusPaypalBraintree
         run 'bundle exec rake railties:install:migrations FROM=solidus_paypal_braintree'
       end
 
+      def mount_engine
+        insert_into_file File.join('config', 'routes.rb'), after: "Rails.application.routes.draw do\n" do
+          "mount SolidusPaypalBraintree::Engine, at: '/solidus_paypal_braintree'"
+        end
+      end
+
       def run_migrations
         run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
         if run_migrations

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -24,6 +24,10 @@ module SolidusPaypalBraintree
       defined?(Spree::Frontend::Engine) == "constant"
     end
 
+    def self.backend_available?
+      defined?(Spree::Backend::Engine) == "constant"
+    end
+
     if frontend_available?
       config.assets.precompile += [
         'spree/frontend/solidus_paypal_braintree',
@@ -31,6 +35,10 @@ module SolidusPaypalBraintree
       ]
       paths["app/controllers"] << "lib/controllers/frontend"
       paths["app/views"] << "lib/views/frontend"
+    end
+
+    if backend_available?
+      paths["app/controllers"] << "lib/controllers/backend"
     end
   end
 end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -39,6 +39,7 @@ module SolidusPaypalBraintree
 
     if backend_available?
       paths["app/controllers"] << "lib/controllers/backend"
+      paths["app/views"] << "lib/views/backend"
     end
   end
 end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -1,7 +1,6 @@
 module SolidusPaypalBraintree
   class Engine < Rails::Engine
-    require 'spree/core'
-    isolate_namespace Spree
+    isolate_namespace SolidusPaypalBraintree
     engine_name 'solidus_paypal_braintree'
 
     # use rspec for tests

--- a/lib/views/backend/solidus_paypal_braintree/configurations/_admin_tab.html.erb
+++ b/lib/views/backend/solidus_paypal_braintree/configurations/_admin_tab.html.erb
@@ -1,0 +1,3 @@
+<%= tab :braintree, match_path: /braintree\/configurations/,
+  url: solidus_paypal_braintree.list_configurations_path
+%>

--- a/lib/views/backend/solidus_paypal_braintree/configurations/list.html.erb
+++ b/lib/views/backend/solidus_paypal_braintree/configurations/list.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= t(:title, scope: 'solidus_paypal_braintree.configurations') %>
+<% end %>
+
+<%= form_for :configurations, url: solidus_paypal_braintree.configurations_path do |f| %>
+  <% @configurations.each do |config| %>
+    <div class="row">
+      <fieldset>
+        <h1><%= config.store.name %></h1>
+
+        <%= f.fields_for 'configuration_fields[]', config do |c| %>
+          <div class="field">
+            <%= c.label :paypal %>
+            <%= c.check_box :paypal %>
+          </div>
+          <div class="field">
+            <%= c.label :apple_pay %>
+            <%= c.check_box :apple_pay %>
+          </div>
+        <% end %>
+      </fieldset>
+    </div>
+  <% end %>
+
+  <%= submit_tag %>
+<% end %>

--- a/spec/controllers/solidus_paypal_braintree/checkouts_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/checkouts_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'support/order_ready_for_payment'
 
 RSpec.describe SolidusPaypalBraintree::CheckoutsController, type: :controller do
+  routes { SolidusPaypalBraintree::Engine.routes }
+
   include_context 'order ready for payment'
 
   describe 'PATCH update', vcr: { cassette_name: 'checkout/update' } do

--- a/spec/controllers/solidus_paypal_braintree/client_tokens_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/client_tokens_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe SolidusPaypalBraintree::ClientTokensController do
+  routes { SolidusPaypalBraintree::Engine.routes }
+
   cassette_options = { cassette_name: "braintree/token" }
   describe "POST create", vcr: cassette_options do
     let!(:gateway) { create_gateway }

--- a/spec/controllers/solidus_paypal_braintree/configurations_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/configurations_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalBraintree::CheckoutsController, type: :controller do
+end

--- a/spec/controllers/solidus_paypal_braintree/configurations_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/configurations_controller_spec.rb
@@ -1,4 +1,70 @@
 require 'spec_helper'
 
-RSpec.describe SolidusPaypalBraintree::CheckoutsController, type: :controller do
+describe SolidusPaypalBraintree::ConfigurationsController, type: :controller do
+  routes { SolidusPaypalBraintree::Engine.routes }
+
+  let!(:store_1) { create :store }
+  let!(:store_2) { create :store }
+  let(:store_1_config) { store_1.braintree_configuration }
+  let(:store_2_config) { store_2.braintree_configuration }
+
+  stub_authorization!
+
+  describe "GET #list" do
+    subject { get :list }
+
+    it "assigns all store's configurations as @configurations" do
+      subject
+      expect(assigns(:configurations)).
+        to eq [store_1.braintree_configuration, store_2.braintree_configuration]
+    end
+
+    it "renders the correct view" do
+      expect(subject).to render_template :list
+    end
+  end
+
+  describe "POST #update" do
+    let(:configurations_params) do
+      {
+        configurations: {
+          configuration_fields: {
+            store_1_config.id.to_s => { paypal: true, apple_pay: true },
+            store_2_config.id.to_s => { paypal: true, apple_pay: false }
+          }
+        }
+      }
+    end
+
+    subject { post :update, configurations_params }
+
+    context "with valid parameters" do
+      it "updates the configuration" do
+        expect { subject }.to change { store_1_config.reload.paypal }.
+          from(false).to(true)
+      end
+
+      it "displays a success message to the user" do
+        subject
+        expect(flash[:success]).to eq "Successfully updated Braintree configurations."
+      end
+
+      it "displays all configurations" do
+        expect(subject).to redirect_to action: :list
+      end
+    end
+
+    context "with invalid parameters" do
+      before { allow(SolidusPaypalBraintree::Configuration).to receive(:update) { false } }
+
+      it "displays an error message to the user" do
+        subject
+        expect(flash[:error]).to eq "An error occurred while updating Braintree configurations."
+      end
+
+      it "returns the user to the edit page" do
+        expect(subject).to redirect_to action: :list
+      end
+    end
+  end
 end

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller do
+  routes { SolidusPaypalBraintree::Engine.routes }
+
   include_context "order ready for payment"
 
   let(:payment_method) { create_gateway }


### PR DESCRIPTION
Since we're reusing the same payment method and source for Paypal, Apple Pay, and Braintree Hosted Fields, we need some way of configuring which payment methods are enabled on a per-store basis.

This adds a new `Configuration` model that's associated with stores as `braintree_configuration`, where we can set any necessary configuration options. I also added some simple views for admins to modify the configurations.

![braintreeconfig](https://cloud.githubusercontent.com/assets/4382781/20681101/e53f9a24-b556-11e6-86f1-a36807560a3a.png)
