### PR TITLE
Add dependent :destroy to configuration association

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Store.class_eval do
-  has_one :braintree_configuration, class_name: "SolidusPaypalBraintree::Configuration"
+  has_one :braintree_configuration, class_name: "SolidusPaypalBraintree::Configuration", dependent: :destroy
 
   before_create :build_default_configuration
 


### PR DESCRIPTION
Since configurations are tied to the store, it doesn't make sense to keep them around if the store is deleted.