### PR TITLE
Pass order state to transaction import

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -10,8 +10,8 @@ module SolidusPaypalBraintree
 
     belongs_to :customer, class_name: "SolidusPaypalBraintree::Customer"
 
-    scope :with_payment_profile, -> { joins(:customer) }
-    scope :credit_card, -> { where(payment_type: CREDIT_CARD) }
+    scope(:with_payment_profile, -> { joins(:customer) })
+    scope(:credit_card, -> { where(payment_type: CREDIT_CARD) })
 
     delegate :last_4, :card_type, to: :braintree_payment_method, allow_nil: true
 

--- a/app/models/solidus_paypal_braintree/transaction.rb
+++ b/app/models/solidus_paypal_braintree/transaction.rb
@@ -1,5 +1,4 @@
 require 'active_model'
-require 'solidus_paypal_braintree/transaction_address'
 
 module SolidusPaypalBraintree
   class Transaction

--- a/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
+++ b/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
@@ -18,7 +18,7 @@ class SolidusPaypalBraintree::TransactionsController < Spree::StoreController
 
     respond_to do |format|
       if import.valid?
-        import.import!
+        import.import!(import_state)
 
         format.html { redirect_to redirect_url(import) }
         format.json { render json: { redirectUrl: redirect_url(import) } }
@@ -31,6 +31,10 @@ class SolidusPaypalBraintree::TransactionsController < Spree::StoreController
   end
 
   private
+
+  def import_state
+    params[:state] || 'confirm'
+  end
 
   def import_error(import)
     raise InvalidImportError,


### PR DESCRIPTION
Users might not always want the order to be advanced all the way through to confirm. This allows a state parameter to be sent to the create action on the transactions controller to specify the desired end state for the order. If none is provided, the default value 'confirm' is used.