### PR TITLE
Validate the address on a transaction if it exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ end
 gem 'solidus_auth_devise', '~> 1.0'
 
 group :development, :test do
+  gem "chromedriver-helper"
   gem "pry-rails"
   gem "selenium-webdriver"
-  gem "chromedriver-helper"
 end
 
 gemspec

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
@@ -129,7 +129,7 @@ window.SolidusPaypalBraintree = {
             if (xhr.status === 422) {
               var errors = xhr.responseJSON.errors
 
-              if (errors && (errors["Address"] || errors["TransactionAddress"])) {
+              if (errors && errors["Address"]) {
                 session.completePayment(ApplePaySession.STATUS_INVALID_SHIPPING_POSTAL_ADDRESS);
               } else {
                 session.completePayment(ApplePaySession.STATUS_FAILURE);

--- a/app/models/solidus_paypal_braintree/transaction.rb
+++ b/app/models/solidus_paypal_braintree/transaction.rb
@@ -17,6 +17,11 @@ module SolidusPaypalBraintree
       unless payment_method.is_a? SolidusPaypalBraintree::Gateway
         errors.add(:payment_method, 'Must be braintree')
       end
+      if address && !address.valid?
+        address.errors.each do |field, error|
+          errors.add(:address, "#{field} #{error}")
+        end
+      end
     end
 
     def address_attributes=(attributes)

--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -7,12 +7,11 @@ module SolidusPaypalBraintree
     include ActiveModel::Model
 
     validate do
-      errors.add("Transaction", "is invalid") if !transaction.valid?
       errors.add("Address", "is invalid") if address && !address.valid?
 
-      if transaction.address && !transaction.address.valid?
-        transaction.address.errors.each do |field, error|
-          errors.add("TransactionAddress", "#{field} #{error}")
+      if !transaction.valid?
+        transaction.errors.each do |field, error|
+          errors.add(field, error)
         end
       end
       errors.none?

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
           SolidusPaypalBraintree::TransactionsController::InvalidImportError,
           "Import invalid: " \
           "Address is invalid, " \
-          "Transactionaddress city can't be blank"
+          "Address city can't be blank"
         )
       end
     end
@@ -121,7 +121,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
         it "raises an error including the validation messages" do
           expect { post_create }.to raise_error(
             SolidusPaypalBraintree::TransactionsController::InvalidImportError,
-            "Import invalid: Transaction is invalid"
+            "Import invalid: Email can't be blank"
           )
         end
       end
@@ -137,7 +137,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
 
         it "returns the errors as JSON" do
           post_create
-          expect(json["errors"]["Transaction"]).to eq ["is invalid"]
+          expect(json["errors"]["email"]).to eq ["can't be blank"]
         end
       end
     end

--- a/spec/models/solidus_paypal_braintree/transaction_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe SolidusPaypalBraintree::Transaction do
   describe "#valid?" do
+    let!(:country) { create :country, iso: "US" }
     let(:valid_attributes) do
       {
         nonce: 'abcde-fghjkl-lmnop',
@@ -11,8 +12,22 @@ describe SolidusPaypalBraintree::Transaction do
         email: "test@example.com"
       }
     end
+    let(:valid_address_attributes) do
+      {
+        address_attributes: {
+          first_name: "Bruce",
+          last_name: "Wayne",
+          address_line_1: "42 Spruce Lane",
+          city: "Gotham",
+          zip: "98201",
+          state_code: "WA",
+          country_code: "US"
+        }
+      }
+    end
+    let(:transaction) { described_class.new(valid_attributes) }
 
-    subject { described_class.new(valid_attributes).valid? }
+    subject { transaction.valid? }
 
     it { is_expected.to be true }
 
@@ -44,6 +59,25 @@ describe SolidusPaypalBraintree::Transaction do
     context 'no email' do
       let(:valid_attributes) { super().except(:email) }
       it { is_expected.to be false }
+    end
+
+    context "valid address" do
+      let(:valid_attributes) { super().merge(valid_address_attributes) }
+      it { is_expected.to be true }
+    end
+
+    context "invalid address" do
+      let(:valid_attributes) { super().merge(valid_address_attributes) }
+
+      before { valid_address_attributes[:address_attributes][:zip] = nil }
+
+      it { is_expected.to be false }
+
+      it "sets useful error messages" do
+        transaction.valid?
+        expect(transaction.errors.full_messages).
+          to eq ["Address zip can't be blank"]
+      end
     end
   end
 end


### PR DESCRIPTION
Currently a transaction will be valid even if its associated address is invalid. We do the nested validation on the transaction import, but I think it belongs on the transaction itself. This will validate the address on a transaction only if it exists and keep existing behaviour otherwise.