### PR TITLE
Bump rubocop and add exclude blocklength from spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -209,6 +209,10 @@ Metrics/AbcSize:
 Metrics/BlockNesting:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Metrics/ClassLength:
   Enabled: false
 

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '>= 0.47'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
A new rubocop feature will check blocklength of spec files, which we
don't want or care about.