### PR TITLE
Only setup Apple Pay if HTTPS

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
@@ -53,7 +53,7 @@ window.SolidusPaypalBraintree = {
   },
 
   setupApplePay: function(braintreeClient, merchantId, readyCallback) {
-    if(window.ApplePaySession) {
+    if(window.ApplePaySession && location.protocol == "https:") {
       var promise = ApplePaySession.canMakePaymentsWithActiveCard(merchantId);
       promise.then(function (canMakePayments) {
         if (canMakePayments) {


### PR DESCRIPTION
Apple Pay doesn't work on non-https domains, so there's no point in throwing an error that will end up breaking other JS.