### PR TITLE
Set PayPal payee emails as preference on gateway

### DIFF
--- a/spec/fixtures/cassettes/gateway/authorize.yml
+++ b/spec/fixtures/cassettes/gateway/authorize.yml
@@ -21,7 +21,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.68.1
+      - Braintree Ruby Gem 2.66.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -34,7 +34,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 24 Oct 2016 23:13:15 GMT
+      - Mon, 28 Nov 2016 22:38:06 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -55,49 +55,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"6828ef37ff9d35fbab06cd43273a8dae"
+      - W/"cd6cee1cd37c82bf8bba08b877de993b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5683c4a3-c894-46a1-91f1-ed92eed293ea
+      - 1ecc3bbd-1f19-4cf2-92d3-121b669c3086
       X-Runtime:
-      - '0.574291'
+      - '0.608174'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAIuVDlgAA+RYTW/jNhC951cYvjOyHDtxForSAkWBothedrOHXgJKHFlM
-        JFIlKcfur+9QlGTJopIceihQIAdr5nHI+eDMY6LHY1ksDqA0l+JhGV6vlgsQ
-        qWRc7B+WT99/JbvlY3wVGUWFpqlBVHy1WEScxXd0vTUvLzoK8MPKtKGm1jGt
-        TS4V/xtYFLQiqzWnCmJNC4iC5qeVpbVSuNuJcC0Jbgrx07dfomAqtmBaylqY
-        OFxdr1ZR0H5ZRQkqzakwhKapFRI8jzZQJrIwUeDTNqetE+LRLQQvHpZG1bAM
-        nHWKttSnoFIxRHoUqQJqgBFqFtb3hyXDT8NLWMbrVXhLwhVZb76vb76E+Lf5
-        EyPQL2jW1xX7/Potrj8vaOOsjUQP7IdL3u7+7ub2JrzrkofSjCttiKAlXJ4f
-        lQWd16WyrKg4eTRQUl545G+QaG58tqpcCp88o8dJVIOhW1HCiwKLtnfRZ+Tf
-        91AbBYBFwZgCrX0hOBoQzKZiFlLIlBbc+Mwr2OON88VJ4tUq3OW434QrTORQ
-        1B0bC1Wd5r1yaruC0KLK6fpTqJuPUKLGpPB0mrBBjtC1rBbMd1t6jW6rnSpF
-        TyMlxnPQkXxGKqoMx3BoMKaAEvDGjlf4jJ9b10fmB2YTatLci8l5Vf0vS/Kd
-        AvnP1OIwO22DJBmHgum2Fg6agFJSEYxRJYUGr2sNbuD6GB1/xUn1LqAzMc7a
-        Beg3Z+VdTOPG4TDdfyq00D3Ohzd6Qs0LuCrHkaOniY0qJVPcDePQ3Q7awBtL
-        2/vff3zFafwuaGxlfJRwtRotnx7UozNYwfHPFWoOlmTMIZrQMsbtSTD4U9jE
-        14PkqU1QhonHFVg7CahpRGpLBXAXN+9nUIYeiSMpXhUcoay6cZ5IWQAVyzij
-        hbYEqQd09AG9IClV3aw28hVEzJLbF4YBcF9Ok3ARb1bherez7VYMO8kmDne7
-        MAraj/ayoFHSELIfXFOslv67axYVVy6ZpRQmj8N1FEyEE+wJqEJusl6NwI20
-        3bed3cS2moZWPn07T/Sz9HzKXBZNuP0NhJd0D6RWRZwbU+kvQUA1Nml9nSjK
-        hb04bcVfY+cMKnqyvfu5BKxW9lzIvQwO6P91JfaPIA5cSWEBD5oKlsgj0qTe
-        ftvtFFQUudMf0hag++00OdDC5HhiZLPiVcg3EQUDmQMxSLg5691nq6oVJg6r
-        cF8XlsQNUJeafhRYdorT7gwdyNrz0pOSxQDRCdrwaV1jM8RhJl7PmJF03Fxl
-        RqyWihRiu91U2sVJsjptWPd567PMgWrB/6qhvUkoxshz7MUqptl2e7e5z7b3
-        WZixmx27TbM0REG22e6SDEtxdqmzfABRSqLZ68xN6/UtoxzftPZJQ3KOZalO
-        I8bQT9sGAWioTaC9nkjNUVFWn6T7Pb638O5bqkHMPYdcQDVGoK/8n7rXkK19
-        DJnuwmOPOuA5WmJng5hWHI80lTuHg0uPe0kbJdcjC+rnTXWiU8WrWV410Pcd
-        rSGNpMI5LhlB6kJsPD094AKJx1LGi8UjX+xjBwXBmeAhhYzrpry9OnBWZFdv
-        M91p7lmD/WR6trFRJFz2PYx+zZRwr3ezAh+pAqZWMecHO9wygLmxZLeVb8Rl
-        c6LFMCS10o7zMjD4stNdxxqp/LkZEGb/9mPM5F8An4TD0QYAO7XyH8M+HrBS
-        keb5DNZp6uHDmJEZ363nVW3AVxrtiCFcIG2r3QPEjlXXYp5ti4mCOdCY+Awc
-        HfOjIfeZBX1sq2FLH9nqKZXJsaUQvF627gCPnslxxEbNI776BwAA//8DAJ85
-        5pNjEgAA
+        H4sIAM6xPFgAA+RYTW/jNhC951cEvjOyHDtxAkVpgaJAW3SBYjc99BJQ4sji
+        RiJVknLs/fU7FCVZsqgkBXoo0Js18zjkfHDm0dHjoSwu96A0l+JhEV4tF5cg
+        Usm42D0snr78TLaLx/giMooKTVODqPji8jLiLL5Oq2+vkGdRgB9Wpg01tY5p
+        bXKp+DdgUdCKrNYcK4g1LSAKmp9WltZK4W5HwrUkuCnET59/ioKp2IJpKWth
+        4nB5tVxGQftlFSWoNKfCEJqmVkjwPNpAmcjCRIFP25y2TohHdyl48bAwqoZF
+        4KxTtKU+BJWKIdKjSBVQA4xQc2l9f1gw/DS8hEW8WoY3JAzJavtltbq/3t4v
+        N39hBPoFzfq6Yv9s/WlBG2dtJHpgP1zytrfbzXp7d9slD6UZV9oQQUs4Pz8q
+        CzqvS2VZUXH0aKCkvPDIXyHR3PhsVbkUPnlGD5OoBkO3ooQXBRZt76LPyL/v
+        oTYKAIuCMQVa+0JwMCCYTcUspJApLbjxmVewwxvni5PEq1W4y3G3DpeYyKGo
+        OzYWqjrOe+XUdgWhRZXT1YdQ1++hRI1J4ek0YYMcoWtZLZjvtvQa3VY7VYoe
+        R0qM56Aj+YxUVBmO4dBgTAEl4I0dr/AZP7Wu98wPzCbUpLkXk/Oq+l+W5BsF
+        8p+pxWF22gZJMg4F020t7DUBpaQiGKNKCg1e1xrcwPUxOv4dJ9WbgM7EOGtn
+        oF+clTcxjRv7/XT/qdBCdzgfXukRNV/BVTmOHD1NbFQpmeJuGIfudtAG3lj6
+        49fNp99s73kLNLYyPkq4tMN8Tjuz0mAFxz9WqNlbkjGHaELLGLcnweBPYRNf
+        95KnNkEZJh5XYO0koKYRqS0VwF3cvJ9BGXogjqR4VXCAsurGeSJlAVQs4owW
+        2hKkHtDRB/SCpFR1s9rIFxAxu9m/fMUAuC+nSbiI18twtd3adiuGnWQdh9tt
+        GAXtR3tZ0ChpCNmfXFOslv67axYVVy6ZpRQmj8NVFEyEE+wRqEJuslqOwI20
+        3bed3cS2moZWPn0+TfST9HTKXBZNuP0NhJd0B6RWRZwbU+n7IKAam7S+ShTl
+        wl6ctuKvsHMGFT3a3v1cAlYrey7kTgZ79P+qErtHEHuupLCAB00FS+QBaVJv
+        v+12CiqK3OmTtAXofjtNDrQwOZ4Y2ax4EfJVRMFA5kAMEm5OevfZqmqFicMq
+        3NWFJXED1LmmHwWWneK0O0EHsva89KhkMUB0gjZ8WtfYDHGYiZcTZiQdN1eZ
+        EaulIoXYbjeVdnGSrE4b1n3a+iRzoFrwv2tobxKKMfIce7GKabbZ3K7vss1d
+        Fmbsestu0iwNUZCtN9skw1KcXeos70GUkmj2MnPTen3LKMc3rX3SkJxjWarj
+        iDH007ZBABpqE2ivJ1JzVJTVB+l6j+8tvPmWahBzzyEXUI0R6Cv/h+41ZGsf
+        Q6a78NijDniOltjZIKYVxyNN5c7h4NzjXtJGyfXIgvp5U53oVPFqllcN9H1H
+        a0gjqXCOS0aQuhAbT08POEPisZTxYvHIZ/vYQUFwJnhIIeO6KW+vDpwV2dXb
+        THeae9ZgP5mebWwUCZd9D6NfMyXc692swEeqgKlVzPneDrcMYG4s2W3lK3HZ
+        nGgxDEmttOO8DAy+7HTXsUYqf24GhNm//Rgz+Qvgg3A42ABgp1b+Y9jHA1Yq
+        0jyfwTpNPXwYMzLju/W8qg34SqMdMYQLpG21e4DYsepazLNtMVEwBxoTn4Gj
+        Y3405D6zoPdtNWzpPVs9pTI5thSC18vWHeDRMzmO2Kh5xBffAQAA//8DAPuE
+        7IBjEgAA
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 23:13:14 GMT
+  recorded_at: Mon, 28 Nov 2016 22:38:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/authorize/merchant_account/EUR.yml
+++ b/spec/fixtures/cassettes/gateway/authorize/merchant_account/EUR.yml
@@ -1,0 +1,196 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount>10.00</amount>
+          <options>
+            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
+            <paypal>
+              <payee-email>paypal+europe@example.com</payee-email>
+            </paypal>
+          </options>
+          <merchant-account-id>stembolt_EUR</merchant-account-id>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.66.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 28 Nov 2016 22:50:58 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"df9df741d6d045858b07907cd3c7e618"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2ed35eaa-7d00-4fc4-bc91-128451104733
+      X-Runtime:
+      - '0.674800'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIANK0PFgAA+RYTW/jNhC9768wfGdkOXbiBIrSHrpAC7RA200PvQSUOLK4
+        kUgtSTl2f32HoiRLFpWkQA8FerNmHoecD848Ono8lsXiAEpzKR6W4dVquQCR
+        SsbF/mH59OUz2S0f40+RUVRomhpExZ8Wi4iz+GZbZitId1GAH1amDTW1jmlt
+        cqn4X8CioBVZrTlVEGtaQBQ0P60srZXC3U6Ea0lwU4h/ePotCqZiC6alrIWJ
+        w9XVahUF7ZdVlKDSnApDaJpaIcHzaANlIgvz3Bj0IZoT1wnx6BaCFw9Lo2pY
+        Bm4HivbUh6BSMUR6FKkCaoARahbW/4clw0/DS1jG61V4Q8KQrHdf1uv77ep+
+        u/sTo9AvaNbXFftn688L2lhrI9ED++ESuL25Da+vN9sugSjNuNKGCFrC5flR
+        WdB5XSrLioqTRwMl5YVH/gqJ5sZnq8ql8MkzepxENRi6FSW8KLBwexd9Rv59
+        D7VRAFgUjCnQ2heCowHBbCpmIYVMacGNz7yCPd46X5wkXq/CXZC7Tbi6jYKh
+        qDs2Fqo6zXvl1HYFoUWV0/WHUNfvoUSNSeHpNGGDHKFrWS2Y77b0Gt1WO1WK
+        nkZKjOegK/mMVFQZjuHQYEwBJeCNHa/wGT+3r/fMD8wm1KS5F5PzqvpfluQb
+        BfKfqcVhdtoGSTIOBdNtLRw0AaWkIhijSgoNXtca3MD1MTr+GafVm4DOxDhr
+        F6AfnZU3MY0bh8N0/6nQQvc4H17pCTVfwVU5jhw9TWxUKZnibhiH7nbQBt5Y
+        +vWnz7cb3ONN0NjK+Cjhyg70Oe3MSoMVHH9foeZgicYcogktY9yeBIM/hU18
+        PUie2gRlmHhcgbWTgJpGpLZUAHdx834GZeiROKLiVcERyqob54mUBVCxjDNa
+        aEuSekBHH9ALklLVzWojX0DE69fbb3dfEd58OU3CRbxZhevdzrZbMewkmzjc
+        7cIoaD/ay4JGSUPK/uCaYrX0312zqLhyySylMHkcrqNgIpxgT0AVcpP1agRu
+        pO2+7ewmttU01PLp9/NEP0vPp8xl0YTb30B4SfdAalXEuTGVvg8CqrFJ66tE
+        US7sxWkr/go7Z1DRk+3dzyVgtbLnQu5lcED/ryqxfwRx4EoKC3jQVLBEHpEm
+        9fbbbqegosidfpG2AN1vp8mBFibHE0P8JF6EfBVRMJA5EIOEm7PefbaqWmHi
+        sAr3dWFJ3AB1qelHgWWnOO3O0IGsPS89KVkMEJ2gDZ/WNTZDHGbi5YwZScfN
+        VWbEaqlIIbbbTaVdnCSr04Z1n7c+yxyoFvxbDe1NQjFGnmMvVjHNttvbzV22
+        vcvCjF3v2E2apSEKss12l2RYirNLneUDiFISzV5mblqvbxnl+Ka1zxqScyxL
+        dRoxhn7aNghAQ20C7fVEao6KsvogXe/xvYU331MNYu5J5AKqMQJ95X/XvYhs
+        7WPIdBcee9QBz9ESOxvEtOJ4pKncORxcetxL2ii5HllQP2+qE50qXs3yqoG+
+        72gNaSQVznHJCFIXYuPp6QEXSDyWMl4sHvliHzsoCM4EDylkXDfl7dWBsyK7
+        epvpTnPPGuwn07ONjSLhsm9i9GumhHu9mxX4SBUwtYo5P9jhlgHMjSW7rXwl
+        LpsTLYYhqZV2nJeBwZed7jrWSOXPzYAw+7cfYyZ/A3wQDkcbAOzUyn8M+3jA
+        SkWa5zNYp6mHD2NGZny3nle1AV9ptCOGcIG0rXYPEDtWXYt5ti0mCuZAY+Iz
+        cHTMj4bcZxb0vq2GLb1nq6dUJseWQvB62boDPHomxxEbNY/4098AAAD//wMA
+        nLZgVmcSAAA=
+    http_version: 
+  recorded_at: Mon, 28 Nov 2016 22:50:58 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/65mf0ec8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.66.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 28 Nov 2016 22:50:59 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"ee035054438bf3a936b36b626e170ed1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fbef18a3-7117-4924-b333-0f449ce3c21f
+      X-Runtime:
+      - '0.237052'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIANO0PFgAA+RYTW/jNhC9768wfGdkOXbiBIrSHrpAC7RA200PvQSUOLK4
+        kUgtSTl2f32HoiRLFpWkQA8FerNmHoecD848Ono8lsXiAEpzKR6W4dVquQCR
+        SsbF/mH59OUz2S0f40+RUVRomhpExZ8Wi4iz+GZbZitId1GAH1amDTW1jmlt
+        cqn4X8CioBVZrTlVEGtaQBQ0P60srZXC3U6Ea0lwU4h/ePotCqZiC6alrIWJ
+        w9XVahUF7ZdVlKDSnApDaJpaIcHzaANlIgvz3Bj0IZoT1wnx6BaCFw9Lo2pY
+        Bm4HivbUh6BSMUR6FKkCaoARahbW/4clw0/DS1jG61V4Q8KQrHdf1uv77ep+
+        u/sTo9AvaNbXFftn688L2lhrI9ED++ESuL25Da+vN9sugSjNuNKGCFrC5flR
+        WdB5XSrLioqTRwMl5YVH/gqJ5sZnq8ql8MkzepxENRi6FSW8KLBwexd9Rv59
+        D7VRAFgUjCnQ2heCowHBbCpmIYVMacGNz7yCPd46X5wkXq/CXZC7Tbi6jYKh
+        qDs2Fqo6zXvl1HYFoUWV0/WHUNfvoUSNSeHpNGGDHKFrWS2Y77b0Gt1WO1WK
+        nkZKjOegK/mMVFQZjuHQYEwBJeCNHa/wGT+3r/fMD8wm1KS5F5PzqvpfluQb
+        BfKfqcVhdtoGSTIOBdNtLRw0AaWkIhijSgoNXtca3MD1MTr+GafVm4DOxDhr
+        F6AfnZU3MY0bh8N0/6nQQvc4H17pCTVfwVU5jhw9TWxUKZnibhiH7nbQBt5Y
+        +vWnz7cb3ONN0NjK+Cjhyg70Oe3MSoMVHH9foeZgicYcogktY9yeBIM/hU18
+        PUie2gRlmHhcgbWTgJpGpLZUAHdx834GZeiROKLiVcERyqob54mUBVCxjDNa
+        aEuSekBHH9ALklLVzWojX0DE69fbb3dfEd58OU3CRbxZhevdzrZbMewkmzjc
+        7cIoaD/ay4JGSUPK/uCaYrX0312zqLhyySylMHkcrqNgIpxgT0AVcpP1agRu
+        pO2+7ewmttU01PLp9/NEP0vPp8xl0YTb30B4SfdAalXEuTGVvg8CqrFJ66tE
+        US7sxWkr/go7Z1DRk+3dzyVgtbLnQu5lcED/ryqxfwRx4EoKC3jQVLBEHpEm
+        9fbbbqegosidfpG2AN1vp8mBFibHE0P8JF6EfBVRMJA5EIOEm7PefbaqWmHi
+        sAr3dWFJ3AB1qelHgWWnOO3O0IGsPS89KVkMEJ2gDZ/WNTZDHGbi5YwZScfN
+        VWbEaqlIIbbbTaVdnCSr04Z1n7c+yxyoFvxbDe1NQjFGnmMvVjHNttvbzV22
+        vcvCjF3v2E2apSEKss12l2RYirNLneUDiFISzV5mblqvbxnl+Ka1zxqScyxL
+        dRoxhn7aNghAQ20C7fVEao6KsvogXe/xvYU331MNYu5J5AKqMQJ95X/XvYhs
+        7WPIdBcee9QBz9ESOxvEtOJ4pKncORxcetxL2ii5HllQP2+qE50qXs3yqoG+
+        72gNaSQVznHJCFIXYuPp6QEXSDyWMl4sHvliHzsoCM4EDylkXDfl7dWBsyK7
+        epvpTnPPGuwn07ONjSLhsm9i9GumhHu9mxX4SBUwtYo5P9jhlgHMjSW7rXwl
+        LpsTLYYhqZV2nJeBwZed7jrWSOXPzYAw+7cfYyZ/A3wQDkcbAOzUyn8M+3jA
+        SkWa5zNYp6mHD2NGZny3nle1AV9ptCOGcIG0rXYPEDtWXYt5ti0mCuZAY+Iz
+        cHTMj4bcZxb0vq2GLb1nq6dUJseWQvB62boDPHomxxEbNY/4098AAAD//wMA
+        nLZgVmcSAAA=
+    http_version: 
+  recorded_at: Mon, 28 Nov 2016 22:50:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/authorize/paypal/EUR.yml
+++ b/spec/fixtures/cassettes/gateway/authorize/paypal/EUR.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount>10.00</amount>
+          <options>
+            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
+            <paypal>
+              <payee-email>paypal+europe@example.com</payee-email>
+            </paypal>
+          </options>
+          <merchant-account-id>stembolt_EUR</merchant-account-id>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.66.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 28 Nov 2016 22:51:00 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"634371f7941a37d8394dd0cee1bfdfc8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9a598130-3a43-4aa0-820b-f9b57eebd404
+      X-Runtime:
+      - '0.548090'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIANS0PFgAA+RYwXLjNgy971d4fGdkOXbWyShKe+jO9NA9tJudtpcMJUIW
+        G4nUkpRj9+sXFCVZsqgknemhM71ZwCMIgCDw6OjhWBaLAyjNpbhfhler5QJE
+        KhkX+/vl45dPZLd8iD9ERlGhaWoQFX9YLCLO4urmepfBtzIK8MPKtKGm1jGt
+        TS4V/xtYFLQiqzWnCmJNC4iC5qeVpbVSuNuJcC0JbgrxT4+/RsFUbMG0lLUw
+        cbi6Wq2ioP2yihJUmlNhCE1TKyTojzZQJrIwT41BH6LxuE6IR7cQvLhfGlXD
+        MnA7ULSn3gWViiHSo0gVUAOMULOw8d8vGX4aXsIyXq/CGxKGZL37sl7fbcO7
+        1epPzEK/oFlfV+yfrT8vaHOtjcQI7Ic7wO1mvQ1Dm0yXDpRmXGlDBC3h0n9U
+        FnRel8qyouLk0UBJeeGRv0CiufHZqnIpfPKMHidZDYZhRQkvCizcPkSfkX8/
+        Qm0UABYFYwq09qXgaEAwexSzkEKmtODGZ17BHm+dL08Sr1fhLsjtJlx9jIKh
+        qHMbC1Wd5qNyaruC0KLK6fpdqOu3UKLGQ+Hp9MAGZ4ShZbVgvtvSa3Rb7VQp
+        ehopMZ+DruQzUlFlOKZDgzEFlIA3drzCZ/zcvt4yPzCbUJPmXkzOq+p/WZKv
+        FMh/phaHp9M2SJJxKJhua+GgCSglFcEcVVJo8IbW4Aahj9HxLzitXgV0Jsan
+        dgH62Vl5FdOEcThM958KLXSP8+GFnlDzF7gqx5GjpwcbVUqmuBvmobsdtIE3
+        lnafP/3+9Q/sPa+BxlbGruAIWg2XTx316AxWcPxjhZqDJRpziCa1jHHrCSZ/
+        CpvEepA8tQeU4cHjCqydBNQ0I7WlAriLm/czKEOPxBEVrwqOUFbdOE+kLICK
+        ZZzRQluS1AM6+oBRkJSqblYb+QwiZuKGMUyA+3KahIt4swrXu51tt2LYSTZx
+        uNuFUdB+tJcFjZKGlH3lmmK19N9ds6i4codZSmHyOFxHwUQ4wZ6AKuQm69UI
+        3EjbfdvZTWyraajl42/niX6Wnr3MZdGk299AeEn3QGpVxLkxlb4LAqqxSeur
+        RFEu7MVpK/4KO2dQ0ZPt3U8lYLWyp0LuZXDA+K8qsX8AceBKCgu411SwRB6R
+        JvX2226noKLInT5LW4Dut9PkQAuTo8cQP4pnIV9EFAxkDsQg4easd5+tqlZ4
+        cFiF+7qwJG6AutT0o8CyU5x2Z+hA1vpLT0oWA0QnaNOndY3NEIeZeD5jRtJx
+        c5UZsVoqUojtdlNplyfJ6rRh3eetzzIHqgX/VkN7k1CMmefYi1VMs+324+Y2
+        295mYcaud+wmzdIQBdlmu0syLMXZpc7yAUQpiWbPMzet17eMcnzT2mcNyTmW
+        pTqNGEM/bRsEoKH2AO31RGqOirJ6J13v8b2FV99TDWLuSeQSqjEDfeX/0L2I
+        bO1jynSXHuvqgOdoiZ0NYlpxdGkqdwEHlxH3kjZLrkcW1M+b6kSnilezvGqg
+        7ztaQxpJhXNcMoLUhdh8enrABRLdUsaLRZcv9rGDguBM8JBCxnVT3l4dOCuy
+        q7eZ7jT3rMF+MvVtbBQJl30TY1wzJdzr3azAR6qAqVU884MdbhnA3Fiy28oX
+        4k5zosU0JLXSjvMyMPiy013HGqn8ZzMgzP7tx5jJ3wDvhMPRJgA7tfK7YR8P
+        WKlI83wG6zT18GE8kZnYbeRVbcBXGu2IIVwgbavdA8SOVddinmyLiYI50Jj4
+        DAId86Mh95kFvW2rYUtv2eoplcmxpRC8XrbuAF3P5Dhjo+YRf/gOAAD//wMA
+        zJR/lWcSAAA=
+    http_version: 
+  recorded_at: Mon, 28 Nov 2016 22:51:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/complete.yml
+++ b/spec/fixtures/cassettes/gateway/complete.yml
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 31 Oct 2016 20:43:50 GMT
+      - Mon, 28 Nov 2016 22:44:07 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,40 +50,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"988122ff460733c9a4b04f9f1d744791"
+      - W/"88d6098160c469b73f51c9c4804d4478"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 763a9195-7380-44dd-a611-521b0e59df56
+      - aa21697f-8a2c-40f0-a8c1-d5fdb35ad5cb
       X-Runtime:
-      - '0.348664'
+      - '0.399298'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAatF1gAA6xVy1bjMAzd8xU92Zs82tLCSc1ulrMZmMVsOE6sNKaOHWwH
-        2r8fO82rj5RyYBddXdmKdC3Fj9uCT95BaSbFygtvA28CIpWUifXKe376hZbe
-        I76J00obWYDCN5NJzCiOwuk0jBZB7FvDYdaX5kQYZO2Fouv76HWRFItsM8+n
-        sT/0OnbGlDZIkAImgvGVZ1QFnl+7OBnzpLIoidid4FAQxk/QMpfi9IyMbE+w
-        D0g0M2fuU0AMUETMxOxKWHnUmoYV4OEoCO9QGKBp+BQFD7Ppwzz4F/t9QB1f
-        lfRr8X3A/v665ihjwKnuUqLMoJQoqptDiVJk5znvoX+PWCxhnNtuIkKpAq1b
-        fN/HxWvbwQZrG40OmjxEe+54FxvCaC/by853tPFqowBMm/cICbYGBHVFu0jj
-        MiWcmbGrFKyt/kecpdSGcGQfBeD7WRgsYn8IDX+nEkbtahgRXuYkGv3xY+b0
-        GqaobA9Y+gn1UsG/J+nmlG8Kuz7DH5GllavAsyCMlkvHER3uNI3cdfgv08Rm
-        1tlDRi45tTIdK4FTnJtFjHD8LDZCfgh7Uo/1tH0pZYaY1hURKWBHPEW7iO9X
-        9vq31zOdro2VLn7+M2B2aMunkDDT//He7J0ZqXibdyIlByI87CrnqLWzJ1fK
-        dgXZB1Nxl//g0GNPGwLbkqk6H1RIYXIcRrF/Ap5h74AoW70oOKDX6AEb6HHu
-        GeEamqhBJjkQbnKrE+jTHmAtjRVkDahSHOfGlPrB94nWYPRtoggTbiqt7Q9+
-        kN2tlY5fkl0BwrwUYHJJX7hcS//dSvS2FOtHEO9MSeEIK00ETeTWDtzu/O5G
-        Kyf3GBIiNn1qB2hLrWfqDIfLZRj7jdH6bCpK8oG0W6AjKCiJ1dFvaX3Nd++T
-        tErrFd3H91hL01WiU8VK14vDHdS/MiM3IHC6fFMljf291foqwd6qepQltaZt
-        ZZhdcQqTbD5fzO6z+X0WZnS6pHdploYWyGbzZZJZzYyGdmf/wGB6B1FIpOlm
-        RFOdfxChbBr7F3e2IvVjH+7lA6AefXEzBuHsWj+ekSeL+wuj4/LSvryyLy3s
-        K9b1Vcv64qq+sKivXNPXLulrV/TVC/rT9fwjK+TbLyD2B2LrDLBmLyd88x8A
-        AP//AwAnpJ7dNwwAAA==
+        H4sIADezPFgAA6xVy3LbOgzd5ys82jN6RK7ljMzsuuymzV1006FEyGJNkSpJ
+        Ofb9+pKyXo4t1510JxwckBBwCKQvh4ov9qA0k2LjhY+BtwCRS8rEduO9fvuM
+        Eu8FP6R5o42sQOGHxSJlFCfBeh0+BUHqW8Nh1peXRBhk7ZWi23X0c5VVq2K3
+        LJ9Sf+p17IIpbZAgFSwE4xvPqAY8v3VxMufJZVUTcbzAoSKMX6B1KcXlGQU5
+        XGBvkGlmrtyngBigiJiFOdaw8ag1DavAw1EQfkJhiKLkWxQ9x/FzsPqe+mNA
+        G9/U9O/ix4DT/W3NUcGAUz2kRJlBOVFUd4cSpcjRc95z/wmxWMY4t91EhFIF
+        Wvf4qY//7/sOdljfaHTW5Ck6cue72BFme9lfdr2jnVcbBWD6vGdIcDAgqCva
+        TRqXOeHMzF2lYGv1P+OspTaEI/soAK/jMFil/hSa/k4jjDq2MCK8Lkk0++Pv
+        mU/3MEVje8DyP1BvFfxjku5O+aCw2zP8GVlauQocB2GUJI4jBtxpGrnr8H9M
+        E5vZYE8ZpeTUynSuBE5xbhYxwvGr2An5JuxJIzbSTqWUBWJaN0TkgB3xEh0i
+        Pl7Z+9/eyHS6Nla6+PXrhDmgPZ9Cxsz4xydzdBak4X3emZQciPCwq5yjts6R
+        3CjbFWQfTMNd/pND33v6EDjUTLX5oEoKU+IwSv0L8Ar7CETZ6kXBGb1Fz9hA
+        3+deEK6hi5pkUgLhprQ6gTHtCdbTWEW2gBrFcWlMrZ99n2gNRj9mijDhptLW
+        /uAbOT5a6fg1OVYgzI8KTCnpDy630t9biT7WYvsCYs+UFI6w0UTQTB7swB3O
+        H260cnKPISNiN6Z2hvbUdqbGOEySMPU7o/fZVJTkE2n3wEBQUBOroy/S+rrv
+        0Sdpk7creowfsZ6mm0znitWuF+c7aHxlRu5A4PyQx1mc+ier9zWC/WraUZa1
+        mraVYXbFKUyK5XIVr4vluggL+pTQT3mRhxYo4mWSFVYzs6HD2f9gMO1BVBJp
+        upvR1OCfRCibxunFXa1I+9ine/kMaEdf2o1BuLrW38/Ii8X9F6Pj9tK+vbJv
+        Lew71vVdy/rmqr6xqO9c0/cu6XtX9N0L+o/r+Z+skA+/gNSfiG0wwJqjnPDD
+        bwAAAP//AwDOjmXPNwwAAA==
     http_version: 
-  recorded_at: Mon, 31 Oct 2016 20:43:50 GMT
+  recorded_at: Mon, 28 Nov 2016 22:44:07 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -93,13 +93,13 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
           <amount>55.00</amount>
+          <order-id>ORDER0-PAYMENT0</order-id>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
-          <order-id>ORDER0-PAYMENT0</order-id>
-          <payment-method-token>c8qrpd</payment-method-token>
-          <customer-id>21331270</customer-id>
+          <payment-method-token>cxc4b4</payment-method-token>
+          <customer-id>80991300</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -121,7 +121,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 31 Oct 2016 20:43:51 GMT
+      - Mon, 28 Nov 2016 22:44:08 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -142,50 +142,50 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"f21690eee7fbea2d86c7c7cf35d1e6ce"
+      - W/"4f419d82edd9b866f15bbadc1d260711"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1f47c33a-ca6f-4cc3-ac7d-2c2c029f87ed
+      - 5efa9568-865a-4235-a404-07a474780d63
       X-Runtime:
-      - '0.521826'
+      - '0.540802'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAetF1gAA9xYUW/bNhB+z68I/M5IcuzGCRRlBdoNG9B0aJsC20tASSeL
-        jUSqJOXY+/U7ipIsRVSSPRQo9mbdfTzeHY93Hx3e7MvidAdSMcGvF8GZvzgF
-        noiU8e314u7Lr2SzuIlOQi0pVzTRiIpOTk9Dlkb+Vi3X36rvoYcfRqY01bWK
-        VB2XTGtI7zMh7xVoXUAJXIdeCzBYfaggUrSA0Gt+GllSS4l7HwhTgqALEN19
-        fhd6U7EB01LUXEfr9Znvh177ZRQlyCSnXBOaJEZI0DuloYxFgS64tI3vdUwc
-        ulPOiuuFljUsPGudoi35KqiQKSLR/sdP795/8smfb//68P72C3rba5qoJVBM
-        FqH61GTiepHip2YlLKKlH7whgU/Ogy9L/2p1frUO/sZ89Aua9XWV/rf1xwVt
-        1pUWGI/5sAe7DM7Pg+WF3x0sSjMmlSaclvA0TFQWdF6XiLKi/ODQQElZ4ZA/
-        QqyYdtmqcsFd8ozuJ8n3hmGFMSsKLOhjiBfffmxwSksArI40laCUK/q9Bp6a
-        U5iFFCKhBdMu8xK2eBFdKRJ4xwp7Sy5XgX8RekNR5zZWrDzMR2XVZgWhRZXT
-        5atQ5y+heI3nwZLpWQ2OB0PLap667lOvUW2hUynpYaTEfA4alctIRaVmmI5j
-        W3qywmWc1joXkv3zsvmB2ZjqJHdiclZVw2p0lfT/siSfKZCfphaHp9P2RpIx
-        KFLV1sJOEZBSSII5qgRX4AytwQ1CH6OjDziyngV0Jsan9gT0u7XyLKYJY7eb
-        rpwKDXSLo+GRHlDzDWyV47RR04MNKykS3A3z0N0O2sAbS59vv/72xwp7z3Og
-        sZWxK4FvpvqcdmalxgqO3lao2UHqXN0gmtSmKTOeYPKnsEmsO8ESc0AZHjyu
-        wNqJQU4zUhtOgLvY8T6D0nRPLFtxqmAPZdVN8liIAihfRBktlGFKPaBjDhgF
-        SajsJpkWD8CjZPNdVpgA+2U1MePRyg+Wm41pt3zYSVZRsNkEodd+tJcFjZKG
-        mX1limK19N9ds6iYtIdZCq7zKFiG3kQ4wR6ASqQlS38EbqTtvu3YJqbVNGzz
-        7vNxmB+lRy9zUTTpdjcQVtItkFoWUa51pa48jyps0uoslpRxc3Haij/DzulV
-        9GB6930JWK3pfSG2wtth/GcV394A3zEpuAFcK8rTWOyRRPT2224noaLILG6F
-        KUD722pyoIXO0WOktfyBi0ceegOZBaUQM33U289WVUs8OKzCbV0Y/jZAPdX0
-        o8DQVJx2R+hA1vpLD1IUA0QnaNOnVI3NEIcZfzhiRtJxcxUZMVrKE4jMdlNp
-        lyeR1klDv49bH2UWVHP2vYb2JqEYM8+wF8uIZuv1xeoyW19mQZaeb9I3SZYE
-        KMhW602cYSnOLrWWd8BLQVT6MHPTen1LJsc3rX3pkJxhWcrDiDH007ZBABpq
-        D9BcT2TlqCirVzL1Ht9baF9QR0IyfFQ1iLl3kU2owgz0lf9L9ywytY8pU116
-        jKsDnqMEdjaIaMXQpancBuxNI/7BSXjNO/PnSkkvaQvHjo2CuqlkHatEsmqW
-        ag70fZNveDSpkNqIlCCbIya7jrb4BIluSe3EostP9jGzk+CYdPDklKnmxjt1
-        YK2I7grONOy5Rx622KlvY6PIQc1/BRjXzK3u9XZ84gOew9QqnvnOzPsMYG5S
-        m23FI7GnOdFiGuJaKvsMSEHjO1d1TXykcp/N4A3h3n6Mmfw98ko47E0CcHhJ
-        txvmPYWViszXZbBOEscTAU9kJnYTeVVrcJVGO3UJ48hka/smM0zDdt1703VD
-        bw405oKDQMeUcUgHZ0Ev22oI5Eu2epapc2wpBK+XqTtA1zMxztioeUQn/wIA
-        AP//AwAvVFeIjRMAAA==
+        H4sIADizPFgAA9xYUW/bOAx+768o8q46TpM1LVz3BnQH3MN2h60dbvdSyDYd
+        62pLniSnSX/9KMt27Fhuew8DhnuLyU8USVHkpwQ3uyI/3YJUTPDrmX82n50C
+        j0XC+OZ6dn/3O1nPbsKTQEvKFY01osKT09OAJeEavi8vVs+PgYcfRqY01ZUK
+        VRUVTGtIHlIhHxRonUMBXAdeAzBYvS8hVDSHwKt/GllcSYl77wlTgqALEN5/
+        uQ28sdiAaSEqrsPV6mw+D7zmyygKkHFGuSY0jo2QoHdKQxGJHF1waWvfq4g4
+        dKec5dczLSuYedY6RVvyTVAhE0Si/T8/3374PCd/vf/28cOnO/S209RRS6CY
+        LEL1qcnE9SzBT80KmIWLuf+O+D5ZrO8Wi6vl8mq+/gfz0S2o11dl8t/WHxY0
+        WVdaYDzmoznY+eWlf27Sal1Eacqk0oTTAo7DRGVOp3WxKErK9w4NFJTlDvkT
+        RIppl60yE9wlT+lulHyvH1YQsTzHgj6E+Lz9ucEpLQGwOpJEglKu6HcaeGJO
+        YRKSi5jmTLvMS9jgRXSlSOAdy+0tuVz684vA64tat7Fi5X46Kqs2KwjNy4wu
+        3oQ6fw3FKzwPFo/Pqnc8GFpa8cR1nzqNagqdSkn3AyXms9eoXEZKKjXDdBza
+        0tEKl3Fa6UxI9vy6+Z7ZiOo4c2IyVpb9anSV9P+yJF8okF+mFvun0/RGkjLI
+        E9XUwlYRkFJIgjkqBVfgDK3G9UIfosOPOLJeBLQmhqd2BPrDWnkRU4ex3Y5X
+        joUGusHR8ET3qPkXbJXjtFHjgw1KKWLcDfPQ3g5aw2tLa//2729fsfe8BBpa
+        Gbriz834mdJOrNRYweH7EjVbSJyra0Sd2iRhxhNM/hg2inUrWGwOKMWDxxVY
+        OxHIcUYqwwlwFzveJ1Ca7ohlK04V7KAo20keCZED5bMwpbkyTKkDtMwBoyAx
+        le0k0+IReBjv4mW0RHj9ZTUR4+Fy7i/Wa9Nueb+TLEN/vfYDr/loLgsaJTUz
+        +8oUxWrpvttmUTJpD7MQXGehvwi8kXCE3QOVSEsW8wG4ljb7NmObmFZTs837
+        L4dhfpAevMxEXqfb3UBYQTdAKpmHmdaluvI8qrBJq7NIUsbNxWkq/gw7p1fS
+        vendDwVgtSYPudgIb4vxn5V8cwN8y6TgBnCtKE8isUMS0dlvup2EkiKz+CRM
+        AdrfVpMBzXWGHiOt5Y9cPPHA68ksKIGI6YPefjaqSuLBYRVuqtzwtx7qWNON
+        AkNTcdodoD1Z4y/dS5H3EK2gSZ9SFTZDHGb88YAZSIfNVaTEaCmPITTbjaVt
+        nkRSxTX9Pmx9kFlQxdn3CpqbhGLMPMNeLEOarlYXy8t0dZn6aXK+Tt7Faeyj
+        IF2u1lGKpTi51FreAi8EUcnjxE3r9A2ZHN605qVDMoZlKfcDxtBN2xoBaKg5
+        QHM9kZWjoijfyNQ7fGeheUEdCEn/UVUjpt5FNqEKM9BV/m/ts8jUPqZMtekx
+        rvZ4jhLY2SCkJUOXxnIbsDeO+Ccn4S3vzF8rJZ2kKRw7NnLqppJVpGLJykmq
+        2dN3Tb7m0aREaiMSgmyOmOw62uIREt2S2olFl4/2MbOT4Jh08OSEqfrGO3Vg
+        rYj2Ck407KlHHrbYsW9Do8hBzX8FGNfEre70dnziA57D2Cqe+dbM+xRgalKb
+        bcUTsac50mIaokoq+wxIQOM7V7VNfKByn03vDeHefogZ/T3yRjjsTAJweEm3
+        G+Y9hZWKzNdlsIpjxxMBT2QidhN5WWlwlUYzdQnjyGQr+yYzTMN23QfTdQNv
+        CjTkgr1Ah5SxTwcnQa/bqgnka7Y6lqkzbCkEr5epO0DXUzHM2KB5hCc/AAAA
+        //8DAEwV+zmNEwAA
     http_version: 
-  recorded_at: Mon, 31 Oct 2016 20:43:51 GMT
+  recorded_at: Mon, 28 Nov 2016 22:44:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/purchase.yml
+++ b/spec/fixtures/cassettes/gateway/purchase.yml
@@ -22,7 +22,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.68.1
+      - Braintree Ruby Gem 2.66.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -35,7 +35,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 24 Oct 2016 23:13:14 GMT
+      - Mon, 28 Nov 2016 22:35:29 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -56,49 +56,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"e1d718aa3f3319eaa2b1102a4a0c80a5"
+      - W/"5ac53de82e8d9ccdf0fc6c299d11e254"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ca485985-ec1b-4ff6-928a-819468e2a88b
+      - 2e0ceac8-87e3-4fb3-98ed-f11cb26b4003
       X-Runtime:
-      - '0.625698'
+      - '0.571147'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAIqVDlgAA+RYS2/jNhC+768wfGdk+bFxForSAsWiPbSX3bRALwEljiw2
-        EqmSlGP313coSrJkUUkKtMACBXKIZj4OOQ/OfHT0cCqLxRGU5lLcL8Ob1XIB
-        IpWMi8P98vHrZ7JfPsQfIqOo0DQ1iIo/LBYRZ3F5Ert1frePAvywMm2oqXWs
-        66TkxgB7yqR60mBMASUIEwUtwGLNuYJY0wKioPnXytJaKdz7TLiWBI8A8eOX
-        H6JgKrZgWspamDhc3axWUdB+WUUJKs2pMISmqRUSPJ02UCaywCP4tM3Z64R4
-        dAvBi/ulUTUsA2edoi31LqhUDJEeRaqAYngINQvr+/2S4afhJSzj9Sr8SMIV
-        WW+/rjefQvzb/o4R6Bc06+uK/bP1lwVtnLWR6IH9cKncbG+3t5vNbZdKlGZc
-        aUMELeH6/Kgs6LwulWVFxdmjgZLywiN/gURz47NV5VL45Bk9TaIaDN2KEl4U
-        WMK9iz4j/76H2igALArGFGjtC8HJgGA2FbOQQqa04MZnXsEB758vThKvVuEu
-        x902XGEih6Lu2Fio6jzvlVPbFYQWVU7X70Jt3kKJGpPC02nCBjlC17JaMN9t
-        6TW6rXaqFD2PlBjPQX/yGamoMhzDcelGVyt8xmltcqn4X2+bH5hNqElzLybn
-        VfW/LMlXCuSbqcVhdtoGSTIOBdNtLRw1AaWkIhijSgoNXtca3MD1MTr+GSfV
-        q4DOxDhrV6CfnJVXMY0bx+N0/6nQQg84H17oGTV/gKtyHDl6mtioUjLF3TAO
-        3e2gDbyx9Nt6t/nxM/ae10BjK+OjhCs7zOe0MysNVnD8fYWaIzDv6gbRhJYx
-        bk+CwZ/CJr4eJU9tgjJMPK7A2klATSNSWyqAu7h5P4My9EQcSfGq4ARl1Y3z
-        RMoCqFjGGS20JUg9oKMP6AVJqepmtZHPIOLDXm/YGeHNl9MkXMTbVbje7227
-        FcNOso3D/T6MgvajvSxolDSE7FeuKVZL/901i4orl8xSCpPH4ToKJsIJ9gxU
-        ITdZr0bgRtru285uYltNQzIfv1wm+kV6OWUuiybc/gbCS3oAUqsizo2p9Kcg
-        oBqbtL5JFOXCXpy24m+wcwYVPdve/VQCVit7KuRBBkf0/6YShwcQR66ksIB7
-        TQVL5AlpUm+/7XYKKorc6RdpC9D97zQ50MLkeGJks+JZyBcRBQOZAzFIuLno
-        3WerqhUmDqvwUBeWxA1Q15p+FFh2itPuAh3I2vPSs5LFANEJ2vBpXWMzxGEm
-        ni+YkXTcXGVGrJaKFGK73VTaxUmyOm1Y92Xri8yBasH/rKG9SSjGyHPsxSqm
-        2W53u73LdndZmLHNnn1MszREQbbd7ZMMS3F2qbN8BFFKotnzzE3r9S2jHN+0
-        9oFDco5lqc4jxtBP2wYBaKhNoL2eSM1RUVbvpOs9vrfQPpwuhGT4lmoQc88h
-        F1CNEegr/7vuNWRrH0Omu/DYow54jpbY2SCmFccjTeXO4WDq8X8chPc8L7+t
-        kPSStnDc2Cion0rWiU4Vr2ap5kDfN/mGR5MKqY1kBNkcsdH1tMUrJB5LGS8W
-        j3y1j52dBMekhyczrpsb79WBsyK7KzjTsOdeethip2cbG0UOan8iQL9mbnWv
-        d+MT3+0CplYx50c77zOAuUltt5UvxGVzosUwJLXS7hnAwOBjV3dNfKTy52bw
-        hvBvP8ZMfhV5JxxONgA4vJT/GPY9hZWKzNdnsE5TzxMBMzLju/W8qg34SqOd
-        uoQLZLK1e5NZpuG67pPtulEwBxpzwYGjY8o4pIOzoLdtNQTyLVs9yzQ5thSC
-        18vWHeDRMzmO2Kh5xB/+BgAA//8DAIRExjaEEwAA
+        H4sIADGxPFgAA+RYUW/jNgx+768I8q46TpO7tHB9GzDcMGAbMNx1G/ZSyBYd
+        a7UlT5LT5H79KMt27FhuO2ADDthbTH6iSIoiPyX6cCyLxQGU5lLcL8Pr1XIB
+        IpWMi/398uHzR7JbfoivIqOo0DQ1iIqvFouIs7h8vmX5YVdGAX5YmTbU1DrW
+        dVJyY4A9ZlI9ajCmgBKEiYIWYLHmVEGsaQFR0Py0srRWCvc+Ea4lQRcgfvj0
+        XRRMxRZMS1kLE4er69UqCtovqyhBpTkVhtA0tUKC3mkDZSILdMGnbXyvE+LR
+        LQQv7pdG1bAMnHWKttSboFIxRHoUqQKK6SHULGzs90uGn4aXsIzXq/AdCUOy
+        3n1er+9utnfr2z8wA/2CZn1dsX+2/rygzbM2EiOwH+4o1+E23G52q+4oUZpx
+        pQ0RtIRL/1FZ0HldKsuKipNHAyXlhUf+DInmxmeryqXwyTN6nGQ1GIYVJbwo
+        sIT7EH1G/v0ItVEAWBSMKdDal4KjAcHsUcxCCpnSghufeQV7vH++PEm8WoW7
+        HLebcPU+Coaizm0sVHWaj8qp7QpCiyqn6zehbl5DiRoPhafTAxucEYaW1YL5
+        bkuv0W21U6XoaaTEfA76k89IRZXhmI5zN7pY4TNOa5NLxb+8bn5gNqEmzb2Y
+        nFfV/7IkXyiQr6YWh6fTNkiScSiYbmvhoAkoJRXBHFVSaPCG1uAGoY/R8U84
+        qV4EdCbGp3YB+sFZeRHThHE4TPefCi10j/PhmZ5Q8ye4KseRo6cHG1VKprgb
+        5qG7HbSBN5a+//H3j7/8hr3nJdDYytiVcGWH+Zx2ZqXBCo6/rVBzAOZd3SCa
+        1DLGrSeY/ClsEutB8tQeUIYHjyuwdhJQ04zUlgrgLm7ez6AMPRJHUrwqOEJZ
+        deM8kbIAKpZxRgttCVIP6OgDRkFSqrpZbeQTiDi/ec6TCuHNl9MkXMSbVbje
+        7Wy7FcNOsonD3S6MgvajvSxolDSE7FeuKVZL/901i4ord5ilFCaPw3UUTIQT
+        7AmoQm6yXo3AjbTdt53dxLaahmQ+fDpP9LP07GUuiybd/gbCS7oHUqsizo2p
+        9F0QUI1NWl8ninJhL05b8dfYOYOKnmzvfiwBq5U9FnIvgwPGf12J/QcQB66k
+        sIB7TQVL5BFpUm+/7XYKKorc6WdpC9D9dpocaGFy9BjZrHgS8llEwUDmQAwS
+        bs5699mqaoUHh1W4rwtL4gaoS00/Ciw7xWl3hg5krb/0pGQxQHSCNn1a19gM
+        cZiJpzNmJB03V5kRq6UihdhuN5V2eZKsThvWfd76LHOgWvC/amhvEoox8xx7
+        sYpptt2+39xm29sszNjNjr1LszREQbbZ7pIMS3F2qbN8AFFKotnTzE3r9S2j
+        HN+09oFDco5lqU4jxtBP2wYBaKg9QHs9kZqjoqzeSNd7fG+hfTidCcnwLdUg
+        5p5DLqEaM9BX/jfda8jWPqZMd+mxrg54jpbY2SCmFUeXpnIXcDCN+D9Owlue
+        l19XSnpJWzhubBTUTyXrRKeKV7NUc6Dvm3zDo0mF1EYygmyO2Ox62uIFEt1S
+        xotFly/2sbOT4Jj08GTGdXPjvTpwVmR3BWca9txLD1vs1LexUeSg9i8CjGvm
+        Vvd6Nz7x3S5gahXP/GDnfQYwN6nttvKZuNOcaDENSa20ewYwMPjY1V0TH6n8
+        ZzN4Q/i3H2Mm/4q8EQ5HmwAcXsrvhn1PYaUi8/UZrNPU80TAE5mJ3UZe1QZ8
+        pdFOXcIFMtnavcks03Bd99F23SiYA4254CDQMWUc0sFZ0Ou2GgL5mq2eZZoc
+        WwrB62XrDtD1TI4zNmoe8dXfAAAA//8DAEIqueyEEwAA
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 23:13:13 GMT
+  recorded_at: Mon, 28 Nov 2016 22:35:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/transaction/import/valid/capture.yml
+++ b/spec/fixtures/cassettes/transaction/import/valid/capture.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.68.1
+      - Braintree Ruby Gem 2.66.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 24 Oct 2016 23:13:30 GMT
+      - Mon, 28 Nov 2016 22:33:25 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,40 +50,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"b116481f421722d697d31afa4b3255c2"
+      - W/"68013348aead3241105a2b3b0c9be8a9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 69dac663-9904-4171-a28b-a0190c2d4eb8
+      - 391ca978-ac89-450f-9594-a2977d4e6024
       X-Runtime:
-      - '0.323863'
+      - '0.409511'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJqVDlgAA6xVu3bjOAzt8xU+6hlZfsRKjsx0W26zky22mQOJkMUxRWpI
-        KrH/fklZL8eWx3MynXBxQULAJZC8Hkoxe0dtuJLbIHqcBzOUmWJc7rbB27e/
-        SBy80ockq41VJWr6MJslnNE4etqs402chM7wmPNlBUhLnL3RbPe8+LFJy02+
-        XxfLJBx7PTvn2lgiocSZ5GIbWF1jEDYuAVOeTJUVyOMFjiVwcYFWhZKXZ+Rw
-        uMA+MDXcXrlPI1hkBOzMHivcBsyZlpcY0MU8eiLRnCxW3xbLl2j5spz/l4RD
-        QBNfV+z34oeA0/1NzUnOUTDTp8S4JRloZtpDQWs4Bt577j8hDku5EK6bBBjT
-        aEyHn/pY/Ow62GJdo8lZk8fowJ3uYkuY7GV32fWOtl5jNaLt8p4g4cGiZL5o
-        N2lCZSC4nbpK487pf8JZKWNBEPcokD6vovkmCcfQ+HdqafWxgQmIqoDF5I9/
-        Zi7vYcra9YBnv6DeKvjXJN2e8kVhN2eEE7J0cpV0NY8Wcew5sse9pom/jv7L
-        DbjMenvMKJRgTqZTJfCK87OIg6Bvci/Vh3QnDdhAO5VS5YQbU4PMkHriJdpH
-        fL2y97+9gel1bZ106ds/I2aPdnyGKbfDH5/MwZlDLbq8U6UEggyor5ynNs6B
-        XGvXFeIeTC18/qNDP3u6EDxUXDf5kFJJW9BokYQX4BX2EUG76i3mZ/QGPWMj
-        +5x7DsJgGzXKpEAQtnA6wSHtEdbReAk7JLUWtLC2Mi9hCMagNY+pBi79VNq5
-        H/yA46OTTljBsURpv5doC8W+C7VT4buT6GMld68o37lW0hO2BiRL1cEN3P78
-        /kYnJ/8YUpD7IbUztKM2M3VFoziOkrA1Op9LRSsxknYH9ASNFTgd/a2cr/0e
-        fIrVWbOih/gB62imTk2meeV7cb6Dhldm1R4lzc3qIG0SnqzOV0v+s25GWdpo
-        2lWGuxWnKeTr9Wb1nK+f8yhny5g9ZXkWOSBfreM0d5qZDO3P/gOD6R1lqYhh
-        +wlN9f5RhHZpnF7c1Yo0j328l8+AZvQl7RjEq2v984y8WNy/MTpuL+3bK/vW
-        wr5jXd+1rG+u6huL+s41fe+SvndF372gf7me/8gK+fILSMKR2HoDnTnIiT78
-        DwAA//8DAEnraF43DAAA
+        H4sIALWwPFgAA6xVu3bbMAzd8xU+2hlZ8jtHVraOXdp06NJDiZDFmiJVkkrs
+        vy8o6+XYctyTbsLFBQkBl0D0fCjE5BW04UpuveBx6k1Apopxudt6L9+/kLX3
+        HD9EaWWsKkDHD5NJxFkchJvlbLkKIx8Nh6Evzam0BO2VZrtN+HuVFKtsv8hn
+        kT/0OnbGtbFE0gImkoutZ3UFnl+7BB3zpKooqTxe4FBQLi7QMlfy8oyMHi6w
+        N0gMt1fu00AtMELtxB5L2HoMTcsL8OJwGixJEJBw/T0Mn2azp3DxM/L7gDq+
+        Ktm/xfcBp/vrmpOMg2CmS4lxS1KqmWkOpVrTo+e85/4TgljChcBuEsqYBmNa
+        /NTHbNZ2sMHaRpOzJg/RnjvexYYw2sv2susdbbzGagDb5j1CgoMFyVzRbtKE
+        SqngduwqDTvU/4izVMZSQfBRQLyZB9NV5A+h4e9U0upjDRMqypyGoz/+njm7
+        hykr7AFPP6DeKvjnJN2c8klh12f4I7JEucp4Pg3C9dpxZIc7TRN3XfyDG4qZ
+        dfaQkSvBUKZjJXCKc7OIUxG/yL1UbxJP6rGediqlygg3pqIyhdgRL9Eu4vOV
+        vf/t9Uyna4vSjV++DZgd2vIZJNz2f3wye2dGK9HmnSglgEovdpVz1NrZkyuN
+        XSH4YCrh8h8c+t7ThsCh5LrOhxRK2hz/LfIvwCvsI1CN1QunZ/QaPWMDe597
+        RoWBJmqQSQ5U2Bx1An3aA6yl8YLugFRaxLm1pXnyfWoMWPOYaMqlm0o7/ME3
+        enxE6fglPRYg7a8CbK7YL6F2yn9FiT6WcvcM8pVrJR1ha6hkiTrgwO3O725E
+        ObnHkFC571M7Q1tqPVPncbBeB5HfGK0PU9FKDKTdAh1BQ0lRR18V+prv3qdY
+        ldYruo/vsZZmqsSkmpeuF+c7qH9lVu1Bxhu9PDIW+Ser9VWS/6nqUZbUmsbK
+        cFxxOqbZYrGab7LFJgsyNluzZZqlAQLZfLFOMtTMaGh39n8YTK8gC0UM249o
+        qvMPIjSmcXpxVytSP/bhXj4D6tEXNWMQrq719zPyYnH/w+i4vbRvr+xbC/uO
+        dX3Xsr65qm8s6jvX9L1L+t4VffeC/nA9/5cV8ukXEPkDsXUGoNnLKX74CwAA
+        //8DAMVSxes3DAAA
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 23:13:29 GMT
+  recorded_at: Mon, 28 Nov 2016 22:33:25 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -93,12 +93,12 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
           <amount>15.00</amount>
+          <order-id>R999999999-ABCD1234</order-id>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <order-id>R999999999-ABCD1234</order-id>
-          <payment-method-token>fs4xnt</payment-method-token>
-          <customer-id>81675878</customer-id>
+          <payment-method-token>9r6ydd</payment-method-token>
+          <customer-id>12963672</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -107,7 +107,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.68.1
+      - Braintree Ruby Gem 2.66.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -120,7 +120,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 24 Oct 2016 23:13:30 GMT
+      - Mon, 28 Nov 2016 22:33:26 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -141,54 +141,54 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"826df054d0842cd5d3825587f218b713"
+      - W/"a74b437337340b43993a966359e935d9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0bb856b0-accc-48bb-9f81-07e2981c9984
+      - 8eda0d89-2663-464a-94df-f4bc57151a76
       X-Runtime:
-      - '0.383465'
+      - '0.439095'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJqVDlgAA9xYTXOzNhC+51d4fFcw/kjsDCF9377TmR7aQ/Omh14yAhaj
-        BiQiCcfur+8KAQYjkvTQmU5zMruPVtoP7T5K8HAs8tkBpGKC38/968V8BjwW
-        CeP7+/nT95/Idv4QXgVaUq5orBEVXs1mAUvCcr3fxbv9a+Dhh5EpTXWlQlrp
-        TEj2FySB14iMVp9KCBXNIfDqn0YWV1LibifClCC4KYRPj98Cbyw2YFqIiuvQ
-        31wvFoHXfBlFATLOKNeExrEREjyP0lBEIteB59LWp60i4tDNOMvv51pWMPes
-        dYq25KegQiaIRPu/7do/8uXrj9/85WodeJ229lwC1ZAQqmcmGvfzBD81K2Ae
-        Lhf+DfEXZLn+vlzd+au71eIPjEm3oF5flck/W39e0EReaYE+mQ+bzq1/c7vZ
-        3m7bdKI0ZVJpwmkBl66iMqfTulgUJeUnhwYKynKH/A0ixbTLVpkJ7pKn9DhK
-        gNd3K4hYnmMZn13MXv9d55SWAFghSSJBKZf3Rw08MVmYhOQipjnTLvMS9nj9
-        XCESeM9ye1N2a39xG3h9UXtsrFp5mvbKqs0KQvMyo8tPoVYfoXiF+WDxOFe9
-        9KBracUT153qNKopdColPQ2UGM9ee3IZKanUDMOhQOscCsDrO1zhMn7uYx+Z
-        75mNqI4zJyZjZdmvRldJ/y9L8p0C+c/UYj87TW8kKYM8UU0tHBQBKYUkGKNS
-        cAVO12pcz/UhOvwFx9a7gNbEMGsXoJ+tlXcxtRuHw3jlWGigexwNb/SEmj/B
-        VjlOGzVObFBKEeNuGIf2dtAaXlta3N58fcRR8y5oaGV4FH9hJvuUdmKlxgoO
-        v5SoORjGMYWoQ5skzJwEgz+GjXw9CBabBKWYeFyBtROBHEekMrwAd7HjfQKl
-        6ZFYxuJUwRGKsp3kkRA5UD4PU5orw5Y6QMsc0AsSU9lOMi1egIepWh858h37
-        ZTUR4+F64S+3W9Nueb+TrEN/u/UDr/loLgsaJTU7+50pitXSfbfNomTSJrMQ
-        XGehvwy8kXCEPQGVSEuWiwG4ljb7NmObmFZTc8ynx/MwP0vPp8xEXofb3UBY
-        QfdAKpmHmdaluvM8qrBJq+tIUsbNxWkq/ho7p1fSk+ndzwVgtSbPudgL74D+
-        X5d8/wD8wKTgBnCvKE8icUQS0dlvup2EkiKz+FWYArS/rSYDmusMT4zUlr9w
-        8cYDryezoAQips96+9moKomJwyrcV7nhbz3UpaYbBYaq4rQ7Q3uy5rz0JEXe
-        Q7SCJnxKVdgMcZjxlzNmIB02V5ESo6U8htBsN5a2cRJJFdcU/Lz1WWZBFWev
-        FTQ3CcUYeYa9WIY03Wxu17t0s0v9NFltk5s4jX0UpOvNNkqxFCeXWssH4IUg
-        KnmZuGmdviGTw5vWvG9IxrAs5WnAGLppWyMADTUJNNcTWTkqivKTTL3Ddxbe
-        fVjViKm3kQ2owgh0lf9D+zQytY8hU214zFF7PEcJ7GwQ0pLhkcZy67B36XEn
-        aaJke2RO3bypilQsWTnJq3r6rqPVpJGUOMdFQpC6EBNPRw+4QOKxpHZi8cgX
-        +5hBQXAmOEhhwlRd3k4dWCuirbeJ7jT1osF+Mj7b0CgSLvM4Rr8mSrjT21mB
-        L1YOY6uY84MZbinA1Fgy24o3YrM50mIYokoqy3kT0PioU23HGqjcuekRZvf2
-        Q8zo/wGfhMPRBAA7tXQfwzwesFKR5rkMVnHs4MOYkQnfjedlpcFVGs2IIYwj
-        bavsA8SMVdtink2LCbwp0JD49Bwd8qM+95kEfWyrZksf2eoolc6wpRC8Xqbu
-        AI+eimHEBs0jvPobAAD//wMAOu0cP3ASAAA=
+        H4sIALawPFgAA9xYTW/jNhC951cEvjOy7MRrB4rSbRcFeugC7W4KtJeAEkcW
+        G4nUkpRj99d3KEqyFFFJeihQNCdr5nHI+eDMY6L7Y1lcHkBpLsXdIrxaLi5B
+        pJJxsb9bPHz9kWwX9/FFZBQVmqYGUfHF5WXEWZym2bfTkm2iAD+sTBtqah3T
+        2uRS8b+ARUErslpzqiDWtIAoaH5aWVorhbudCNeS4KYQP3z5FAVTsQXTUtbC
+        xOHN1XIZBe2XVZSg0pwKQ2iaWiHB82gDZSILEwU+bXPaOiEe3aXgxd3CqBoW
+        gbNO0ZZ6F1Qqhki0/+uu+yMfv//hU7haX0dBr208V0ANMELNpY3G3YLhp+El
+        LOLVMtyQMCSr7dfV6na9vl1t/sCY9Aua9XXF/tn684I28tpI9Ml+uHSGq91m
+        vfmw6tKJ0owrbYigJbx0FZUFndelsqyoOHk0UFJeeOTPkGhufLaqXAqfPKPH
+        SQKCoVtRwosCy/jsYrb+d53TRgFghTCmQGuf90cDgtkszEIKmdKCG595BXu8
+        fr4QSbxnhbspu+tw+SEKhqLu2Fi16jTvlVPbFYQWVU5X70Kt30KJGvPB02mu
+        BulB17JaMN+d6jW6LXSqFD2NlBjPQXvyGamoMhzDocGYAkrA6zte4TN+7mNv
+        mR+YTahJcy8m51U1rEZfSf8vS/KVAvnP1OIwO21vJBmHgum2Fg6agFJSEYxR
+        JYUGr2sNbuD6GB3/jGPrVUBnYpy1F6CfnJVXMY0bh8N05VRooXscDc/0hJo/
+        wVU5Ths9TWxUKZnibhiH7nbQBt5YWv7+y+cbHN+vgsZWxkcJl3ayz2lnVhqs
+        4PhjhZqDZRxziCa0jHF7Egz+FDbx9SB5ahOUYeJxBdZOAmoakdryAtzFjfcZ
+        lKFH4hiLVwVHKKtukidSFkDFIs5ooS1b6gEdc0AvSEpVN8mMfAIR79TmxDAA
+        7stpEi7i62W42m5tuxXDTnIdh9ttGAXtR3tZ0Chp2NlvXFOslv67axYVVy6Z
+        pRQmR9IQBRPhBHsCqpCWrJYjcCNt923HNrGtpuGYD1/Ow/wsPZ8yl0UTbn8D
+        4SXdA6lVEefGVPo2CKjGJq2vEkW5sBenrfgr7JxBRU+2dz+WgNXKHgu5l8EB
+        /b+qxP4exIErKSzgTlPBEnlEEtHbb7udgoois/gsbQG6306TAy1MjidGaiue
+        hHwWUTCQORCDhJuz3n22qlph4rAK93Vh+dsA9VLTjwJLVXHanaEDWXteelKy
+        GCA6QRs+rWtshjjMxNMZM5KOm6vMiNVSkUJst5tKuzhJVqcNBT9vfZY5UC34
+        txram4RijDzHXqximt3cfLjeZTe7LMzYess2aZaGKMiub7ZJhqU4u9RZPoAo
+        JdHsaeam9fqWTI5vWvu+ITnHslSnEWPop22DADTUJtBeT2TlqCirdzL1Ht9b
+        ePVh1SDm3kYuoBoj0Ff+d93TyNY+hkx34bFHHfAcLbGzQUwrjkeayp3DwUuP
+        e0kbJdcjC+rnTXWiU8WrWV410PcdrSGNpMI5LhlB6kJsPD094AUSj6WMF4tH
+        frGPHRQEZ4KHFDKum/L26sBZkV29zXSnuRcN9pPp2cZGkXDZxzH6NVPCvd7N
+        CnyxCphaxZwf7HDLAObGkt1WPhOXzYkWw5DUSjvOy8Dgo053HWuk8udmQJj9
+        248xk/8HvBMORxsA7NTKfwz7eMBKRZrnM1inqYcPY0ZmfLeeV7UBX2m0I4Zw
+        gbStdg8QO1Zdi3m0LSYK5kBj4jNwdMyPhtxnFvS2rYYtvWWrp1Qmx5ZC8HrZ
+        ugM8eibHERs1j/jibwAAAP//AwBT++Z/cBIAAA==
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 23:13:29 GMT
+  recorded_at: Mon, 28 Nov 2016 22:33:26 GMT
 - request:
     method: put
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/p4g9c9gq/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/ccfqy0d6/submit_for_settlement
     body:
       encoding: UTF-8
       string: |
@@ -202,7 +202,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.68.1
+      - Braintree Ruby Gem 2.66.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -215,7 +215,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 24 Oct 2016 23:13:31 GMT
+      - Mon, 28 Nov 2016 22:33:26 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -236,50 +236,50 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"1abc6bc9da3b0147573df1b5424311e0"
+      - W/"598cd54ba89a8014518a8e3c03027efb"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3c172df8-ea9b-4437-8357-e71da867e70f
+      - bc6e0d2a-4a68-403d-8f86-e08086fb3aed
       X-Runtime:
-      - '0.202028'
+      - '0.315081'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJuVDlgAA9xYTW/jNhC9768wfGdkOXZiB4rS3S4K9NAemk0PvQSUNLLY
-        SKRCUo7dX79DUZIli0oMFAUWzSmaeRxyPjjz6ODhUOSzPUjFBL+f+1eL+Qx4
-        LBLGd/fzp2+/kM38IfwUaEm5orFGVPhpNgtYEpar3Tbe7l4DDz+MTGmqKxWq
-        KiqY1pA8p0I+K9A6hwK4DrwGYLD6WEKoaA6BV/9rZHElJe59JEwJgkeA8Onx
-        a+CNxQZMC1FxHfrrq8Ui8JovoyhAxhnlmtA4NkKCp1MaikjkeASXtj57FRGH
-        bsZZfj/XsoK5Z61TtCUvggqZIBLt/7Ft/8jnLz9/9ZfXq8DrtLXnEigGjFA9
-        M9G4nyf4qVkB83C58G+IvyDL1bfl9Z1/fXe9+Atj0i2o11dlcvl6H9efFjSR
-        V1qgT+bDJnfj39yuN7ebNrkoTZlUmnBawLmrqMzptC4WRUn50aGBgrLcIX+D
-        SDHtslVmgrvkKT2MEuD13QoiludY1CcXs9f/1jmlJQBWSJJIUMrl/UEDT0wW
-        JiG5iGnOtMu8hB1eRleIBN6z3N6U7cpf3AZeX9QeG6tWHqe9smqzgtC8zOjy
-        ItT1RyheYT5YPM5VLz3oWlrxxHWnOo1qCp1KSY8DJcaz16xcRkoqNcNwnFrT
-        2QqXcVrpTEj2z8fme2YjquPMiclYWfar0VXS/8uSfKdAfpha7Gen6Y0kZZAn
-        qqmFvSIgpZAEY1QKrsDpWo3ruT5Eh7/h2HoX0JoYZu0M9Ku18i6mdmO/H68c
-        Cw10h6PhjR5R8zfYKsdpo8aJDUopYtwN49DeDlrDa0uL25svjzhq3gUNrQyP
-        4i/MZJ/STqzUWMHh5xI1e0icq2tEHdokYeYkGPwxbOTrXrDYJCjFxOMKrJ0I
-        5DgileEFuIsd7xMoTQ/EMhanCg5QlO0kj4TIgfJ5mNJcGbbUAVrmgF6QmMp2
-        kmnxAjxM1epgKJf9spqI8XC18JebjWm3vN9JVqG/2fiB13w0lwWNkpqd/ckU
-        xWrpvttmUTJpk1kIrrPQXwbeSDjCHoFKpCXLxQBcS5t9m7FNTKupGefT42mY
-        n6SnU2Yir8PtbiCsoDsglczDTOtS3XkeVdik1VUkKePm4jQVf4Wd0yvp0fTu
-        5wKwWpPnXOyEt0f/r0q+ewC+Z1JwA7hXlCeROCCJ6Ow33U5CSZFZ/C5MAdr/
-        rSYDmusMT4zUlr9w8cYDryezoAQipk96+9moKomJwyrcVbnhbz3UuaYbBYaq
-        4rQ7QXuy5rz0KEXeQ7SCJnxKVdgMcZjxlxNmIB02V5ESo6U8htBsN5a2cRJJ
-        FdcU/LT1SWZBFWevFTQ3CcUYeYa9WIY0Xa9vV9t0vU39NLneJDdxGvsoSFfr
-        TZRiKU4utZb3wAtBVPIycdM6fUMmhzetee2QjGFZyuOAMXTTtkYAGmoSaK4n
-        snJUFOWFTL/DdxaaV9SJkPQfVjVi6m1kA6owAl3l/9Q+jUztY8hUGx5z1B7P
-        UQI7G4S0ZHiksdw67I09/vdB8N8LwiVvzR8rJJ2kKRw7NnLqppJVpGLJykmq
-        2dN3Tb7m0aREaiMSgmyOmOg62uIZEo8ltROLRz7bx8xOgmPSwZMTpuob79SB
-        tSLaKzjRsKceedhix2cbGkUOan4vQL8mbnWnt+MTH/EcxlYx53sz71OAqUlt
-        thVvxGZzpMUwRJVU9hmQgMZ3rmqb+EDlzk3vDeHefogZ/URyIRwOJgA4vKT7
-        GOY9hZWKzNdlsIpjxxMBMzLhu/G8rDS4SqOZuoRxZLKVfZMZpmG77rPpuoE3
-        BRpywZ6jQ8rYp4OToI9t1QTyI1sdy9QZthSC18vUHeDRUzGM2KB5hJ++AwAA
-        //8DAOImhSuREwAA
+        H4sIALawPFgAA9xYTW/jNhC951cEvjOy7MRxAkXptosCPXSBdjcF2ktAiSOL
+        jURqScqx++s7FCVZiqgkPSywaE7RzOOQ88GZR0f3h7I434PSXIq7RXixXJyD
+        SCXjYne3ePjyM9ku7uOzyCgqNE0NouKz8/OIszhNs6/HJdtEAX5YmTbU1DrW
+        dVJyY4A9ZlI9ajCmgBKEiYIWYLHmWEGsaQFR0PxrZWmtFO59JFxLgkeA+OHz
+        xyiYii2YlrIWJg6vLpbLKGi/rKIEleZUGELT1AoJnk4bKBNZ4BF82ubsdUI8
+        unPBi7uFUTUsAmedoi31LqhUDJFo//eb7o98+PGnj+FqfRkFvbbxXAHFgBFq
+        zm007hYMPw0vYRGvluGGhCFZbb+sVrfr9e1q8xfGpF/QrK8r9t/Wnxa0kddG
+        ok/2wyU3XN1s1pvrVZdclGZcaUMELeGlq6gs6LwulWVFxdGjgZLywiN/hkRz
+        47NV5VL45Bk9TBIQDN2KEl4UWNQnF7P1t3VOGwWAFcKYAq193h8MCGazMAsp
+        ZEoLbnzmFezwMvpCJPGeFe6m3FyGy+soGIq6Y2PVquO8V05tVxBaVDldvQu1
+        fgslaswHT6e5GqQHXctqwXx3qtfottCpUvQ4UmI8B83KZ6SiynAMx6k1vVjh
+        M05rk0vF/3nb/MBsQk2aezE5r6phNfpK+n9Zkq8UyHdTi8PstL2RZBwKptta
+        2GsCSklFMEaVFBq8rjW4getjdPwrjq1XAZ2JcdZegH5xVl7FNG7s99OVU6GF
+        7nA0PNMjav4GV+U4bfQ0sVGlZIq7YRy620EbeGNp+edvn65wfL8KGlsZHyVc
+        2sk+p51ZabCC4w8VavbAvKsbRBNaxrg9CQZ/Cpv4upc8tQnKMPG4AmsnATWN
+        SG15Ae7ixvsMytADcYzFq4IDlFU3yRMpC6BiEWe00JYt9YCOOaAXJKWqm2RG
+        PoGIb9TmyDAA7stpEi7iy2W42m5tuxXDTnIZh9ttGAXtR3tZ0Chp2NkfXFOs
+        lv67axYVVy6ZpRQmR9IQBRPhBHsEqpCWrJYjcCNt923HNrGtpmGcD59Pw/wk
+        PZ0yl0UTbn8D4SXdAalVEefGVPo2CKjGJq0vEkW5sBenrfgL7JxBRY+2dz+W
+        gNXKHgu5k8Ee/b+oxO4exJ4rKSzgTlPBEnlAEtHbb7udgoois/gkbQG6/50m
+        B1qYHE+M1FY8CfksomAgcyAGCTcnvftsVbXCxGEV7urC8rcB6qWmHwWWquK0
+        O0EHsva89KhkMUB0gjZ8WtfYDHGYiacTZiQdN1eZEaulIoXYbjeVdnGSrE4b
+        Cn7a+iRzoFrwrzW0NwnFGHmOvVjFNLu6ur68ya5usjBj6y3bpFkaoiC7vNom
+        GZbi7FJneQ+ilESzp5mb1utbMjm+ae1rh+Qcy1IdR4yhn7YNAtBQm0B7PZGV
+        o6Ks3snUe3xvoX1FnQjJ8GHVIObeRi6gGiPQV/4P3dPI1j6GTHfhsUcd8Bwt
+        sbNBTCuOR5rKncPB1ONvHIT3vDW/r5D0krZw3NgoqJ9K1olOFa9mqeZA3zf5
+        hkeTCqmNZATZHLHR9bTFF0g8ljJeLB75xT52dhIckx6ezLhubrxXB86K7K7g
+        TMOee+Rhi52ebWwUOaj9vQD9mrnVvd6NT3zEC5haxZzv7bzPAOYmtd1WPhOX
+        zYkWw5DUSrtnAAOD71zdNfGRyp+bwRvCv/0YM/mJ5J1wONgA4PBS/mPY9xRW
+        KjJfn8E6TT1PBMzIjO/W86o24CuNduoSLpDJ1u5NZpmG67qPtutGwRxozAUH
+        jo4p45AOzoLettUQyLds9SzT5NhSCF4vW3eAR8/kOGKj5hGf/QsAAP//AwBW
+        cAXtkRMAAA==
     http_version: 
-  recorded_at: Mon, 24 Oct 2016 23:13:30 GMT
+  recorded_at: Mon, 28 Nov 2016 22:33:27 GMT
 recorded_with: VCR 3.0.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,9 @@ module BraintreeHelpers
         merchant_id: '7rdg92j7bm7fk5h3',
         merchant_currency_map: {
           'EUR' => 'stembolt_EUR'
+        },
+        paypal_payee_email_map: {
+          'EUR' => 'paypal+europe@example.com'
         }
       }
     }.merge(opts))


### PR DESCRIPTION
Stores that accept payment in different currencies in different countries may have separate PayPal accounts linked to bank accounts for those countries. To ensure payments go to the correct account, PayPal requires that we pass in the email associated with the account for that currency as the payee_email.