### PR TITLE
Add convenience methods for card details

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -1,45 +1,59 @@
-class SolidusPaypalBraintree::Source < ApplicationRecord
-  PAYPAL = "PayPalAccount"
-  APPLE_PAY = "ApplePayCard"
+module SolidusPaypalBraintree
+  class Source < ApplicationRecord
+    PAYPAL = "PayPalAccount"
+    APPLE_PAY = "ApplePayCard"
 
-  belongs_to :user, class_name: "Spree::User"
-  belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
-  has_many :payments, as: :source, class_name: "Spree::Payment"
+    belongs_to :user, class_name: "Spree::User"
+    belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
+    has_many :payments, as: :source, class_name: "Spree::Payment"
 
-  belongs_to :customer, class_name: "SolidusPaypalBraintree::Customer"
+    belongs_to :customer, class_name: "SolidusPaypalBraintree::Customer"
 
-  scope :with_payment_profile, -> { joins(:customer) }
+    scope :with_payment_profile, -> { joins(:customer) }
 
-  # we are not currenctly supporting an "imported" flag
-  def imported
-    false
-  end
+    delegate :last_4, :card_type, to: :braintree_payment_method
 
-  def actions
-    %w[capture void credit]
-  end
+    # we are not currenctly supporting an "imported" flag
+    def imported
+      false
+    end
 
-  def can_capture?(payment)
-    payment.pending? || payment.checkout?
-  end
+    def actions
+      %w[capture void credit]
+    end
 
-  def can_void?(payment)
-    !payment.failed? && !payment.void?
-  end
+    def can_capture?(payment)
+      payment.pending? || payment.checkout?
+    end
 
-  def can_credit?(payment)
-    payment.completed? && payment.credit_allowed > 0
-  end
+    def can_void?(payment)
+      !payment.failed? && !payment.void?
+    end
 
-  def friendly_payment_type
-    I18n.t(payment_type.underscore, scope: "solidus_paypal_braintree.payment_type")
-  end
+    def can_credit?(payment)
+      payment.completed? && payment.credit_allowed > 0
+    end
 
-  def apple_pay?
-    payment_type == APPLE_PAY
-  end
+    def friendly_payment_type
+      I18n.t(payment_type.underscore, scope: "solidus_paypal_braintree.payment_type")
+    end
 
-  def paypal?
-    payment_type == PAYPAL
+    def apple_pay?
+      payment_type == APPLE_PAY
+    end
+
+    def paypal?
+      payment_type == PAYPAL
+    end
+
+    private
+
+    def braintree_payment_method
+      @braintree_payment_method ||= braintree_client.payment_method.find(token)
+    end
+
+    def braintree_client
+      @braintree_client ||= payment_method.braintree
+    end
   end
 end


### PR DESCRIPTION
Braintree will provide us with some payment details if we ask them. For Paypal and Apple Pay payments, we'll still get the payment method object but the fields will be nil.