### PR TITLE
Handle processor and gateway error responses

### DIFF
--- a/app/models/solidus_paypal_braintree/response.rb
+++ b/app/models/solidus_paypal_braintree/response.rb
@@ -34,8 +34,18 @@ module SolidusPaypalBraintree
       end
 
       def build_failure(result)
-        msg = result.errors.map { |e| "#{e.message} (#{e.code})" }.join(" ")
-        new(false, msg)
+        new(false, error_message(result))
+      end
+
+      def error_message(result)
+        if result.errors.any?
+          result.errors.map { |e| "#{e.message} (#{e.code})" }.join(" ")
+        else
+          [result.transaction.status,
+           result.transaction.gateway_rejection_reason,
+           result.transaction.processor_settlement_response_code,
+           result.transaction.processor_settlement_response_text].compact.join(" ")
+        end
       end
     end
   end


### PR DESCRIPTION
The existing code here will only return error messages if they come from Braintree. In the case that the transaction is rejected by the gateway or the processor, we'll return an error response with a blank message.

For these cases, the `errors` array will be empty, and we need to look at the gateway rejection status or processor response codes as per the documentation here:
https://developers.braintreepayments.com/reference/response/transaction/ruby#result-object