### PR TITLE
Submit shipping address with PayPal transactions

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -261,11 +261,29 @@ module SolidusPaypalBraintree
         params[:payment_method_nonce] = source.nonce
       end
 
+      if source.paypal?
+        params[:shipping] = braintree_shipping_address(options)
+      end
+
       if source.customer.present?
         params[:customer_id] = source.customer.braintree_customer_id
       end
 
       params
+    end
+
+    def braintree_shipping_address(options)
+      address = options[:shipping_address]
+      first, last = address[:name].split(" ", 2)
+      {
+        first_name: first,
+        last_name: last,
+        street_address: [address[:address1], address[:address2]].compact.join(" "),
+        locality: address[:city],
+        postal_code: address[:zip],
+        region: address[:state],
+        country_code_alpha2: address[:country]
+      }
     end
 
     def merchant_account_for(_source, options)

--- a/spec/fixtures/cassettes/gateway/authorize.yml
+++ b/spec/fixtures/cassettes/gateway/authorize.yml
@@ -14,6 +14,15 @@ http_interactions:
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <shipping>
+            <first-name>Bruce</first-name>
+            <last-name>Wayne</last-name>
+            <street-address>42 Spruce Lane Apt 312</street-address>
+            <locality>Gotham</locality>
+            <postal-code>90210</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
           <type>sale</type>
         </transaction>
     headers:
@@ -22,7 +31,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -35,7 +44,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:29 GMT
+      - Fri, 28 Apr 2017 20:33:08 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -56,49 +65,51 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"54d798d964fd06eaf277f5a6661eaeeb"
+      - W/"d86e90e96f2176f6340b21dfefd393c2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3d300059-3ec4-4bac-9138-6ac650099962
+      - 7d1bc2ae-cede-4653-8018-b9861f2065e1
       X-Runtime:
-      - '0.465756'
+      - '0.813205'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKGBklgAA+RYz2+sNhC+56+I9u4Am92XTURIWz1V6qG95KWHXiKDh8UN
-        2NQ2m93313eMgYVgklTqoVKlHJaZz2PPD898TvxwrMrLAyjNpbhfRVfh6hJE
-        JhkX+/vV07efyW71kFzERlGhaWYQlVxcXsacJVv2fXeKrqs4wA8r04aaRie0
-        MYVU/DuwOOhEVmtONSSalhAH7U8ryxqlcLcT4VoS3BSSp8evcTAXWzCtZCNM
-        EoVXYRgH3ZdVVKCyggpDaJZZIcHzaANVKksTBz5te9omJR7dpeDl/cqoBlaB
-        s07RlvoUVCqGSI8iU0ANMELNpfX9fsXw0/AKVsk6jG5IuMa/b2F4t7m5W9/+
-        gREYFrTrm5r9s/XnBV2ctZHogf1wybvebqL1l5uwTx5Kc660IYJW8Pb8qCzp
-        si6TVU3FyaOBivLSI3+FVHPjs1UXUvjkOT3OohqM3YpTXpZYtIOLPiP/vofa
-        KAAsCsYUaO0LwdGAYDYVi5BSZrTkxmdewR5vnC9OEq9W6S7H7SYKb+JgLOqP
-        jYWqTsteObVdQWhZF3T9KdT1RyjRYFJ4Nk/YKEfoWt4I5rstg0Z31U6VoqeJ
-        EuM56kg+IzVVhmM4NBhTQgV4Y6crfMbPresj8yOzKTVZ4cUUvK7/lyX5ToH8
-        Z2pxnJ2uQZKcQ8l0VwsHTUApqQjGqJZCg9e1FjdyfYpOfsVJ9S6gNzHN2hvQ
-        L87Ku5jWjcNhvv9caKF7nA+v9ISaP8FVOY4cPU9sXCuZ4W4Yh/520BbuzIfr
-        n75+w97zHmhqZXqUKLTDfEm7sNJgBSc/1qg5WJKxhGhDyxi3J8Hgz2EzXw+S
-        ZzZBOSYeV2DtpKDmEWksFcBd3LxfQBl6JI6keFVwhKrux3kqZQlUrJKcltoS
-        pAHQ0wf0gmRU9bPayBcQybY+qHWN8PbLaVIukk0YrXc7227FuJNskmi3i+Kg
-        ++guCxolLSH7nWuK1TJ8982i5sols5LCFEm0joOZcIY9AVXITdbhBNxKu327
-        2U1sq2lp5dPjeaKfpedTFrJsw+1vILyieyCNKpPCmFrfBQHV2KT1VaooF/bi
-        dBV/hZ0zqOnJ9u7nCrBa2XMp9zI4oP9Xtdg/gDhwJYUF3GsqWCqPSJMG+123
-        U1BT5E6/SVuA7rfTFEBLU+CJkc2KFyFfRRyMZA7EIOXmrHefnapRmDiswn1T
-        WhI3Qr3VDKPAslOcdmfoSNadl56ULEeIXtCFT+sGmyEOM/Fyxkyk0+Yqc2K1
-        VGSQ2O3m0j5OkjVZy7rPW59lDtQI/lcD3U1CMUaeYy9WCc2325vNbb69zaOc
-        Xe/YlyzPIhTkm+0uzbEUF5c6ywcQlSSavSzctEHfMcrpTeueNKTgWJbqNGEM
-        w7RtEYCGugTa64nUHBVV/Um6PuAHC+++pVrE0nPIBVRjBIbK/6F/Ddnax5Dp
-        Pjz2qCOeoyV2NkhozfFIc7lzOHjr8SDpouR6ZEn9vKlJdaZ4vcirRvqho7Wk
-        kdQ4xyUjSF2IjaenB7xB4rGU8WLxyG/2sYOC4EzwkELGdVveXh04K7Kvt4Xu
-        tPSswX4yP9vUKBIu+x5GvxZKeNC7WYGPVAFl8ihLzhqNJd0JHGtVBzvhcoCl
-        2WT3lq/EpXSmxVikjdKO+DIw+LzTfduaqPwJGrFm//ZTzOz/AJ+Ew9E6je1a
-        +Y9hXxBYrsj1fAabLPOQYkzLgu/W87ox4KuPbs4QLpC7Ne4VYmer6zPPts/E
-        wRJoyn5Gjk5J0pgALYI+ttVSpo9sDbzKFNhXCN4xW3yAR8/lNGKTDpJc/A0A
-        AP//AwD4gd6maBIAAA==
+        H4sIAASnA1kAA6xY3XOjNhB/v7/C43cFsMnFd0N0Tdvp1/T6kks705eMQMLo
+        AhKVhGP3r+8KAQYjktxM38zuTyvtaj9+cvLpWJWrA1OaS3G7jq7C9YqJTFIu
+        9rfrhy8/od36E36XGEWEJpkBFH63WiWc4m1Gwq/vo1MSwIeVaUNMozFpTCEV
+        /5fRJOhEVmtONcOalCwJ2p9WljVKwW4nxLVEsCnDD/c/JsFcbMGkko0wOAqv
+        wjAJui+rqJjKCiIMIllmhQjOow2rUlmaJPBp29M2KfLoVoKXt2ujGrYOnHUC
+        ttSboFJRQHoUmWLEMIqIWVnfb9cUPg2v2BpvwugGhTHa7L5swo/b7cdw9zdE
+        YFjQrm9q+m3rzwu6OGsjwQP74S4vvtnG7+NduO1vD8Q5V9ogQSp26QAoS7Ks
+        y2RVE3HyaFhFeOmRP7NUc+OzVRdS+OQ5Oc7CGoz9SlJelpC1g48+I/+/h9oo
+        xiArKFVMa18IjoYJau9iEVLKjJTc+MwrtoeS88VJQm2Vrjo+xFF4kwRjUX9s
+        yFR1WvbKqe0KRMq6IJs3obavoUQDl8Kz+YWN7ghcyxtBfeUyaHSX7kQpcpoo
+        IZ6jluQzUhNlOIRDM2NKVjEo2ekKn/Fz73rN/MhsSkxWeDEFr+s3pyT+XjUZ
+        dMeR5CIx8V/kJABxFnxbduJ4s7qv7S6r3wlU2V1tVttoY9v0BPbNiYt/lqYg
+        FZysF4yzF/9wlwTdT0/yhpsofC158YOAdkFX9zBPmF7JfHXXZhiBHjCGLeY1
+        DJYzdCxfzHFYcedbsn0h4fEuDi/W9Jo2/ccJ0TVllHNWUt2l30EjppRUCAJe
+        S6FZa2SWWBY3CtgUjT/DdHwR0JuYXvsF6Fdn5UVM68bhMN9/LrTQPVzeMzmB
+        5itzhQVjTs/bW1IrmcFuEIe+IEkLby3d/PbL9ecdZMxLoKmV6VGi0BKIJe3C
+        SgPlgO9q0BwssVlCtKGllNuTQPDnsJmvB8kze0E5XDysgHxJmZpHpLH0A3Zx
+        HGMBZcgROWLkVbEjq+qeQqRSloyINc5JqS0pGwA9ZQEvUEZUTw+MfGICX8fP
+        T3EM8PbLaVIucBxGm93Odngxblsxjna7qGtZcV86YBS1JPBPrm0JD99956m5
+        cpdZSWEKbHvUTDjDnhhRwIc24QTcSrt9O7qAbJtqqWzbFWbS8ykLWbbh9s9P
+        XpE9Q40qcWFMrT8GAdEwF/RVqggXtnC6jL+CDh3U5GTHxWPFIFvpYyn3MjiA
+        /1e12H9i4sCVFBZwq4mgqTwCMxvsd21TsZoAXftD2gR0v52mYKQ0BZzYdson
+        IZ9FEoxkDkRZys1Z7z47VaPg4iAL901pieMIdakZRo5lxDBgz9CRrDsvOSlZ
+        jhC9oAuf1g00Q5if4umMmUinrVbmyGqJyBg+t9mxtI+TpE3WMv3z1meZAzWC
+        /9OwrpJADJHn0IsVJvn19U38Ib/+kEc53e7o+yzPIhDk8fUuzSEVF5c6ywcm
+        Kok0fVqotEHfkdhppXXPKFRwSEt1mpCUYaq3CAaGugu05QnPAVBU9RufCAN+
+        sPDi+61FLD3BXEA1RGDI/O/6F5jNfQiZ7sNjjzqiVlpCZ2OY1ByONJc7h4NL
+        jwdJFyXXI0vip2pNqjPF60UqN9IPHa3lqaiG2S0pAh6EbDw9PeACCcdSxouF
+        I1/sYwcFgpng4aGU6za9vTrmrMg+3xa609JLCvrJ/GxTo0Dc7Bsc/FpI4UHv
+        ZgU8jAUr8b0sOW00pHQncERZHeyEyxlbmk12b/mM3JXOtBCLtFHacW3KDLwo
+        e4o6VfkvaETU/dtPMbP/Ht4IZ0frNLRr5T+GfbRAugLX8xlssszDsOFaFny3
+        nteNpcLz/OjmDOICuFvjHj52tro+82j7TBIsgabsZ+TolCSNCdAi6HVbLWV6
+        zdbAq0wBfQVBjdnkY3D0XE4jNukg+N1/AAAA//8DABhRXazcEgAA
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:29 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/authorize/merchant_account/EUR.yml
+++ b/spec/fixtures/cassettes/gateway/authorize/merchant_account/EUR.yml
@@ -18,6 +18,15 @@ http_interactions:
           </options>
           <merchant-account-id>stembolt_EUR</merchant-account-id>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <shipping>
+            <first-name>Bruce</first-name>
+            <last-name>Wayne</last-name>
+            <street-address>42 Spruce Lane Apt 312</street-address>
+            <locality>Gotham</locality>
+            <postal-code>90210</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
           <type>sale</type>
         </transaction>
     headers:
@@ -26,7 +35,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -39,7 +48,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:30 GMT
+      - Fri, 28 Apr 2017 20:33:07 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -60,54 +69,56 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"b9a973fa5da11e6c069afbf6dec3456a"
+      - W/"217fb686a56940b0a85a3ce9c05175a4"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - dd95d5b8-647e-4be7-b3ef-b10e38cd740c
+      - eaeac5fb-4714-4c26-98a7-13b01da00679
       X-Runtime:
-      - '0.482031'
+      - '0.524159'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKKBklgAA+RYS2/jNhC+768IfGckP7JxFoq2PbRADy3a7qYoegkocWSx
-        oUiVpBy7v75DUZKliEpy6KFAgRysmY9DzoMzH5N8PlXi6gjacCXvV+vreHUF
-        MleMy8P96uHr92S/+px+SKym0tDcIir9cHWVcJb+eXum2+ppl0T44WTGUtuY
-        lDa2VJr/DSyJOpHT2nMNqaECkqj96WR5ozXudibcKIKbQvrdw69JNBc7MK1U
-        I226jq/jOIm6L6eoQOcllZbQPHdCgucxFqpMCfvYGgwh2hM3GQnoriQX9yur
-        G1hFfgeK9vS7oEozRAYUuQZqgRFqr5z/9yuGn5ZXsEo38fqWxBv8+xrHn3a3
-        nzZ3f2AUhgXt+qZm716/jXH9ZUEXa2MVeuA+fAI3H7c327vbfZ9AlBZcG0sk
-        reDl+VEp6LIuV1VN5TmggYpyEZA/Q2a4DdmqSyVD8oKeZlGNxm4lGRcCC3dw
-        MWTk3/fQWA2ARcGYBmNCIThZkMylYhEiVE4FtyHzGg5460JxUni9hL8gd7t1
-        fJtEY1F/bCxUfV72yqvdCkJFXdLNu1Dbt1CywaTwfJ6wUY7QtaKRLHRbBo3p
-        qp1qTc8TJcZz1JVCRmqqLcdwGLBWQAV4Y6crQsYv7est8yOzGbV5GcSUvK7/
-        lyX5SoH8Z2pxnJ2uQZKCg2Cmq4WjIaC10gRjVCtpIOhaixu5PkWnP+K0ehXQ
-        m5hm7QXoB2/lVUzrxvE4338udNADzodnekbNn+CrHEeOmSc2qbXKcTeMQ387
-        aAtvLf1y8+Xnj79j73kNNLUyPco6dgN9Sbuw0mIFp9/WqDk6orGEaEPLGHcn
-        weDPYTNfj4rnLkEFJh5XYO1koOcRaRwVwF38vF9AWXoinqgEVXCCqu7HeaaU
-        ACpXaUGFcSRpAPT0Ab0gOdX9rLbqCWR6V23s1iK8/fKajMt0F683+71rt3Lc
-        SXbper9fJ1H30V0WNEpaUvYbNxSrZfjum0XNtU9mpaQt0/UmiWbCGfYMVCM3
-        2cQTcCvt9u1mN3GtpqWWD18uE/0ivZyyVKINd7iB8IoegDRapKW1tfkURdRg
-        kzbXmaZcuovTVfw1ds6opmfXux8rwGplj0IdVHRE/69refgM8si1kg5wb6hk
-        mTohTRrsd91OQ02RO/2kXAH6315TAhW2xBND+iCfpHqWSTSSeRCDjNuL3n92
-        qkZj4rAKD41wJG6EeqkZRoFjpzjtLtCRrDsvPWslRohe0IXPmAabIQ4z+XTB
-        TKTT5qoK4rRU5pC67ebSPk6KNXnLui9bX2Qe1Ej+VwPdTUIxRp5jL9YpLW5u
-        bnd3xc1dsS7Yds8+5kW+RkGxu9lnBZbi4lJv+QiyUsSwp4WbNug7Rjm9ad2z
-        hpQcy1KfJ4xhmLYtAtBQl0B3PZGao6Kq30n3B/xg4dX3VItYehL5gBqMwFD5
-        3/QvIlf7GDLTh8cddcRzjMLOBimtOR5pLvcORy89HiRdlHyPFDTMm5rM5JrX
-        i7xqpB86WksaSY1zXDGC1IW4eAZ6wAskHkvbIBaP/GIfNygIzoQAKWTctOUd
-        1IG3ovp6W+hOS88a7Cfzs02NIuFyb2L0a6GEB72fFfhIlSDSL0pw1hgs6U7g
-        Was+uglXACzNJre3eiY+pTMtxiJrtPHEl4HF553p29ZEFU7QiDWHt59iZv8L
-        eCccTs5pbNc6fAz3gsByRa4XMtjkeYAUY1oWfHee142FUH10c4Zwidyt8a8Q
-        N1t9n3l0fSaJlkBT9jNydEqSxgRoEfS2rZYyvWVr4FW2xL5C8I654gM8eqGm
-        EZt0kPTDPwAAAP//AwBYVunXbBIAAA==
+        H4sIAAOnA1kAA6xY227jNhB9368w/M5IdpzYCRRus0VbFGgXaLPp7SWgRMpi
+        I5EqSSl2v75DUZIli0qyQN+smcMhZziXQ0cfD0W+qJnSXIq75eoiXC6YSCTl
+        Yn+3fPzyPdotP+IPkVFEaJIYQOEPi0XEKb7SV0ZvyzoK4MPKtCGm0phUJpOK
+        /8toFLQiqzXHkmFNchYFzU8rSyqlYLcj4loi2JTh7x5/jYKp2IJJISth8Cq8
+        CMMoaL+somAqyYgwiCSJFSI4jzasiGVunhqDPkRz4ipGHt1C8PxuaVTFloHb
+        gYA99S6oVBSQHkWiGDGMImIW1v+7JYVPwwu2xOtwtUXhBq13X9bh7eXlbbj9
+        C6LQL2jWVyX9uvWnBW2stZHggf1wF7i+2W6v16ub6+4GQZxypQ0SpGDnDoAy
+        J/O6RBYlEUePhhWE5x75C4s1Nz5bZSaFT56SwySswdCvKOZ5Dpnb++gz8v97
+        qI1iDLKCUsW09oXgYJig9i5mIblMSM6Nz7xieyg7X5wk1FfuKuRmswq3UTAU
+        dceGTFXHea+c2q5AJC8zsn4X6vItlKjgUngyvbDBHYFraSWor1x6jW7TnShF
+        jiMlxHPQlnxGSqIMh3BoZkzOCgYlO17hM37qX2+ZH5iNiUkyLybjZfnulMSf
+        VJVAhxxIzhIT/06OAhAnwddlJ96sFw+l3WXxE4Equy/N4nK1tq16BPvqxMU/
+        SJORAk7WCYbZi7+9j4L2pyd5w/UqfCt58aOAdkEXDzBTmF7IdHHfZBiBHjCE
+        zeY1fnw4QYfy2RyHFfe+JZevJDzebcKzNZ2mSf9hQrRNGaWc5VS36VdrxJSS
+        CkHASyk0a4xMEsviBgEbo/HPMCFfBXQmxtd+BvrRWXkV07hR19P9p0IL3cPl
+        vZAjaP5mrrBgzOlpe4tKJRPYDeLQFSRp4C5h/vjzl08w414Fja2Mj7IKLYmY
+        086sNFAO+L4ETW3JzRyiCS2l3J4Egj+FTXytJU/sBaVw8bAC8iVmahqRytIP
+        2MVxjBmUIQfkyJFXxQ6sKDsKEUuZMyKWOCW5tsSsB3SUBbxACVEdPTDymQm8
+        r+vd9RHgzZfTxFzgTbha73a2w4th29rg1W63alvWpisdMIoaIvgb17aE+++u
+        85RcucsspDAZtj1qIpxgj4wo4EPrcARupO2+LV1Atk01dLbpChPp6ZSZzJtw
+        ++cnL8ieoUrlODOm1LdBQDTMBX0RK8KFLZw24y+gQwclOdpx8VQwyFb6lMu9
+        DGrw/6IU+49M1FxJYQF3mggaywMws95+2zYVKwnQtc/SJqD77TQZI7nJ4MS2
+        Uz4L+SKiYCBzIMpibk5699mqKgUXB1m4r3JLHAeoc00/ciwjhgF7gg5k7XnJ
+        Ucl8gOgEbfi0rqAZwvwUzyfMSDputTJFVktEwvCpzQ6lXZwkrZKG6Z+2Pskc
+        qBL8n4q1lQRiiDyHXqwwSa+utpub9OomXaX0ckevkzRZgSDdXO3iFFJxdqmz
+        XDNRSKTp80yl9fqWxI4rrX1KoYxDWqrjiKT0U71BMDDUXqAtT3gOgKIo3/lE
+        6PG9hVffcA1i7hnmAqohAn3mf9O9wmzuQ8h0Fx571AG10hI6G8Ok5HCkqdw5
+        HJx73EvaKLkemRM/VatinShezlK5gb7vaA1PRSXMbkkR8CBk4+npAWdIOJYy
+        Xiwc+WwfOygQzAQPD6VcN+nt1TFnRXb5NtOd5l5S0E+mZxsbBeJm3+Hg10wK
+        93o3K+BhLFiOH2TOaaUhpVuBI8qqthMuZWxuNtm95QtyVzrRQiziSmnHtSkz
+        8KLsKOpY5b+gAVH3bz/GTP5/eCecHazT0K6V/xj20QLpClzPZ7BKEg/DhmuZ
+        8d16XlaWCk/zo50ziAvgbpV7+NjZ6vrMk+0zUTAHGrOfgaNjkjQkQLOgt201
+        lOktWz2vMhn0FQQ1ZpOPwdFTOY7YqIPgD/8BAAD//wMAzPtrpeASAAA=
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:30 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:07 GMT
 - request:
     method: get
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/j7ya3mk4
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/5s5ts7pv
     body:
       encoding: US-ASCII
       string: ''
@@ -117,7 +128,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -128,7 +139,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:30 GMT
+      - Fri, 28 Apr 2017 20:33:07 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -149,49 +160,51 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"b9a973fa5da11e6c069afbf6dec3456a"
+      - W/"217fb686a56940b0a85a3ce9c05175a4"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 11e891cc-ce8c-48fd-9f48-d2c5989c084c
+      - f756d788-4801-42c2-864d-89fb1d4147af
       X-Runtime:
-      - '0.155768'
+      - '0.196977'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKKBklgAA+RYS2/jNhC+768IfGckP7JxFoq2PbRADy3a7qYoegkocWSx
-        oUiVpBy7v75DUZKliEpy6KFAgRysmY9DzoMzH5N8PlXi6gjacCXvV+vreHUF
-        MleMy8P96uHr92S/+px+SKym0tDcIir9cHWVcJb+eXum2+ppl0T44WTGUtuY
-        lDa2VJr/DSyJOpHT2nMNqaECkqj96WR5ozXudibcKIKbQvrdw69JNBc7MK1U
-        I226jq/jOIm6L6eoQOcllZbQPHdCgucxFqpMCfvYGgwh2hM3GQnoriQX9yur
-        G1hFfgeK9vS7oEozRAYUuQZqgRFqr5z/9yuGn5ZXsEo38fqWxBv8+xrHn3a3
-        nzZ3f2AUhgXt+qZm716/jXH9ZUEXa2MVeuA+fAI3H7c327vbfZ9AlBZcG0sk
-        reDl+VEp6LIuV1VN5TmggYpyEZA/Q2a4DdmqSyVD8oKeZlGNxm4lGRcCC3dw
-        MWTk3/fQWA2ARcGYBmNCIThZkMylYhEiVE4FtyHzGg5460JxUni9hL8gd7t1
-        fJtEY1F/bCxUfV72yqvdCkJFXdLNu1Dbt1CywaTwfJ6wUY7QtaKRLHRbBo3p
-        qp1qTc8TJcZz1JVCRmqqLcdwGLBWQAV4Y6crQsYv7est8yOzGbV5GcSUvK7/
-        lyX5SoH8Z2pxnJ2uQZKCg2Cmq4WjIaC10gRjVCtpIOhaixu5PkWnP+K0ehXQ
-        m5hm7QXoB2/lVUzrxvE4338udNADzodnekbNn+CrHEeOmSc2qbXKcTeMQ387
-        aAtvLf1y8+Xnj79j73kNNLUyPco6dgN9Sbuw0mIFp9/WqDk6orGEaEPLGHcn
-        weDPYTNfj4rnLkEFJh5XYO1koOcRaRwVwF38vF9AWXoinqgEVXCCqu7HeaaU
-        ACpXaUGFcSRpAPT0Ab0gOdX9rLbqCWR6V23s1iK8/fKajMt0F683+71rt3Lc
-        SXbper9fJ1H30V0WNEpaUvYbNxSrZfjum0XNtU9mpaQt0/UmiWbCGfYMVCM3
-        2cQTcCvt9u1mN3GtpqWWD18uE/0ivZyyVKINd7iB8IoegDRapKW1tfkURdRg
-        kzbXmaZcuovTVfw1ds6opmfXux8rwGplj0IdVHRE/69refgM8si1kg5wb6hk
-        mTohTRrsd91OQ02RO/2kXAH6315TAhW2xBND+iCfpHqWSTSSeRCDjNuL3n92
-        qkZj4rAKD41wJG6EeqkZRoFjpzjtLtCRrDsvPWslRohe0IXPmAabIQ4z+XTB
-        TKTT5qoK4rRU5pC67ebSPk6KNXnLui9bX2Qe1Ej+VwPdTUIxRp5jL9YpLW5u
-        bnd3xc1dsS7Yds8+5kW+RkGxu9lnBZbi4lJv+QiyUsSwp4WbNug7Rjm9ad2z
-        hpQcy1KfJ4xhmLYtAtBQl0B3PZGao6Kq30n3B/xg4dX3VItYehL5gBqMwFD5
-        3/QvIlf7GDLTh8cddcRzjMLOBimtOR5pLvcORy89HiRdlHyPFDTMm5rM5JrX
-        i7xqpB86WksaSY1zXDGC1IW4eAZ6wAskHkvbIBaP/GIfNygIzoQAKWTctOUd
-        1IG3ovp6W+hOS88a7Cfzs02NIuFyb2L0a6GEB72fFfhIlSDSL0pw1hgs6U7g
-        Was+uglXACzNJre3eiY+pTMtxiJrtPHEl4HF553p29ZEFU7QiDWHt59iZv8L
-        eCccTs5pbNc6fAz3gsByRa4XMtjkeYAUY1oWfHee142FUH10c4Zwidyt8a8Q
-        N1t9n3l0fSaJlkBT9jNydEqSxgRoEfS2rZYyvWVr4FW2xL5C8I654gM8eqGm
-        EZt0kPTDPwAAAP//AwBYVunXbBIAAA==
+        H4sIAAOnA1kAA6xY227jNhB9368w/M5IdpzYCRRus0VbFGgXaLPp7SWgRMpi
+        I5EqSSl2v75DUZIli0qyQN+smcMhZziXQ0cfD0W+qJnSXIq75eoiXC6YSCTl
+        Yn+3fPzyPdotP+IPkVFEaJIYQOEPi0XEKb7SV0ZvyzoK4MPKtCGm0phUJpOK
+        /8toFLQiqzXHkmFNchYFzU8rSyqlYLcj4loi2JTh7x5/jYKp2IJJISth8Cq8
+        CMMoaL+somAqyYgwiCSJFSI4jzasiGVunhqDPkRz4ipGHt1C8PxuaVTFloHb
+        gYA99S6oVBSQHkWiGDGMImIW1v+7JYVPwwu2xOtwtUXhBq13X9bh7eXlbbj9
+        C6LQL2jWVyX9uvWnBW2stZHggf1wF7i+2W6v16ub6+4GQZxypQ0SpGDnDoAy
+        J/O6RBYlEUePhhWE5x75C4s1Nz5bZSaFT56SwySswdCvKOZ5Dpnb++gz8v97
+        qI1iDLKCUsW09oXgYJig9i5mIblMSM6Nz7xieyg7X5wk1FfuKuRmswq3UTAU
+        dceGTFXHea+c2q5AJC8zsn4X6vItlKjgUngyvbDBHYFraSWor1x6jW7TnShF
+        jiMlxHPQlnxGSqIMh3BoZkzOCgYlO17hM37qX2+ZH5iNiUkyLybjZfnulMSf
+        VJVAhxxIzhIT/06OAhAnwddlJ96sFw+l3WXxE4Equy/N4nK1tq16BPvqxMU/
+        SJORAk7WCYbZi7+9j4L2pyd5w/UqfCt58aOAdkEXDzBTmF7IdHHfZBiBHjCE
+        zeY1fnw4QYfy2RyHFfe+JZevJDzebcKzNZ2mSf9hQrRNGaWc5VS36VdrxJSS
+        CkHASyk0a4xMEsviBgEbo/HPMCFfBXQmxtd+BvrRWXkV07hR19P9p0IL3cPl
+        vZAjaP5mrrBgzOlpe4tKJRPYDeLQFSRp4C5h/vjzl08w414Fja2Mj7IKLYmY
+        086sNFAO+L4ETW3JzRyiCS2l3J4Egj+FTXytJU/sBaVw8bAC8iVmahqRytIP
+        2MVxjBmUIQfkyJFXxQ6sKDsKEUuZMyKWOCW5tsSsB3SUBbxACVEdPTDymQm8
+        r+vd9RHgzZfTxFzgTbha73a2w4th29rg1W63alvWpisdMIoaIvgb17aE+++u
+        85RcucsspDAZtj1qIpxgj4wo4EPrcARupO2+LV1Atk01dLbpChPp6ZSZzJtw
+        ++cnL8ieoUrlODOm1LdBQDTMBX0RK8KFLZw24y+gQwclOdpx8VQwyFb6lMu9
+        DGrw/6IU+49M1FxJYQF3mggaywMws95+2zYVKwnQtc/SJqD77TQZI7nJ4MS2
+        Uz4L+SKiYCBzIMpibk5699mqKgUXB1m4r3JLHAeoc00/ciwjhgF7gg5k7XnJ
+        Ucl8gOgEbfi0rqAZwvwUzyfMSDputTJFVktEwvCpzQ6lXZwkrZKG6Z+2Pskc
+        qBL8n4q1lQRiiDyHXqwwSa+utpub9OomXaX0ckevkzRZgSDdXO3iFFJxdqmz
+        XDNRSKTp80yl9fqWxI4rrX1KoYxDWqrjiKT0U71BMDDUXqAtT3gOgKIo3/lE
+        6PG9hVffcA1i7hnmAqohAn3mf9O9wmzuQ8h0Fx571AG10hI6G8Ok5HCkqdw5
+        HJx73EvaKLkemRM/VatinShezlK5gb7vaA1PRSXMbkkR8CBk4+npAWdIOJYy
+        Xiwc+WwfOygQzAQPD6VcN+nt1TFnRXb5NtOd5l5S0E+mZxsbBeJm3+Hg10wK
+        93o3K+BhLFiOH2TOaaUhpVuBI8qqthMuZWxuNtm95QtyVzrRQiziSmnHtSkz
+        8KLsKOpY5b+gAVH3bz/GTP5/eCecHazT0K6V/xj20QLpClzPZ7BKEg/DhmuZ
+        8d16XlaWCk/zo50ziAvgbpV7+NjZ6vrMk+0zUTAHGrOfgaNjkjQkQLOgt201
+        lOktWz2vMhn0FQQ1ZpOPwdFTOY7YqIPgD/8BAAD//wMAzPtrpeASAAA=
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:30 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/authorize/paypal/EUR.yml
+++ b/spec/fixtures/cassettes/gateway/authorize/paypal/EUR.yml
@@ -18,6 +18,15 @@ http_interactions:
           </options>
           <merchant-account-id>stembolt_EUR</merchant-account-id>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <shipping>
+            <first-name>Bruce</first-name>
+            <last-name>Wayne</last-name>
+            <street-address>42 Spruce Lane Apt 312</street-address>
+            <locality>Gotham</locality>
+            <postal-code>90210</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
           <type>sale</type>
         </transaction>
     headers:
@@ -26,7 +35,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -39,7 +48,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:31 GMT
+      - Fri, 28 Apr 2017 20:33:05 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -60,49 +69,51 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d5ecc7a34c40ccbfabe60d3c8300e050"
+      - W/"b353ce8b8ef27608346d6262c1f63891"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 82e92991-8e17-420d-b444-4902f47f1d8c
+      - 2beeb7b6-1c6f-4f66-9a58-ddfe189e445a
       X-Runtime:
-      - '0.542590'
+      - '0.564276'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKOBklgAA+RYQW/rNgy+91cUuau207RNC9fdDhuww3bYe30D3qWQLTrW
-        akueJKfJfv0oy3bsWG572GHAgB5i8hNFUhT5qfHToSov96A0l+JxFV2Fq0sQ
-        mWRc7B5Xz19/JtvVU3IRG0WFpplBVHJxeRlzlmyz24Lq/W0c4IeVaUNNoxPa
-        mEIq/jewOOhEVmuONSSalhAH7U8ryxqlcLcj4VoS3BSSn55/j4O52IJpJRth
-        kii8CsM46L6sogKVFVQYQrPMCgn6ow1UqSzNS2vQh2g9blLi0V0KXj6ujGpg
-        FbgdKNpTn4JKxRDpUWQKqAFGqLm08T+uGH4aXsEqWYfRHQnX+Pc1DB82dw/X
-        4XfMwrCgXd/U7PPrI1x/WtDlWhuJEdgPd4A3d/fr8Hq97g8QpTlX2hBBKzj3
-        H5UlXdZlsqqpOHo0UFFeeuRvkGpufLbqQgqfPKeHWVaDcVhxyssSC3cI0Wfk
-        349QGwWARcGYAq19KTgYEMwexSKklBktufGZV7DDW+fLk8TrVboLcr+Jwrs4
-        GIt6t7FQ1XE5Kqe2Kwgt64KuP4W6/gglGjwUns0PbHRGGFreCOa7LYNGd9VO
-        laLHiRLzOepKPiM1VYZjOjQYU0IFeGOnK3zGT+3rI/Mjsyk1WeHFFLyu/5cl
-        +U6B/GdqcXw6XYMkOYeS6a4W9pqAUlIRzFEthQZvaC1uFPoUnfyK0+pdQG9i
-        empnoF+clXcxbRj7/Xz/udBCdzgf3ugRNX+Cq3IcOXp+sHGtZIa7YR7620Fb
-        eGvp+x/30QYn8rugqZWpK1EYTpbPHfXoDFZw8mONmr0lGkuINrWMcesJJn8O
-        m8W6lzyzB5TjweMKrJ0U1DwjjaUCuIub9wsoQw/EERWvCg5Q1f04T6UsgYpV
-        ktNSW5I0AHr6gFGQjKp+Vhv5CiJ5Zex4u0F4++U0KRfJJozW261tt2LcSTZJ
-        tN1GcdB9dJcFjZKWlH3jmmK1DN99s6i5codZSWGKJELOMBPOsEegCrnJOpyA
-        W2m3bze7iW01LbV8/nKa6CfpyctClm26/Q2EV3QHpFFlUhhT64cgoBqbtL5K
-        FeXCXpyu4q+wcwY1Pdre/VIBVit7KeVOBnuM/6oWuycQe66ksIBHTQVL5QFp
-        0mC/63YKaorc6TdpC9D9dpoCaGkK9BiSZ/Eq5JuIg5HMgRik3Jz07rNTNQoP
-        Dqtw15SWxI1Q55phFFh2itPuBB3JOn/pUclyhOgFXfq0brAZ4jATryfMRDpt
-        rjInVktFBondbi7t8yRZk7Ws+7T1SeZAjeB/NdDdJBRj5jn2YpXQ/ObmbnOf
-        39znUc6ut+w2y7MIBfnmZpvmWIqLS53lPYhKEs1eF27aoO8Y5fSmdc8aUnAs
-        S3WcMIZh2rYIQEPdAdrridQcFVX9Sbo/4AcL776nWsTSk8glVGMGhsr/oX8R
-        2drHlOk+PdbVEc/REjsbJLTm6NJc7gIOziMeJF2WXI8sqZ83NanOFK8XedVI
-        P3S0ljSSGue4ZASpC7H59PSAMyS6pYwXiy6f7WMHBcGZ4CGFjOu2vL06cFZk
-        X28L3WnpWYP9ZO7b1CgSLvsmxrgWSnjQu1mBj1QBZfJFlpw1Gku6EzjWqvZ2
-        wuUAS7PJ7i3fiDvSmRZzkTZKO+LLwODzTvdta6LyH9CINfu3n2Jm/wv4JBwO
-        Nmhs18rvhn1BYLki1/MZbLLMQ4rxWBZit5HXjQFffXRzhnCB3K1xrxA7W12f
-        ebF9Jg6WQFP2Mwp0SpLGBGgR9LGtljJ9ZGvgVabAvkLwjtniA3Q9l9OMTTpI
-        cvEPAAAA//8DAOkZ2SRsEgAA
+        H4sIAAGnA1kAA6xYTXPbNhC951dodIdJ6iOWMzRSt9NmOpPmUMfttBcPSIAi
+        ahJgAVCW8uu7IEiKFEHbmelN3H1YYBcPiwfFH49lsTgwpbkUt8voKlwumEgl
+        5WJ/u3z4+gvaLT/id7FRRGiSGkDhd4tFzCkOv7H3yYZGcQAf1qYNMbXGpDa5
+        VPwbo3HQmqzXnCqGNSlYHDQ/rS2tlYLZTohriWBShn9++D0OpmYLJqWshcFR
+        eBWGcdB+WUfJVJoTYRBJU2tEsB5tWJnIwjw2AX2IZsV1gjy+heDF7dKomi0D
+        NwOBeOpNUKkoID2OVDFiGEXELGz+t0sKn4aXbIlXYXSNwg1a7b6uwg/r9Ydw
+        +zdUoR/QjK8r+n3jzwPaWmsjIQP74Tbw/Wq7iq5Xq3W3g2DOuNIGCVKyywTA
+        WZB5XyrLioiTx8NKwguP/ZklmhtfrCqXwmfPyHFS1mCYV5zwogDm9jn6gvz/
+        GWqjGANWUKqY1r4SHA0T1O7FLKSQKSm48YVXbA/HzlcnCeercCfkZhOF13Ew
+        NHXLBqaq03xWzm1HIFJUOVm9CbV+DSVq2BSeTjdssEeQWlYL6jsuvUe3dCdK
+        kdPICfUctCVfkIoow6EcmhlTsJLBkR2P8AU/96/Xwg/CJsSkuReT86p6MyXx
+        j6pOoUMOLBfExH+SkwDE2fB97MSb1eK+srMsPhM4ZXeVWayjlW3VI9h3Exd/
+        kiYnJaysMwzZi3+6i4P2p4e84SoKXyMvfhDQLujiHu4UphcyW9w1DCPQA4aw
+        WV7jh/szdGif5TiMuPMNWb9AeLzbhBdjOk9D/yEh2qaMMs4Kqlv6HTRiSkmF
+        oOCVFJo1QSbEsrhBwcZo/BvckC8CuhDjbb8A/eqivIhp0jgcpvNPjRa6h817
+        Jifw/MPcwYJrTk/bW1wpmcJsUIfuQJIG3kT69Nd2/eUzMOYl0DjKeClRaEXE
+        nHdmpIHjgO8q8BysuJlDNKWllNuVQPGnsEmuB8lTu0EZbDyMAL4kTE0rUlv5
+        AbM4jTGDMuSInDjyutiRlVUnIRIpC0bEEmek0FaY9YBOskAWKCWqkwdGPjGB
+        n5L186kCePPlPAkXeBNGq93OdngxbFsbHO12UduyNt3RgaCoEYJ/cG2PcP/d
+        dZ6KK7eZpRQmx7ZHTYwT7IkRBXpoFY7AjbWdt5ULyLapRs42XWFiPa8yl0VT
+        bv/9yUuyZ6hWBc6NqfSHICAa7gV9lSjChT04LeOvoEMHFTnZ6+KxZMBW+ljI
+        vQwOkP9VJfYfmThwJYUF3GoiaCKPoMz6+G3bVKwiINe+SEtA99t5ckYKk8OK
+        bad8EvJZxMHA5kCUJdyc/e6zddUKNg5YuK8LKxwHqEtPf+VYRQwX7Bk6sLXr
+        JScliwGiM7Tl07qGZgj3p3g6Y0bWcauVGbJeIlKGz212aO3qJGmdNkr/PPXZ
+        5kC14P/WrD1JYIbKc+jFCpNsu73e3GTbmyzK6HpH36dZGoEh22x3SQZUnB3q
+        Ih+YKCXS9GnmpPX+VsSOT1r7lEI5B1qq00ik9Ld6g2AQqN1AezzhOQCOsnrj
+        E6HH9xFefMM1iLlnmCuohgr0zP+he4VZ7kPJdFceu9SBtNISOhvDpOKwpKnd
+        JRxcZtxb2iq5HlkQv1SrE50qXs1KuYG/72iNTkUV3N2SItBByNbT0wMukLAs
+        ZbxYWPLFPPaiQHAneHQo5bqht9fHXBTZ8W2mO829pKCfTNc2DgrCzb7DIa8Z
+        Cvd+d1fAw1iwAt/LgtNaA6VbgxPK6mBvuIyxubvJzi2fkdvSiRdqkdRKO61N
+        mYEXZSdRxy7/Bg2Eun/6MWby/8Mb4exok4Z2rfzLsI8WoCtoPV/AOk09Chu2
+        ZSZ3m3lVWyk85Ud7zyAuQLvV7uFj71bXZx5tn4mDOdBY/QwSHYukoQCaBb0e
+        q5FMr8XqdZXJoa8gOGOWfAyWnslxxUYdBL/7DwAA//8DAMEaSqfgEgAA
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:31 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/authorize/paypal/address.yml
+++ b/spec/fixtures/cassettes/gateway/authorize/paypal/address.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount>10.00</amount>
+          <channel>Solidus</channel>
+          <options>
+            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
+            <paypal>
+              <payee-email>paypal+europe@example.com</payee-email>
+            </paypal>
+          </options>
+          <merchant-account-id>stembolt_EUR</merchant-account-id>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <shipping>
+            <first-name>Bruce</first-name>
+            <last-name>Wayne</last-name>
+            <street-address>42 Spruce Lane Apt 312</street-address>
+            <locality>Gotham</locality>
+            <postal-code>90210</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.74.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 28 Apr 2017 20:33:06 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"76916321f147acf8830575af76566c4f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 10a86f50-18da-4393-b149-0cbebd196f5e
+      X-Runtime:
+      - '0.725008'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAKnA1kAA6xYXXPrJhB9z6/w+J1IcuzEySjcpnf6NdP2obnpnelLBglk
+        0UhAATl2f30XfVmyUJI70zdr97Cwy2E5OP50KIvFnmnDpbhfRpfhcsFEKikX
+        u/vl05cf0Xb5CV/EVhNhSGoBhS8Wi5hTfJNSdTiuTRzAh7MZS2xlMKlsLjX/
+        l9E4aE3Oa4+KYUMKFgf1T2dLK61htiPiRiKYlOEfnv6Ig6nZgUkpK2FxFF6G
+        YRy0X85RMp3mRFhE0tQZEazHWFYmsrDPdUAfol5xlSCPbyF4cb+0umLLoJmB
+        QDz9IajUFJAeR6oZsYwiYhcu//slhU/LS7bEqzC6QeEarbZfVuHd1dVdeP0X
+        VKEfUI+vFP228acBba2NlZCB+2g2cLMNN+vwNrrtdhDMGdfGIkFKdp4AOAsy
+        70tlqYg4ejysJLzw2F9ZYrj1xVK5FD57Rg6TsgbDvOKEFwUwt8/RF+T/z9BY
+        zRiwglLNjPGV4GCZoG4vZiGFTEnBrS+8Zjs4dr46SThfRXNCbtdReBMHQ1O3
+        bGCqPs5n1bjdCEQKlZPVh1BX76FEBZvC0+mGDfYIUssqQX3HpfeYlu5Ea3Ic
+        OaGeg7bkC6KIthzKYZi1BSsZHNnxCF/wU/96L/wgbEJsmnsxOVfqw5TE3+sq
+        hQ45sJwRE38lRwGIk+Hb2InXq8WjcrMsfiVwyh6UXVxFK9eqR7BvJi7+Sdqc
+        lLCyzjBkL/78EAftTw95w1UUvkde/CSgXdDFI9wpzCxktnioGUagBwxhs7zG
+        T48n6NA+y3EY8eAbcvUG4fF2HZ6N6Tw1/YeEaJsyyjgrqGnptzeIaS01goIr
+        KQyrg0yI5XCDgo3R+De4Id8EdCHG234G+qWJ8iamTmO/n84/NTroDjbvlRzB
+        8zdrDhZcc2ba3mKlZQqzQR26A0lqeB0pevy8+vkrMOYt0DjKeClR6ETEnHdm
+        pIXjgB8UePZO3Mwh6tJSyt1KoPhT2CTXveSp26AMNh5GAF8SpqcVqZz8gFka
+        jTGDsuSAGnHkdbEDK1UnIRIpC0bEEmekME6Y9YBOskAWKCW6kwdWvjCBk6O6
+        3liA11+NJ+ECr8Notd26Di+GbWuNo+02alvWujs6EBTVQvBPbtwR7r+7zqO4
+        bjazlMLm2PWoiXGCPTKiQQ+twhG4trbztnIBuTZVy9m6K0ysp1XmsqjL7b8/
+        eUl2DFW6wLm1ytwFATFwL5jLRBMu3MFpGX8JHTpQ5Oiui+eSAVvpcyF3MthD
+        /pdK7D4xsedaCge4N0TQRB5AmfXx27apmSIg136XjoDN78aTM1LYHFbsOuWL
+        kK8iDga2BkRZwu3J33y2rkrDxgELd1XhhOMAde7prxyniOGCPUEHtna95Khl
+        MUB0hrZ8xlTQDOH+FC8nzMg6brUyQ85LRMrwqc0OrV2dJK3SWumfpj7ZGlAl
+        +D8Va08SmKHyHHqxxiTbbG7Wt9nmNosyerWl12mWRmDI1pttkgEVZ4c2kfdM
+        lBIZ+jJz0np/K2LHJ619SqGcAy31cSRS+lu9RjAI1G6gO57wHABHqT74ROjx
+        fYQ333A1Yu4Z1hTUQAV65n/XvcIc96FkpiuPW+pAWhkJnY1hojgsaWpvEg7O
+        M+4tbZWaHlkQv1SrEpNqrmal3MDfd7RapyIFd7ekCHQQcvX09IAzJCxLWy8W
+        lnw2j7soENwJHh1Kuanp7fWxJors+DbTneZeUtBPpmsbBwXh5t7hkNcMhXt/
+        c1fAw1iwAj/KgtPKAKVbQyOU9d7dcBljc3eTm1u+omZLJ16oRVJp02htyiy8
+        KDuJOnb5N2gg1P3TjzGT/x8+CGcHlzS0a+1fhnu0AF1B6/kCVmnqUdiwLTO5
+        u8xV5aTwlB/tPYO4AO1WNQ8fd7c2febZ9Zk4mAON1c8g0bFIGgqgWdD7sWrJ
+        9F6sXlfZHPoKgjPmyMdg6ZkcV2zUQfDFfwAAAP//AwAlsmRF4BIAAA==
+    http_version: 
+  recorded_at: Fri, 28 Apr 2017 20:33:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/complete.yml
+++ b/spec/fixtures/cassettes/gateway/complete.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:26 GMT
+      - Fri, 28 Apr 2017 20:33:13 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,40 +50,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"8663342e3aec2ea189c6526d5e7fbc71"
+      - W/"90af1f3a7b15b06359f4df2417629ca5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0e97a124-d54d-4e89-8721-9a1821c4e7e6
+      - 00e7f8c8-3336-4233-95bf-64e203f392ae
       X-Runtime:
-      - '0.401262'
+      - '0.327936'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ6BklgAA6xVPXPbMAzd8yt82hlZih07OVnZOnZp0qFLjxIhiTFFqiSV
-        2P++oKwvx5bjXnrnwXx4ICHgAYiedqWYvYE2XMmNF9zOvRnIVDEu84338vyN
-        rL2n+CZKa2NVCTq+mc0izuJwcX8fhHeryMeDw9CWFlRagueVZvlD+LpKylW2
-        XRZ3kT+2OnbGtbFE0hJmkouNZ3UNnt+YBJ2ypKqsqNyf4FBSLk7QqlDy9I6M
-        7k6wd0gMt2fe00AtMELtzO4r2HgMj5aX4MXhPFiReYi/5/n8cbF6DO9/Rf7g
-        0PjXFfs3/8Hh8H6Tc5JxEMz0ITFuSUo1M+2lVGu695z12H5AEEu4EFhNQhnT
-        YEyHH+q4rLoKtlhXaHJU5DE6cKer2BIma9k9dr6irdVYDWC7uCdIsLMgmUva
-        RZpQKRXcTj2lIUf9TxgrZSwVBJsC4odFMMd8jKHx59TS6n0DEyqqgoaTH/6R
-        eXcNU9ZYA55+Qr2U8K9Jur3li8Ju7vAnZIlylfFiHoTrtePIHneaJu65+Cc3
-        FCPrz2NGoQRDmU6lwCnOzSJORfwit1K9S7xpwAbaIZUqI9yYmsoUYkc8RXuP
-        r2f2+t4bmE7XFqUbv/wYMXu04zNIuB2++HAcjBmtRRd3opQAKr3YZc5RG+NA
-        rjVWhWDD1MLFP7r0o6VzgV3FdRMPKZW0RRyEkX8CnmHvgWrMXjg/ojfoERvY
-        x9gzKgy0XqNICqDCFqgTGMIeYR2NlzQHUmsRF9ZW5tH3qTFgzW2iKZduKuX4
-        ge90f4vS8Su6L0Ha3yXYQrHfQuXKf0OJ3lYyfwL5xrWSjrAxVLJE7XDg9vf3
-        L6KcXDMkVG6H0I7QjtrM1EUcrNdB5LeHzoahaCVG0u6AnqChoqij7wpt7f/B
-        plidNit68B+wjmbqxKSaV64Wxzto6DKrtiDjPH9dSuziw6mz1ZL/qZtRljSa
-        xsxwXHE6ptlyuVo8ZMuHLMjY3Zrdp1kaIJAtluskQ81MuvZ3/4fB9AayVMSw
-        7YSmevvIQ2MYh447m5Gm2cd7+QhoRl/UjkE4u9Y/zsiTxf0Po+Py0r68si8t
-        7CvW9VXL+uKqvrCor1zT1y7pa1f01Qv60/X8X1bIlzsg8kdi6w+Ax0FO8c1f
-        AAAA//8DAONMk0s3DAAA
+        H4sIAAmnA1kAA6xVy3ajMAzd9yty2LsEkjSkh7i7Wc5m2lnMZo7BIrgxNmOb
+        Nvn7sQmvPEjT0+7Q1ZUtpGspftoVfPIGSjMp1l5wP/UmIFJJmdisvZfnHyjy
+        nvBdnFbayAIUvptMYkZx9LCIHqbz2Tz2reVA60xzIgyy9lLRzSp8XSbFMtsu
+        8lnsD72OnTGlDRKkgIlgfO0ZVYHn1y5OxjypLEoi9mc4FITxM7TMpTg/IyO7
+        M+wdEs3MhfsUEAMUETMx+xLWHrWmYQV4OJwGSzSdozB6DqePs9ljMPsT+31A
+        HV+V9HPxfcDh/rroKGPAqe5SosyglCiqm0OJUmTvOe+x/4BYLGGc23YiQqkC
+        rVv80Mht3nawwdpOo+MuD+GePN7GhjDazPa2yy1tvNooANMmPkKCnQFBXdWu
+        0rhMCWdm7CoFG/sCRpyl1IZwZJ8F4NU8mC5jfwgNf6cSRu1rGBFe5iQc/fFT
+        5uwWpqhsD1j6AfVawb+m6eaULyq7PsMf0aXVq8DzaRBGkeOIDneiRu46/Jtp
+        YjPr7CEjl5xamY6VwCnODSNGOH4RWyHfhT2px3raoZQyQ0zriogUsCOeo13E
+        1yv7icfXU52wjdUufvk1YHZoy6eQMNP/8sHsnRmpeJt4IiUHIjzsSueotbMn
+        V8q2BdkXU3H3A4NDTz1tCOxKpup8UCGFyXEQxv4ZeIG9B6Js+cLpEb1Gj9hA
+        T3PPCNfQRA0yyYFwk1uhQJ/2AGtprCAbQJXiODem1I++T7QGo+8TRZhwY2lj
+        f/Cd7O+tdvyS7AsQ5m8BJpf0L5cb6b9Zjd6XYvME4o0pKRxhrYmgidzZkdud
+        391o9eReQ0LEtk/tCG2p9VCd4yCKgthvjNZnU1GSD7TdAh1BQUmsjn5K62u+
+        e5+kVVov6T6+x1qarhKdKla6Xhxvof6ZGbkFgbP3131Zxv7Ban2VYP+qepYl
+        taZtZZhdcgqTbLFYzlfZYpUFGZ1F9CHN0sAC2XwRJZnVzGhod/Y3TKY3EIVE
+        mm5HNNX5BxHKpnF4cRcrUr/24WY+AurZFzdzEC4u9tMheba6PzM7rq/t60v7
+        2sq+YWHftK6vLusrq/rGRX3rmr51Sd+8oj9c0N+yRL78BGJ/oLbOAGv2csJ3
+        /wEAAP//AwBu1Ze7OwwAAA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:26 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:13 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -99,8 +99,17 @@ http_interactions:
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
-          <payment-method-token>ggj5n8</payment-method-token>
-          <customer-id>24661237</customer-id>
+          <payment-method-token>fwjypp</payment-method-token>
+          <shipping>
+            <first-name>John</first-name>
+            <last-name>Doe</last-name>
+            <street-address>10 Lovely Street Northwest</street-address>
+            <locality>Herndon</locality>
+            <postal-code>90210</postal-code>
+            <region>AL</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
+          <customer-id>865860434</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -109,7 +118,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -122,7 +131,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:27 GMT
+      - Fri, 28 Apr 2017 20:33:14 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -143,50 +152,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"1b409ed8ec57f7fb0decb626c9be1484"
+      - W/"525fd7003cd8655710779259641e0eb7"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 01f08a48-125c-48d9-a694-df1c29a44188
+      - ec32308f-c6e8-49ed-991e-d5e036bb9ef0
       X-Runtime:
-      - '0.578563'
+      - '0.588350'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ+BklgAA9xY32/bNhB+718R+J2R7dqNWyjqOrQD9tCu6I8N20tAiSeL
-        DUVqJOXY++t3FCVZiqgkeyhQDMhDdPfxeHc83n10/PpYiosDaMOVvF6sLpeL
-        C5CZYlzurxdfv/xCdovXybPYaioNzSyikmcXFzFnSWpPZm8PWRzhh5MZS21t
-        ElOnJbcW2E2u9I0BawWUIG0ctQCHtacKEkMFxFHzr5Nltda494lwowi6AMnX
-        z2/jaCp2YFqqWtpku71cLuOo/XKKEnRWUGkJzTInJOidsVCmSqALIW3je52S
-        gO5CcnG9sLqGReStU7SlnwRVmiES7f/26e27T0vy8c2f7999+ILe9pomag0U
-        k0WovXCZuF4w/LS8hEWyXq6uyHKNf1+Wy1ebq1frq78wH/2CZn1dsf+2/ryg
-        zbqxCuNxH/5g15sXL1br51fdwaI059pYImkJ98NEpaDzukyVFZWngAZKykVA
-        fgep4TZkqyqUDMlzepwkPxqGFadcCCzoc4jb6vsGZ6wGwOpgTIMxoeiPFiRz
-        pzALESqjgtuQeQ17vIihFCm8Y8Lfkpeb1RLPcCjq3MaK1af5qLzarSBUVAVd
-        Pwn1/DGUrPE8eDY9q8HxYGh5LVnoPvUa0xY61ZqeRkrM56BRhYxUVFuO6Ti3
-        pXsrQsZpbQul+T+Pmx+YTanNiiCm4FU1rMZQSf8vS/KBAvlhanF4Om1vJDkH
-        wUxbCwdDQGulCeaoUtJAMLQGNwh9jE7e48h6ENCZGJ/aPdCv3sqDmCaMw2G6
-        cip00D2Ohjt6Qs038FWO08ZMDzautMpwN8xDdztoA28s7T798fNmi73nIdDY
-        ytiV1dJN9TntzEqLFZy8qVBzABZc3SCa1DLGnSeY/ClsEutB8cwdUI4Hjyuw
-        dlLQ04zUjhPgLn68z6AsPRLPVoIqOEJZdZM8VUoAlYskp8I4ptQDOuaAUZCM
-        6m6SWXULMtnvv23lDuHNl9ekXCab5Wq927l2K4edZJOsdrtVHLUf7WVBo6Rh
-        Zr9zQ7Fa+u+uWVRc+8MslbRFslrH0UQ4wZ6AaqQl6+UI3EjbfduxTVyradjm
-        18/nYX6Wnr0slGjSHW4gvKR7ILUWSWFtZV5FETXYpM1lqimX7uK0FX+JnTOq
-        6Mn17psSsFrZjVB7FR0w/stK7l+DPHCtpANcGypZqo5IInr7bbfTUFFkFh+U
-        K0D/v9cUQIUt0GOktfJWqjsZRwOZBzFIuT3r/WerqjUeHFbhvhaOvw1Q9zX9
-        KHA0FafdGTqQtf7Sk1ZigOgEbfqMqbEZ4jCTt2fMSDpurionTktlBonbbirt
-        8qRYnTX0+7z1WeZBteR/19DeJBRj5jn2Yp3QfLu92rzMty/zVc6e79iLLM9W
-        KMg3212aYynOLvWWDyBLRQy7nblpvb4lk+Ob1r50SMGxLPVpxBj6adsgAA21
-        B+iuJ7JyVJTVE5l6j+8ttC+oMyEZPqoaxNy7yCfUYAb6yv+pexa52seUmS49
-        ztUBzzEKOxsktOLo0lTuA46mEX/nJDzlnfljpaSXtIXjx4agYSpZpybTvJql
-        mgN93+QbHk0qpDaKEWRzxGU30BbvIdEtbYNYdPnePm52EhyTAZ7MuGlufFAH
-        3orqruBMw5575GGLnfo2Nooc1P1WgHHN3Ope78cnPuAliOSzEpzVBm95K/BE
-        Xh/c0M8B5sa121vdEX+kEy3mIq218W8BBhYfu6br5CNV+IAGD4nw9mPM5DeS
-        J8Lh6ILGCabDbrhHFZYr0t+QwTrLAu8EPJaZ2F3kVW0hVB/t6CVcIp2t/cPM
-        0Q3fem9c642jOdCYEA4CHfPGISecBT1uq2GRj9nqqaYtsK8QvGOu+ABdz9U4
-        Y6MOkjz7FwAA//8DADvdQ1OSEwAA
+        H4sIAAqnA1kAA8xYWY/bNhB+z68w/M6VfGWdQMt00aRI2yQtchRoXxaUNLKY
+        lUiVpHzk13eoy5JF7W4eAvTNmvk4nBnO6eDVMc9me1CaS3EzX1z58xmISMZc
+        7G7mXz7/QrbzV/RZYBQTmkUGUfTZbBbwmK6/pYfikBwCDz8sTRtmSk11Gebc
+        GIjvEqnuNBiTQQ7CBF4DsFhzKoBqlkHgVT8tLSqVwrtPhGtJUAWgXz69Drwx
+        2YJZLkth6GZz5fuB13xZRg4qSpkwhEWRJRLUThvIQ5mhCi5upXsZEgdvJnh2
+        MzeqhLlXS2coSz0JKlWMSJT/x8fXbz765M/bv9+/+fAZte04ldUKGDqLMDOz
+        nriZx/hpeA5zuvQX18Rfk+X289J/uVq9XKz+QX90B6rzZRF/3/nzgcbr2ki0
+        x37UD7t9vtk+99erdfuySE640oYIlsOlncjM2DQvknnBxMnBgZzxzEE/QKi5
+        cckqUilc9IQdR973+nYFIc8yjOizjffpjzVOGwWA4RHHCrR2WX80IGL7DJOQ
+        TEYs48YlXsEOM9HlIolJltVp8mK98K8Dr09q1caQVadpq2q2PUFYVqRs+STU
+        6jGUKPE9eDR+q97zoGlJKWJXQnUc3UQ6U4qdBkz0Z69SuYQUTBmO7jjXpYsT
+        LuGsNKlU/Nvj4ntiQ2ai1IlJeVH0o9EV0l1I0t9kKgKvR7iIS/paYhU9f35f
+        aNKFP3sn95CdZp8qxuyDVCY9gK4K9gD63ZFL34ISsUT1O0o/funtu8BrfjrC
+        118u/MfCl34RWCti1B1rmp7JZHZbxRjDAtCHTUY29pgztE+fjHI8ces6snog
+        5Ol27V+caTlVAvRDoqnIJOGQxboJwL0moJRUBD1eSKGhEjIKLYvrOWyIpu+x
+        UT4IaEUM3/0C9Gst5UFMZcZ+Pz45JlroDh/vwE7I+Qp1amGP0+MCFxRKRngb
+        +qFNSVbBK0m/f3zrX/+MEfMQaChlqMrCt7PEFHfipMF8oLcFcvYQO09XiMq1
+        ccytJuj8MWxk617yyD5Qgg+PJzBeQlBjj5R2EsFb6qFiAmXYkdQzkpMFR8iL
+        dn4IpcyAiTlNWKbtfNYB2nkFrSARU237NPIeBE0OX09FgfDqq+aEXNC1v1hu
+        t7bGi37lWtPFdrto6ta6TR0USqp58C+ubQp3323pKbiqHzOXwqR0sQy8EXGE
+        PQFTOAwt/QG4ojb3NrMCsWWqmnGrqjCinrVMZVa5291Bec52QEqV0dSYQr/0
+        PKaxM+irUDEubOI0EX+FZdor2Mk2jLscMFrju0zupLdH+68KsXsFYs+VFBZw
+        o5mIQ3nEyaWT35RNBQXDceaDtAFY/645KbDMpKixrZT3Qh6wFvdoNSiGkJsz
+        v/5sWKXCh8Mo3JWZnRp7qEtO13fscIwt9gzt0Rp92UnJrIdoCY37tC6xGGIH
+        FfdnzIA6LLUyIZbLRAT0XGb71NZPMi6jaug/X32m1aBS8H9LaDIJyeh5jrVY
+        UZZsNtfrF8nmRbJI4tU2fh4l0QIJyXqzDRMMxcmjteQ9iFwSHd9PZFrHbybY
+        YaY1+xVJOYalOg3GlK61VwhAQc0D2vTEXQAZefHE/aDDdxKave08BfVXuQox
+        tY3VDtXogS7yf2qXMRv76DLduseq2huutMTKBpQVHFUa02uDvbHFP9gJT9lu
+        /18u6ShN4NRtI2Pu+bUMdaR4MTnf9vhdka+Gd1LgOCNjgrMhsd51lMULJKql
+        jBOLKl/cY3snwTbpGM5jrquMd/KgliLbFJwo2FObJZbYsW5DoTjL2n8o0K6J
+        rO74dftMmRCQ0U8y43GpMcsbQr09qL1t+gnAVLu2d8sDqZ90xEVfhKXS9QIS
+        g8ENux3bhyz3A/W2F/f1Q8zon5knwuFojcYOptxq2E0OwxXHX5fAMoocWwc+
+        y4Tt1vKitNvBOD6a1ku4wHG2rLdBO27UpffOlt7AmwINB8KeocO5sT8TToIe
+        l1VNkY/J6kZNk2JdIZhjNvgAVU/k0GODCkKf/QcAAP//AwB2tKLPCBQAAA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:27 GMT
+  recorded_at: Fri, 28 Apr 2017 20:33:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/complete.yml
+++ b/spec/fixtures/cassettes/gateway/complete.yml
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Apr 2017 20:33:13 GMT
+      - Mon, 01 May 2017 20:14:33 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,40 +50,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"90af1f3a7b15b06359f4df2417629ca5"
+      - W/"27b64d0a620cf0ca0c803041e547302e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 00e7f8c8-3336-4233-95bf-64e203f392ae
+      - a900903d-54af-4e09-9436-f36edad45331
       X-Runtime:
-      - '0.327936'
+      - '0.369958'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAmnA1kAA6xVy3ajMAzd9yty2LsEkjSkh7i7Wc5m2lnMZo7BIrgxNmOb
-        Nvn7sQmvPEjT0+7Q1ZUtpGspftoVfPIGSjMp1l5wP/UmIFJJmdisvZfnHyjy
-        nvBdnFbayAIUvptMYkZx9LCIHqbz2Tz2reVA60xzIgyy9lLRzSp8XSbFMtsu
-        8lnsD72OnTGlDRKkgIlgfO0ZVYHn1y5OxjypLEoi9mc4FITxM7TMpTg/IyO7
-        M+wdEs3MhfsUEAMUETMx+xLWHrWmYQV4OJwGSzSdozB6DqePs9ljMPsT+31A
-        HV+V9HPxfcDh/rroKGPAqe5SosyglCiqm0OJUmTvOe+x/4BYLGGc23YiQqkC
-        rVv80Mht3nawwdpOo+MuD+GePN7GhjDazPa2yy1tvNooANMmPkKCnQFBXdWu
-        0rhMCWdm7CoFG/sCRpyl1IZwZJ8F4NU8mC5jfwgNf6cSRu1rGBFe5iQc/fFT
-        5uwWpqhsD1j6AfVawb+m6eaULyq7PsMf0aXVq8DzaRBGkeOIDneiRu46/Jtp
-        YjPr7CEjl5xamY6VwCnODSNGOH4RWyHfhT2px3raoZQyQ0zriogUsCOeo13E
-        1yv7icfXU52wjdUufvk1YHZoy6eQMNP/8sHsnRmpeJt4IiUHIjzsSueotbMn
-        V8q2BdkXU3H3A4NDTz1tCOxKpup8UCGFyXEQxv4ZeIG9B6Js+cLpEb1Gj9hA
-        T3PPCNfQRA0yyYFwk1uhQJ/2AGtprCAbQJXiODem1I++T7QGo+8TRZhwY2lj
-        f/Cd7O+tdvyS7AsQ5m8BJpf0L5cb6b9Zjd6XYvME4o0pKRxhrYmgidzZkdud
-        391o9eReQ0LEtk/tCG2p9VCd4yCKgthvjNZnU1GSD7TdAh1BQUmsjn5K62u+
-        e5+kVVov6T6+x1qarhKdKla6Xhxvof6ZGbkFgbP3131Zxv7Ban2VYP+qepYl
-        taZtZZhdcgqTbLFYzlfZYpUFGZ1F9CHN0sAC2XwRJZnVzGhod/Y3TKY3EIVE
-        mm5HNNX5BxHKpnF4cRcrUr/24WY+AurZFzdzEC4u9tMheba6PzM7rq/t60v7
-        2sq+YWHftK6vLusrq/rGRX3rmr51Sd+8oj9c0N+yRL78BGJ/oLbOAGv2csJ3
-        /wEAAP//AwBu1Ze7OwwAAA==
+        H4sIACmXB1kAA6xVPXPjOAzt8ys86hlZsr12MjLTXbnNba64ZocSIYtnitSS
+        VGL/+wNlfTm2vM5kO+HhgYSARyB5OZRy9gbGCq22QfQ4D2agMs2F2m2D1x9/
+        kU3wQh+SrLZOl2Dow2yWCE6/xYtovXyKoyREy4PozAqmHEF7bfjuKf5vnZbr
+        fL8qFkk49np2Lox1RLESZkrIbeBMDUHYuCSb8mS6rJg6XuBQMiEv0KrQ6vKM
+        nB0usHdIrXBX7jPAHHDC3MwdK9gGHE0nSghoPI/WZL4i8+hHPH+Ols+Lxb9J
+        OAQ08XXFPxc/BJzub4pOcgGS2z4lLhzJmOG2PZQZw46B9577TwhiqZAS20kY
+        5was7fBTI8us62CLdZ0m510ewwN5uo0tYbKZ3W3XW9p6rTMArkt8ggQHB4r7
+        qt2kSZ0xKdzUVQZ2+AImnJW2jkmCzwLo0zKar5NwDI1/p1bOHBuYMFkVLJ78
+        8Y/MxT1MVWMPRPYb6q2Cf03T7SlfVHZzRjihS9Srost5FG82nqN63Iua+Ovo
+        P8IyzKy3x4xCS44ynSqBV5wfRoJJ+qr2Sr8rPGnABtqplDonwtqaqQyoJ16i
+        fcTXK/uJxzdQvbAdape+/j1i9mjH55AKN/zyyRycOatll3iqtQSmAupL56mN
+        cyDXBttC8MXU0v/A6NCPni4EDpUwTT6k1MoVNIqT8AK8wj4CM1i+eH5Gb9Az
+        NvCPuedMWmijRpkUwKQrUCgwpD3COpoo2Q5IbSQtnKvscxgya8HZx9QwofxY
+        2uEPvrPjI2onrNixBOV+luAKzX9KvdPhG2r0sVK7F1BvwmjlCVvLFE/1AUdu
+        f35/I+rJv4aUqf2Q2hnaUZuhuqTRZoPaaI3Oh6kYLUfa7oCeYKBiqKPvGn3t
+        9+DTvM6aJT3ED1hHs3VqMyMq34vzLTQ8M6f3oGi+Lo4lT8KT1flqJX7VzSxL
+        G01jZQQuOUNZvlqh5PPVUx7lfLHh37I8ixDIl6tNmqNmJkP7s//AZHoDVWpi
+        +X5CU71/FGEwjdOLu1qR5rWPN/MZ0My+pJ2DcHWxfxySF6v7M7Pj9tq+vbRv
+        rew7FvZd6/rmsr6xqu9c1Peu6XuX9N0r+rcL+o8skS8/gSQcqa03AM1BTvTh
+        fwAAAP//AwAo0Fy5OwwAAA==
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 20:33:13 GMT
+  recorded_at: Mon, 01 May 2017 20:14:33 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -99,7 +99,7 @@ http_interactions:
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
-          <payment-method-token>fwjypp</payment-method-token>
+          <payment-method-token>f7hymd</payment-method-token>
           <shipping>
             <first-name>John</first-name>
             <last-name>Doe</last-name>
@@ -109,7 +109,7 @@ http_interactions:
             <region>AL</region>
             <country-code-alpha2>US</country-code-alpha2>
           </shipping>
-          <customer-id>865860434</customer-id>
+          <customer-id>623174921</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -131,7 +131,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Apr 2017 20:33:14 GMT
+      - Mon, 01 May 2017 20:14:35 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -152,52 +152,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"525fd7003cd8655710779259641e0eb7"
+      - W/"957d1adb4dbe137c5de807d356d9b4de"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ec32308f-c6e8-49ed-991e-d5e036bb9ef0
+      - 6956b856-24f6-4206-acc8-be476ca4b599
       X-Runtime:
-      - '0.588350'
+      - '0.603704'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAqnA1kAA8xYWY/bNhB+z68w/M6VfGWdQMt00aRI2yQtchRoXxaUNLKY
-        lUiVpHzk13eoy5JF7W4eAvTNmvk4nBnO6eDVMc9me1CaS3EzX1z58xmISMZc
-        7G7mXz7/QrbzV/RZYBQTmkUGUfTZbBbwmK6/pYfikBwCDz8sTRtmSk11Gebc
-        GIjvEqnuNBiTQQ7CBF4DsFhzKoBqlkHgVT8tLSqVwrtPhGtJUAWgXz69Drwx
-        2YJZLkth6GZz5fuB13xZRg4qSpkwhEWRJRLUThvIQ5mhCi5upXsZEgdvJnh2
-        MzeqhLlXS2coSz0JKlWMSJT/x8fXbz765M/bv9+/+fAZte04ldUKGDqLMDOz
-        nriZx/hpeA5zuvQX18Rfk+X289J/uVq9XKz+QX90B6rzZRF/3/nzgcbr2ki0
-        x37UD7t9vtk+99erdfuySE640oYIlsOlncjM2DQvknnBxMnBgZzxzEE/QKi5
-        cckqUilc9IQdR973+nYFIc8yjOizjffpjzVOGwWA4RHHCrR2WX80IGL7DJOQ
-        TEYs48YlXsEOM9HlIolJltVp8mK98K8Dr09q1caQVadpq2q2PUFYVqRs+STU
-        6jGUKPE9eDR+q97zoGlJKWJXQnUc3UQ6U4qdBkz0Z69SuYQUTBmO7jjXpYsT
-        LuGsNKlU/Nvj4ntiQ2ai1IlJeVH0o9EV0l1I0t9kKgKvR7iIS/paYhU9f35f
-        aNKFP3sn95CdZp8qxuyDVCY9gK4K9gD63ZFL34ISsUT1O0o/funtu8BrfjrC
-        118u/MfCl34RWCti1B1rmp7JZHZbxRjDAtCHTUY29pgztE+fjHI8ces6snog
-        5Ol27V+caTlVAvRDoqnIJOGQxboJwL0moJRUBD1eSKGhEjIKLYvrOWyIpu+x
-        UT4IaEUM3/0C9Gst5UFMZcZ+Pz45JlroDh/vwE7I+Qp1amGP0+MCFxRKRngb
-        +qFNSVbBK0m/f3zrX/+MEfMQaChlqMrCt7PEFHfipMF8oLcFcvYQO09XiMq1
-        ccytJuj8MWxk617yyD5Qgg+PJzBeQlBjj5R2EsFb6qFiAmXYkdQzkpMFR8iL
-        dn4IpcyAiTlNWKbtfNYB2nkFrSARU237NPIeBE0OX09FgfDqq+aEXNC1v1hu
-        t7bGi37lWtPFdrto6ta6TR0USqp58C+ubQp3323pKbiqHzOXwqR0sQy8EXGE
-        PQFTOAwt/QG4ojb3NrMCsWWqmnGrqjCinrVMZVa5291Bec52QEqV0dSYQr/0
-        PKaxM+irUDEubOI0EX+FZdor2Mk2jLscMFrju0zupLdH+68KsXsFYs+VFBZw
-        o5mIQ3nEyaWT35RNBQXDceaDtAFY/645KbDMpKixrZT3Qh6wFvdoNSiGkJsz
-        v/5sWKXCh8Mo3JWZnRp7qEtO13fscIwt9gzt0Rp92UnJrIdoCY37tC6xGGIH
-        FfdnzIA6LLUyIZbLRAT0XGb71NZPMi6jaug/X32m1aBS8H9LaDIJyeh5jrVY
-        UZZsNtfrF8nmRbJI4tU2fh4l0QIJyXqzDRMMxcmjteQ9iFwSHd9PZFrHbybY
-        YaY1+xVJOYalOg3GlK61VwhAQc0D2vTEXQAZefHE/aDDdxKave08BfVXuQox
-        tY3VDtXogS7yf2qXMRv76DLduseq2huutMTKBpQVHFUa02uDvbHFP9gJT9lu
-        /18u6ShN4NRtI2Pu+bUMdaR4MTnf9vhdka+Gd1LgOCNjgrMhsd51lMULJKql
-        jBOLKl/cY3snwTbpGM5jrquMd/KgliLbFJwo2FObJZbYsW5DoTjL2n8o0K6J
-        rO74dftMmRCQ0U8y43GpMcsbQr09qL1t+gnAVLu2d8sDqZ90xEVfhKXS9QIS
-        g8ENux3bhyz3A/W2F/f1Q8zon5knwuFojcYOptxq2E0OwxXHX5fAMoocWwc+
-        y4Tt1vKitNvBOD6a1ku4wHG2rLdBO27UpffOlt7AmwINB8KeocO5sT8TToIe
-        l1VNkY/J6kZNk2JdIZhjNvgAVU/k0GODCkKf/QcAAP//AwB2tKLPCBQAAA==
+        H4sIACuXB1kAA8xYS3PbNhC+51dodIdJylKtZGiknibpK0k7eXSmuXhAAhQR
+        kwALgLLUX98FQVKkCNrOITO9ibsfFruL3cUHxS8PZbHYM6W5FNfL6CJcLphI
+        JeVid738/OkN2i5f4mexUURokhpA4WeLRcwpXn81V1dRHsYBfFiZNsTUGus6
+        KbkxjN5mUt1qZkzBSiZMHLQAizXHimFNChYHzU8rS2ulYO8j4loicIHhzx9f
+        xcFUbMGklLUweLO5CMGD9ssqSqbSnAiDSJpaIQLvtGFlIgtwwadtfK8T5NEt
+        BC+ul0bVbBk46wRsqSdBpaKABPt/fHj1+kOI/rz5+93r95/A217TRK0YgWQh
+        YhY2E9dLCp+Gl2yJV2F0hcINCqNPq/BFtH5xuf4C+egXNOvrin7b+tOCNuva
+        SIjHfriD/WF1GV2tn6+i7mRBnHGlDRKkZOdxgrIg87pUlhURR4+GlYQXHvk9
+        SzQ3PltVLoVPnpHDJPvBMK444UUBFX2KsUy/b3DaKMagPChVTGtf9AfDBLXH
+        MAspZEoKbnzmFdtBJ/pSJKHJCtcmz9dReBUHQ1HnNpSsOs5H5dR2BSJFlZPV
+        k1CXj6FEDefB0+lZDY4HQstqQX0N1Wt0W+lEKXIcKSGfg0nlM1IRZTik4zSX
+        zlb4jJPa5FLxfx83PzCbEJPmXkzOq2pYjb6S7ksS/yZzEQcDwVld4lcSpujp
+        89tKE0fh4q3cs+K4+NgoFu+lMvk9083AHkG/uXLxL0wJKsH9XjKsX3zzNg7a
+        n57yDVdR+Fj54s8CZgUF32Gm6YXMFjdNjREYAEPYbGXDHXOCDuWzVQ4rbnxL
+        Lh8oebxdh2drOk3TAMOSaCcyyjgrqG4LcK8RU0oqBBmvpNCsMTIpLYsbJGyM
+        xu/gonwQ0JkYn/sZ6Fdn5UFME8Z+P105FVroDg7vnhxB85W51oI7Tk8HXFwp
+        mcJukIeuJUkDbyz9/uanLz9DjA+CxlbGrkSh5RJz2pmVBvoB31Sg2TPqXd0g
+        mtRSyq0nkPwpbBLrXvLUHlAGBw8roF4SpqYZqS0TgV0cqZhBGXJAjiN5VezA
+        yqrjD4mUBSNiiTNSaMvPekDHVyAKlBLVXZ9G3jGBs6v8WEIC3JfTJFzgdRit
+        tls748Vwcq1xtN1G7dxad60DRlHDB//i2rZw/92Nnoord5ilFCbH0SoOJsIJ
+        9siIAjK0CkfgRtru23IFZMdUw3GbqTCRnrzMZdGk23+D8pLsGKpVgXNjKv0i
+        CIiGm0FfJIpwYRunrfgLGNNBRY72wrgtGVQrvS3kTgZ7iP+iEruXTOy5ksIC
+        rjURNJEHYC69/XZsKlYRoDPvpS1A99tpckYKk4PHdlLeCXkPs3ggcyDKEm5O
+        evfZqmoFBwdVuKsLyxoHqHNNf+9YcgxX7Ak6kLX+kqOSxQDRCdr0aV3DMIQb
+        VNydMCPpeNTKDFktESnDpzE7lHZ5krROG9J/2vokc6Ba8H9q1nYSiCHzHGax
+        wiTbbIAXZ5vnWZTRyy39Ic3SCATZerNNMijF2aXO8p6JUiJN72Y6rde3DHbc
+        ae37CuUcylIdRzSlv9obBAND7QHa9oS3ACjK6onvgx7fW2jfbScWNHzKNYi5
+        15hLqIYM9JX/Y/cYs7UPKdNdeqyrA3KlJUw2hknFwaWp3AUcTCP+zkl4yuv2
+        /5WSXtIWjrs2CuLnr3WiU8WrWX470PdDviHvqAI6IykCbohsdj1j8QwJbinj
+        xYLLZ/vYuxPBNekh55TrpuO9OuasyK4FZwb23MsSRuzUt7FR4LL2HwqIa6ar
+        e727PnMiBCvwR1lwWmvo8lbgXg9qby/9jLG569ruLe+RO9KJFnKR1Eq7Bwhl
+        Bl7YHW0fq/wHNHi9+LcfYyb/zDwRzg42aLjBlN8N+5KDcgX66zNYp6nn1QHH
+        MhO7jbyq7etgWh/t1Yu4ADpbu9egpRtu9N7a0RsHc6AxIRwEOuaNQ044C3rc
+        VsMiH7PVU02Tw1xB0GO2+Bi4nslxxkYTBD/7DwAA//8DAOPtXokIFAAA
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 20:33:14 GMT
+  recorded_at: Mon, 01 May 2017 20:14:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/purchase.yml
+++ b/spec/fixtures/cassettes/gateway/purchase.yml
@@ -15,6 +15,15 @@ http_interactions:
             <submit-for-settlement type="boolean">true</submit-for-settlement>
           </options>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <shipping>
+            <first-name>Bruce</first-name>
+            <last-name>Wayne</last-name>
+            <street-address>42 Spruce Lane Apt 312</street-address>
+            <locality>Gotham</locality>
+            <postal-code>90210</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
           <type>sale</type>
         </transaction>
     headers:
@@ -23,7 +32,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -36,7 +45,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:28 GMT
+      - Fri, 28 Apr 2017 20:34:18 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -57,49 +66,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"09d2e9ce39b6d565f4e78e6cfba0d73f"
+      - W/"2e8695a92977cd09a2851fd01b10f0b5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3ec6c90d-3e5b-458a-8ec0-8506c73a5850
+      - bd904b52-a729-4943-96df-3201896c267b
       X-Runtime:
-      - '0.630853'
+      - '0.765209'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKCBklgAA+RYUW/jNgx+v19R5F11nKbX9OD6tmE4YA/bw+56GPZSyBYd
-        a5UlT5LTZL9+lGU7di23HbABBwzoQ01+okiKIj8l+XisxMUBtOFK3q3iy/Xq
-        AmSuGJf7u9X9l09kt/qYvkusptLQ3CIqfXdxkXCWZjE9QFGxJMIPJzOW2sak
-        pskqbi2wh0LpBwPWCqhA2iTqAA5rTzWkhgpIovZfJ8sbrXHvE+FGEXQB0vvP
-        PybRXOzAtFKNtGm8vlyvk6j7cooKdF5SaQnNcyck6J2xUGVKoAshbet7k5GA
-        7kJycbeyuoFV5K1TtKXfBFWaITKgyDVQTA+h9sLFfrdi+Gl5Bat0s45vyHqD
-        f1/W6w/bmw+b3e+YgWFBu76p2T9bf17Q5dlYhRG4D3+U76/i97fx1XV/lCgt
-        uDaWSFrBc/9RKeiyLldVTeUpoIGKchGQP0FmuA3ZqkslQ/KCHmdZjcZhJRkX
-        Akt4CDFk5N+P0FgNgEXBmAZjQik4WpDMHcUiRKicCm5D5jXs8f6F8qTwagl/
-        OW638fomicai3m0sVH1ajsqr3QpCRV3SzZtQV6+hZIOHwvP5gY3OCEMrGslC
-        t2XQmK7aqdb0NFFiPkf9KWSkptpyTMe5Gz1bETJOG1sqzf963fzIbEZtXgYx
-        Ja/r/2VJvlAg30wtjk+na5Ck4CCY6WrhYAhorTTBHNVKGgiG1uJGoU/R6c84
-        qV4E9Camp/YM9JO38iKmDeNwmO8/FzroHufDEz2h5g/wVY4jx8wPNqm1ynE3
-        zEN/O2gLby39Gv/w9bdP2HteAk2tTF2J126YL2kXVlqs4PT7GjUHYMHVLaJN
-        LWPceYLJn8NmsR4Uz90BFXjwuAJrJwM9z0jjqADu4uf9AsrSI/EkJaiCI1R1
-        P84zpQRQuUoLKowjSAOgpw8YBcmp7me1VY8g0yt9e7PZIrz98pqMy3S7jje7
-        nWu3ctxJtmm828VJ1H10lwWNkpaQfeWGYrUM332zqLn2h1kpacs03iTRTDjD
-        noBq5Cab9QTcSrt9u9lNXKtpSeb95/NEP0vPXpZKtOkONxBe0T2QRou0tLY2
-        H6KIGmzS5jLTlEt3cbqKv8TOGdX05Hr3QwVYrexBqL2KDhj/ZS33H0EeuFbS
-        Ae4MlSxTR6RJg/2u22moKXKnX5QrQP+/15RAhS3RY2Sz8lGqJ5lEI5kHMci4
-        Pev9Z6dqNB4cVuG+EY7EjVDPNcMocOwUp90ZOpJ1/tKTVmKE6AVd+oxpsBni
-        MJOPZ8xEOm2uqiBOS2UOqdtuLu3zpFiTt6z7vPVZ5kGN5H820N0kFGPmOfZi
-        ndLi+vpme1tc3xZxwa527H1e5DEKiu31LiuwFBeXessHkJUihj0u3LRB3zHK
-        6U3rHjik5FiW+jRhDMO0bRGAhroDdNcTqTkqqvqNdH3ADxa6h9OZkIzfUi1i
-        6TnkE2owA0Plf9e/hlztY8pMnx7n6ojnGIWdDVJac3RpLvcBR/OI/+MkvOV5
-        +W2lZJB0hePHhqBhKtlkJte8XqSaI/3Q5FseTWqkNooRZHPEZTfQFp8h0S1t
-        g1h0+dk+bnYSHJMBnsy4aW98UAfeiuqv4ELDXnrpYYud+zY1ihzU/USAcS3c
-        6kHvxye+2yWI9LMSnDUGb3kn8EReH9zQLwCWxrXbWz0Rf6QzLeYia7TxbwEG
-        Fl+8pu/kE1X4gEYPifD2U8zsp5E3wuHogsYJpsNuuEcVlivS35DBJs8D7wQ8
-        loXYXeR1YyFUH93oJVwinW38w8zRDd96H1zrTaIl0JQQjgKd8sYxJ1wEvW6r
-        ZZGv2Rqopi2xrxC8Y674AF0v1DRjkw6SvvsbAAD//wMAzVM0zYkTAAA=
+        H4sIAEqnA1kAA8xYS2/bOBC+91cYvjOSHLtxCoXddIt9ANs9bNou0EtAiZTF
+        RiJVknLs/vodipIsWVSSArvA3qyZj0POcB4fHb89lMViz5TmUtwso4twuWAi
+        lZSL3c3y08df0Hb5Fr+KjSJCk9QACr9aLGJO8dfN5RX5npg4gA8r04aYWmNd
+        JyU3htH7TKp7zYwpWMkE4FqAxZpjxbAmBYuD5qeVpbVSsPcRcS0RHIHhT3fv
+        42AqtmBSyloYHIUXYRgH7ZdVlEylOREGkTS1QgSn04aViSzgCD5tc/Y6QR7d
+        QvDiZmlUzZaBs07AlnoRVCoKSI8iVYxAeBAxC+v7zZLCp+ElW+JVGF2hcI1W
+        24+r8M3l+k20/QIR6Bc06+uK/tj604I2ztpI8MB+uKvcXEdR9Hpzfd3dJYgz
+        rrRBgpTs3AFQFmRel8qyIuLo0bCS8MIjf2SJ5sZnq8ql8MkzcpiENRj6FSe8
+        KCCHex99Rv59D7VRjEFWUKqY1r4QHAwT1N7FLKSQKSm48ZlXbAcF6IuThNoq
+        XHVcr6PwKg6Gou7YkKnqOO+VU9sViBRVTlYvQl0+hxI1XApPpxc2uCNwLasF
+        9ZVLr9FtuhOlyHGkhHgOGpTPSEWU4RCOUzs6W+EzTmqTS8W/P29+YDYhJs29
+        mJxX1YtTEr9TdQrdcSA5S0z8NzkKQJwEP5adeL1a3FV2l8UfBKrstjKLy2hl
+        2/QI9sOJi3+VJiclnKwTDLMX/3wbB+1PT/KGqyh8LnnxJwHtgi7uYJ4wvZDZ
+        4rbJMAI9YAibzWsYLCfoUD6b47Di1rfk8omEx9t1eLam0zTpP0yItimjjLOC
+        6jb99hoxpaRCEPBKCs0aI5PEsrhBwMZo/AGm45OAzsT42s9AvzsrT2IaN/b7
+        6f5ToYXu4PIeyRE0X5krLBhzetre4krJFHaDOHQFSRp4Y+mvd+9/+/IZMuYp
+        0NjK+ChRaAnEnHZmpYFywLcVaPaMelc3iCa0lHJ7Egj+FDbxdS95ai8og4uH
+        FZAvCVPTiNSWfsAujmPMoAw5IEeMvCp2YGXVUYhEyoIRscQZKbQlZT2goyzg
+        BUqJ6uiBkQ9M4OTrN70HWuW+nCbhAq/DaLXd2g4vhm1rjaPtNmpb1rorHTCK
+        GhL4mWtbwv1313kqrtxlllKYHNseNRFOsEdGFPChVTgCN9J235YuINumGmLb
+        dIWJ9HTKXBZNuP3zk5dkx1CtCpwbU+k3QUA0zAV9kSjChS2cNuMvoEMHFTna
+        cXFfMshWel/InQz24P9FJXZvmdhzJYUF3GgiaCIPwMx6+23bVKwiQNf+lDYB
+        3W+nyRkpTA4ntp3yQchHEQcDmQNRlnBz0rvPVlUruDjIwl1dWOI4QJ1r+pFj
+        GTEM2BN0IGvPS45KFgNEJ2jDp3UNzRDmp3g4YUbScauVGbJaIlKGT212KO3i
+        JGmdNkz/tPVJ5kC14N9q1lYSiCHyHHqxwiTbbK7W19nmOosyermlr9MsjUCQ
+        rTfbJINUnF3qLO+ZKCXS9GGm0np9S2LHldY+qlDOIS3VcURS+qneIBgYai/Q
+        lic8B0BRVi98IvT43kL7WDtxoOH7rUHMPcFcQDVEoM/8n7oXmM19CJnuwmOP
+        OqBWWkJnY5hUHI40lTuHg6nH/3EQXvKk/X+FpJe0iePGRkH87LVOdKp4Nctu
+        B/q+yTfUHVVAZyRFQA2Rja6nLZ4h4VjKeLFw5LN97OxEMCY91Jxy3VS8V8ec
+        FdmV4EzDnntcQoudnm1sFLis/VsC/Jqp6l7vxmdOhGAFvpMFp7WGKm8F7u2g
+        9nboZ4zNjWu7t3xE7konWohFUivtnh+UGXhkd6x9rPJf0ODt4t9+jJn8HfNC
+        ODtYp2GCKf8x7DsO0hXor89gnaaeRwdcy4zv1vOqtq+DaX60oxdxAXS2dm9B
+        Szdc6723rTcO5kBjQjhwdMwbh5xwFvS8rYZFPmerp5omh76CoMZs8jE4eibH
+        ERt1EPzqHwAAAP//AwBJxGgY/RMAAA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:28 GMT
+  recorded_at: Fri, 28 Apr 2017 20:34:18 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/paypal/checkout.yml
+++ b/spec/fixtures/cassettes/paypal/checkout.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:18:10 GMT
+      - Fri, 28 Apr 2017 18:06:24 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,49 +50,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"56306efdce4a4cadb02357e216f7a481"
+      - W/"698e3b3b660b579a5adc32359f42f73c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3945d6fb-1bd4-4a6f-9817-719175f5be57
+      - cbc2151e-a048-4718-9856-cce4f223b2aa
       X-Runtime:
-      - '0.153367'
+      - '0.146856'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJLzlFgAA6RWXW+jOBR9n19R9X12wJRuI3VmNPmAYAVnIMSA38BOC8SG
-        bJMQ4NfvNd3th9QdjbQPKBG+vvf4nHOvuf/eKXnV7p6OZVN/vTb/MK6vdjVv
-        RFk/fr3eRs7nu+vv3z7dc1nu6tPnU7Pf1d8+XV3dt5k8777teoxYgocsnpy9
-        qulXM1yIJGxyCx92yjH0+1DJM0O050t8yOugXJdel6qF4buOZJUsfTcw02Hf
-        +dHCWLteT5B/QwbPJkNww6JgSFGA2PzxZj0P+rUb7lns22Q+LUhFZBqniLie
-        6UdCPrikZ7FjsDh8SJNg4lc/OtIbF7+Exwx6P2q69bzp/NlN5895R4aF5Vf+
-        kz//cfGdzoTfnihTckWaNLaNBMn9z0j0zOW2rxorVYbF1NHM5oSLCPZU7CJi
-        fMxi8pAhav+MTStTp6fdUlR87vcpOjW5SkvgpMqRrbJYUK4ucH7ciGV44UPT
-        rpBzyTb2APX2qZrcrBTu01iexRJLFotCuNRKk/05RZPTugoMv5+cgO8qcx2I
-        8Vti4T0b9n1WiTKPhMoG2kBMlbtS5rXmYXpYWWm3QqTNFTswi/ZpEh5ydDPi
-        gjzH3KVan8GrDnmyuZQstlGWYIg35bNe+AWfV17KFHUHiDECyE0TfATdy2wZ
-        Gnzp3676ScHd/Zkj58xc3O5mdsmVA7qHoA2tobYUyLFXCvBEjUHmfpvHgAkV
-        BcQMq+Ejvv3235rJyJd39JQzcEQNbtI+n3m3nioMsZwO6/KuTRMysARy/YLL
-        8RwJNTLno/3wfmYjqHfK+9/TZswX20W+lOB5orn806s/yP3POVaxc07jzhau
-        rPhv1vgPbsoH0Ey4heZ3sUW0EgmWIWBJVScZ1IdcJoMY7jo2PMdfrY24VXjg
-        1vSYJnKdxqbU+m6tUOYxeGIZPPv52V9Y5/D2TsERa8kel6wit1TKlErsbhcH
-        Zx1JO15gFNSNyebFE13cWXwB/jShVx3nIiK8jBYTuq1wzx1pRFtchJHzc+eS
-        ar3w+hCFrViEf7EBr7O5JJpnPUeEcqodfcvvD+09uXOdE3c7OfprM7nwGXil
-        puAHPGWW5lR7OnzXh1oXloD/kumRbWzoVaMV7mQYNQWfMfp/PPYc90GfQO/R
-        KkMTU8zsC3B9SePLyz7mStCTGMGb+nlNj/lM+6w75pbwNHbQy+A1laAJnIsd
-        uJqcoZ/OYmG3kaKGQJM+671bppwjR1voG1hTsod5dNI+1JhyxBToeWabkStY
-        h30u3UcvfQkzQDHwNtF13vbz/J0PlFlw8AnMT5iJkAe8qeMzwJvFdh3EQu8Z
-        63KDgv/xkcXvcr/OtoVTARfmS+6awFw3AWtnjLzCHONwltSSmKPJPEfh6FNK
-        ycKrDTgnaaGm5v9dL7zy8DrnN/F4J1lchfU6wn8RhE8EsScSP44eAD6A0zvt
-        l5Y9z/OCL8ErdFrsNt4t3IGDcB1DJL6OOeWIPD3PyRF/v9uSlrlbvUa3vZ5d
-        xOQ16KWIHaDJHni/9SSNQu3Vd7hCze2BKSl5OfL7sraqSZGrsMytR623FFq/
-        /u2s3Z75a8+eM8APuAeRTC9wN+s7cg2+tOD/Ewd/xHCPZwkpNO48duA8Wnun
-        ZyMmB3R51Pv3EFPlFgM8WDwkxtf7L8/fAZ/uv7z/QvgbAAD//wMAOBgg1lgI
+        H4sIAKCEA1kAA6RWXW+jOBR9n19R9X12wJRuI3VmNEmAYAUzIcSA38BOC8Qm
+        2SaBwK/fa7rbD6k7GmkfoiT4+t7jc8695v77Rcmrdvt0rPbN12vzD+P6atvw
+        vaiax6/Xm9j9fHf9/duney6rbXP6fNrvts23T1dX920uz9tv2x4jluIhTyZn
+        v973yxkuRRrtCwsftso19PNIyTNDtOcLfCiaVRVWvkm8zCAxLsP4sSdzVme1
+        Y8L/KhumO6aYDLyoDIZHlNUbOxseu9ALbJL4HfNWN+F8N2SxY5EksyBOktgZ
+        wmQ1PHikZ4lrsCR6yNLVJKh/XEhvdGRm9KG7uoTzfUcAI5nd3ARz3wrizCS1
+        8xTMf3SBezHhuyfKlFyRfZbYRork7mcseuZxO1B7K1OGxdTRzOeEixj21KwT
+        CT7mCXnIEbV/JqaVq9PTdiFqPg/6DJ32hcoq4KQukK3yRFCuOjg/3otF1PFh
+        3y6R2+Vre4B6u0xNbpYK91kiz2KBJUtEKTxqZenunKHJKaxXRtBPTsB3nXsu
+        xAQtsfCODbs+r0VVxELlA91DTF14UhaN5mF6WFrZZYlIWyh2YBbtszQ6FOhm
+        xAV5joVHtT6DXx+KdN1VLLFRnmKIN+WzXvgFn191VYYuB4gxVpCbpvgIulf5
+        IjL4Irhd9pOSe7szR+6ZebjdzuyKKxd0j0Ab2kBtKZBrLxXgifcGmQdtkQAm
+        VJYQMyyHj/gO2n9rpiNf/tFX7sARNbhJ+2Lm3/qqNMRiOoTVXZulZGAp5PoF
+        l+M5Umrk7kf74fnMRlDvVPS/p82YL7HLYiHB80Rz+afffJD7n3MsE/ecJRdb
+        eLLmv1njP7ipHkAz4ZWaX2eDaC1SLCPAkqmLZFAfcpkMYrjn2vA5/mptxK2i
+        A7emxyyVYZaYUuu7sSJZJOCJxerZz8/+wjqHv3NLjlhLdrhiNbmlUmZUYm/j
+        HNwwlnbiYLRq9iabl0/UubO4A/40oVddtxMxXsTOhG5q3HNXGvEGl1Hs/tx6
+        pA4dv49Q1Aon+osNOMznkmie9RwRyq239C2/P7T35NZzT9y7yNFf60nHZ+CV
+        hoIf8JRZmlPt6ehdH2pdWAr+S6dHtrahV41WeJNh1BR8xuj/8dhz3Ad9Ar1H
+        6xxNTDGzO+C6y5LuZR/zJOhJjNWb+kVDj8VM++xyLCzha+ygl8EbKkETOBc7
+        cDU5Qz+dhWO3saKGQJM+7/1bptwjRxvoG1hTsod5dNI+1JgKxBToeWbrkStY
+        h30e3cUvfQkzQDHwNtF13vbz/J0PlFly8AnMT5iJkAe8qeNzwJsndrNKhN4z
+        1uUGBf/jI0ve5X6dbY5bAxfmS+6GwFw3AevFGHmFOcbhLJklMUeTeYGi0aeU
+        EsdvDDgnaaGm5v9dL7zy8Drn18l4J1lcRU0Y478IwieC2BNJHkcPAB/A6Z32
+        S8ue53nJF+AVOi23a/8W7sBBeK4h0kDHnApEnp7n5Ii/325Iy7yNXqObXs8u
+        YvIG9FLEXqHJDni/9SWNI+3Vd7gize2BKSl5NfL7srZsSFmoqCqsR623FFq/
+        /u2s3Zz5a8+ec8APuAeRTju4m/UdGYIvLfj9xMEfCdzjeUpKjbtIXDiP1t7t
+        2YjJBV0e9f4dxNSFxQAPFg+p8fX+y/N7wKf7L+/fEP4GAAD//wMA9AcUtVgI
         AAA=
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:18:10 GMT
+  recorded_at: Fri, 28 Apr 2017 18:06:24 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/client_token
@@ -109,7 +109,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -122,7 +122,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:18:12 GMT
+      - Fri, 28 Apr 2017 18:06:28 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -143,48 +143,48 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"bea6269ef3db70d7a284c81be1e74786"
+      - W/"96b7636089744e2198ecda87a1a069e6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 05fe872f-14f8-4da3-821e-829631cccb90
+      - 7d76342e-b705-45db-83c1-b4b142e217fa
       X-Runtime:
-      - '0.096597'
+      - '0.182702'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJTzlFgAA6RW25KbOBB9z1dMzXs2IMLsuGqSVHwBozJyjLEAvYHkGcAS
-        OL6A4evTwrtzqZpNpWofXLZRq/vonNMtHr5dlLxptodjUVdfbs2/jNubbcVr
-        UVRPX243ofPx/vbb1w8PXBbb6vTxVO+21dcPNzcPTSrP26/bDiMW4z6NRmev
-        rLvFBOciDurMwvutcgz9PFDyzBDt+Bzvs2pVLAuvX07HBQk3F78McjJNECk9
-        RPqkJ4oUCUqQP2WFX4rdMvJ7H81a3yX5coplUnLEpkTC/5KgxCDIt5KIKL+X
-        +aNLOhY5BouCxyRejfzy+4V0RusX8DFXnR/Wl+W0vvjFZwNqd37PO79MDv70
-        e+s7FxO+O6JMyRWpk8g2YiR3P0LRMZfbvqqtRBkWU0cznRIuQthTslZE+JhG
-        5DFF1P4RmVaqToftXJR86ncJOtWZSgrgpMyQrdJIUK5aOD+uxTxoeV83C+S0
-        6druod4uUaPPC4W7JJJnMceSRSIXLrWSeHdO0Oi0LFeG341OwHeZug7E+A2x
-        8I71uy4tRZGFQqU9rSGmzFwps0rzMN4vrOSyQKTJFNszi3ZJHOwz9HnABXmO
-        mUu1Pr1X7rN43RYsslEaY4g35VUv/IzPK1rQ57KHGGMFuWmMj6B7kc4Dg8/9
-        u0U3yrm7O3PknJmLm+3ELrhyQPcAtKEV1JYCOfZCAZ6wNsjUb7IIMKE8h5h+
-        0b/Ht9/8WzMe+PKOnnJ6jqjBTdplE+/OU7kh5uN+Wdw3SUx6FkOu33A5nCOm
-        Ruq8tx+eT2wE9U5Z92faDPkiO8/mEjxPNJd/e9U7uf85xyJyzkl0sYUrS/6H
-        Nf6Dm+IRNBNurvmdbRAtRYxlAFgSdZEM6kMuk0EMdx0bPsffrQ24VbDn1viY
-        xHKZRKbU+m6sQGYReGK+uvr56i+sc3g7J4eubMgOF6wkd1TKhErsbmZ7ZxlK
-        O5phtKpqk03zA53dW3wG/jShVx2nFSGeh7MR3ZS44440wg3Og9D5sYX+Xs68
-        LkBBI2bBT9bjZTqVRPOs54hQTrmlr/n9rr0nt65z4u5FDv5aj1o+Aa9UFPyA
-        x8zSnGpPB2/6UOvCYvBfPD6ytQ29ajTCHfWDpuAzRv+Px65x7/QJ9B4tUzQy
-        xcRuges2idrnfcyVoCcxVq/qZxU9ZhPts8sxs4SnsYNeBq+oBE3gXGzP1egM
-        /XQWM7sJFTUEGnVp590x5Rw52kDfwJqSHcyjk/ahxpQhpkDPM1sPXME67HPp
-        LnzuS5gBioG3ia7zup+nb3ygzJyDT2B+wkyEPOBNHZ8C3jSyq1Uk9J6hLjco
-        +B8fWfQm98tsmzklcGE+564IzHUTsF6MgVeYYxzOklgSczSaZigYfEopmXmV
-        AeckDdTU/L/phRceXub8OhruJIuroFqG+CdB+EQQO5DoafAA8AGc3mu/NOw6
-        z3M+B6/Qcb5de3dwB/bCdQwR+zrmlCFyuM7JAX+33ZCGuRu9Rjednl3E5BXo
-        pYi9QqMd8H7nSRoG2qtvcAWa2z1TUvJi4Pd5bVGRPFNBkVlPWm8ptH7d61m7
-        OfOXnj2ngB9w9yIet3A36ztyCb604PeBgz8iuMfTmOQadxY5cB6tvdOxAZMD
-        ujzp/TuIKTOLAR4sHmPjy8On63vAh4dPb98QfgEAAP//AwByB8J8WAgAAA==
+        H4sIAKSEA1kAA6RWXW+jOBR9n19R9X12wJRuI3VmNE0CwQrOhBAb/AZ2WiA2
+        yTYJBH79XpPdfkjd0Uj7gILi63uPzzn3mvvvZ62ums3zodzVX6/tP6zrq00t
+        drKsn75er2Pv893192+f7oUqN/Xx83G33dTfPl1d3TeZOm2+bTqMeIL7jI1O
+        QbXr5mNcyCTa5Q7eb7Rnmf8jrU4c0U7M8D6vl+WiDBzOcEk0ViSW8Pxow4pu
+        eby8If3WDVlqER06oR+4vCoKgpZW2PMy7Kc3hK3dsBIWYWm/iAObxOE5jJfw
+        7pWPPuk48yzOosc0WY7C6seZdFZLxla38JbnxWTXEsC4GN/04WR6JhMBv8vn
+        cAL1vbMNvx3RthKa7FLmWglS25+x7Lgv3FDvnFRbDtcHO5sQIQfMvJUMHzJG
+        HjNE3Z/MdjJ9fN7MZCUmYZei4y7XaQmcVDlydcYkFbqF8+OdnEWt6HfNHHlt
+        tnJ7qLdN9ehmrnGXMnWSM6w4k4X0qZMm21OKRsdFBTx0oyPwXWW+BzFhQxy8
+        5f22yypZ5rHUWU93EFPlvlJ5bXh42M+d9DxHpMk133OHdmkS7XN0M+CCPIfc
+        p0afPqj2ebJqS85clCUY4m110Qu/4AvKtkzReQ8x1hJy0wQfQPcym0WWmIW3
+        825UCH97Esg7cR83m7FbCu2B7hFoQ2uorSTy3LkGPPHOIpOwyRlgQkUBMf28
+        /4jvsPm3ZjLwFRwC7fUCUUvYtMvHwW2gC0vOHvpFedekCel5Arl+weVwjoRa
+        mffRfvh/7CKod8y739NmyMfcIp8p8DwxXP4Z1B/k/uccc+adUnZ2pa8q8Zs1
+        /oOb8hE0k35h+J2uEa1kglUEWFJ9VhzqQy6bQ4zwPReew6/WBtw62gvn4ZAm
+        apEyWxl9106kcgaemC0vfr74C5scwdYrBOIN2eKSV+SWKpVShf31dO8tYuWy
+        KUbLemfzSfFMp3eOmII/behVz2tljGfxdETXFe6Ep6x4jYso9n5ufFItpkEX
+        oaiR0+gv3uNFNlHE8GzmiNRetaFv+f1hvKc2vncU/lkN/lqNWjEGr9QU/IAf
+        uGM4NZ6O3vWh0YUn4L/k4cBXLvSq1Uh/1A+ags84/T8eu8R90CfQe7TK0MiW
+        Y7cFrtuUtS/7uK9AT2It39TPa3rIx8Zn50PuyMBgB70sUVMFmsC5+F7o0Qn6
+        6SSnbhNrakk06rIuuOXaOwi0hr6BNa06mEdH40ODKUdcg54nvhq4gnXY59Nt
+        /NKXMAM0B28TU+dtP0/e+UDbhQCfwPyEmQh5wJsmPgO8GXPrJZNmz1BXWBT8
+        jw+cvcv9OtumXgVc2C+5awJz3QasZ2vgFeaYgLOkjsICjSY5igafUkqmQW3B
+        OUkDNQ3/73rhlYfXOb9ilztJ6KhexPgvgvCRIP5M2NPgAeADOL0zfmn4ZZ4X
+        YgZeoQ/FZhXcwh3YS9+zZBKamGOOyPNlTg74u82aNNxfmzW67szsIraoQS9N
+        3CUabYH320DRODJefYcrMtzuuVZKlAO/L2vzmhS5jsrceTJ6K2n0697O2vVJ
+        vPbsKQP8gLuXyUMLd7O5IxfgSwfenwX4g8E9niWkMLhz5sF5jPZexwdMHujy
+        ZPZvIabKHQ54sHxMrK/3Xy7fAZ/uv7z/QvgbAAD//wMAmOWcX1gIAAA=
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:18:12 GMT
+  recorded_at: Fri, 28 Apr 2017 18:06:28 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -193,7 +193,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <customer>
-          <payment-method-nonce>d2be26dc-9bbd-058f-1723-8c5962d3e787</payment-method-nonce>
+          <payment-method-nonce>6e4c94bd-962c-01cb-1376-06e8c852b709</payment-method-nonce>
         </customer>
     headers:
       Accept-Encoding:
@@ -201,7 +201,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -214,7 +214,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:18:34 GMT
+      - Fri, 28 Apr 2017 18:07:06 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -235,32 +235,32 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"7a02c797f19e30000a2a4e9bc55aec14"
+      - W/"9d86e210668dbf5359d47aa20fb2eab5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 12f01414-de04-44d1-9b49-427d6b79c91f
+      - 61f440da-b666-4e6c-a3d5-a740d369bdd7
       X-Runtime:
-      - '0.390098'
+      - '0.358931'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKrzlFgAA6RTTW/bMAy951cEviuyk3ZOAscZBnTYD+guuwSyRTta9WFI
-        dBv/+0l2nLRxehh65HuPpPRIZvuTkvNXsE4YvYuSRRzNQZeGC13vot/PP8k6
-        2uezrGwdGgU2n83nmeB5uk7SNF2lGfVBwDxXHplGEkjL683yb1qotHp5PK4y
-        +p4N6kpYh0QzBXMt5C5C20JEe0qyz5jSqIbpboKDYkJO0OZo9LRGxU4T7A0K
-        J/BOPwsMgROGc+wa2EXchygURPkyTlISL0m8el4m22S9XT38yeg1oc9vG/5/
-        +deEoX/vOakESO4uT+ICScksd+eizFrWjX9mXcMkYWVpWo0fFUEwkQyghwsh
-        pR85YbUFUDBM6gdJVk9pnG7i5Nfy22O8iZ8yelc5lvmiZUON86qRD2v2Hh2V
-        HCrWyrFVYYwEpqM8jDCjZ/Ii7rckdwiqMBIPRduB/T6GCA4Xfr8yOsjGJKFY
-        DaS1Mj8iNm5LKXMO0C0Ky4RG70Dtn//GupBMvbfBkIMCPBp+kKY2dPB70eh6
-        D/pVWKODZOeY5oU5+fO5dBh7urZwpRUN+ou8M+Reg+YFdP7AFXZdRodo5L64
-        dsO/HQn3qkESoQWKwN/aXDHpvM/3pJc6/vdhZLoyt9fV01IoETq3DoixvJ/u
-        VJjR6dLeYq4HGecW/IAmtl33J5/9AwAA//8DACkAip3zBAAA
+        H4sIAMqEA1kAA6RTTXObMBC9+1d4uMsCkprgwbjTQ39Ax53J9OJZ0IKV6IOR
+        RGL+fQUYOzHuoZPjvvd2V3q7m+1OUizf0Fiu1TaIVmGwRFVqxlW9DX7vf5Kn
+        YJcvsrK1Tks0+WK5zDjL11ESx1GSRBn1UQ96sjyCcsTHiWF1Gr8khUyq12/H
+        h4x+ZHt1xY11RIHEpeJiGzjTYkAHSsC/mFLLBlQ3w1ECFzO0OWo1r1HBaYa9
+        Y2G5u9PPIDhkBNzSdQ1uA+ZDxyUGeRxGCQkfSfy0j542YbIJ138yek0Y8tuG
+        /V/+NWHsP5hOKo6C2cuTGHekBMPsuSgYA930Z+gaEATKUrfKfVb0gplkBD1c
+        cCH8zAnUBlHiOKkfZP38HIdpmP5ah2mUPsb7jN5VTmW+aNlY47xr5POefYQn
+        KcMKWjH1KrQWCCrI+xlm9ExexMOa5NahLLRwh6Lt0HyfQofWrfyCZXSUTUlc
+        Qo2kNSI/OtfYDaVgLTq7Kgxw5bwFtX//O3R9MvXm9o4cJLqjZgeha01Hw1eN
+        qneo3rjRqpdsLShW6JO/n0uHqadtC1sa3jh/k3emPGicfkWVp6fuIXnJ6BhN
+        3Bf3bvy3Jf3BKhSEK+54z9/aXIGw3ud70ksd//t+ZKrSt+c10IJL3nduLRJt
+        2DDduTCj8629xewAAmMG/YBmtl33J1/8BQAA//8DADoc+/X1BAAA
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:18:34 GMT
+  recorded_at: Fri, 28 Apr 2017 18:07:06 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -270,13 +270,22 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
           <amount>29.99</amount>
-          <order-id>R112301578-VCRV89V6</order-id>
+          <order-id>R261592293-VRPCCARC</order-id>
           <channel>Solidus</channel>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>4dmtyy</payment-method-token>
-          <customer-id>78177737</customer-id>
+          <payment-method-token>9xy37j</payment-method-token>
+          <shipping>
+            <first-name>Ryan</first-name>
+            <last-name>Bigg</last-name>
+            <street-address>143 Swan Street</street-address>
+            <locality>San Jose</locality>
+            <postal-code>95131</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
+          <customer-id>617221771</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -285,7 +294,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -298,7 +307,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:18:39 GMT
+      - Fri, 28 Apr 2017 18:07:12 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -319,53 +328,56 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"c704f84a586c8255efc378f5fc799606"
+      - W/"9355c6cffe177c551796b85515d08025"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - dd225366-f08b-4a16-afb6-cfc11f3c4a3c
+      - 0024308f-7ad1-4d2f-9620-3debae4f8fe7
       X-Runtime:
-      - '4.527862'
+      - '5.205523'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAK/zlFgAA+xYyXLbOBC95ytcusMkJTmSUzQzWZyMK0ul7Ng1nosLJCAR
-        MQgwAChL8/XT4CZSBGMdcpjD3KTuhwZ6QfcDw9fbjJ9sqNJMiotJcOpPTqhI
-        JGFifTG5/f4BLSevoxehUVhonBhARS9OTkJGoh/TjZ+/JD9DD/5YmTbYFDrC
-        hUmlYv9QEnq1yGrNLqeRxpyGXvnTypJCKdhth5iWCDal0e3N+9Abii0YZ7IQ
-        Jpqen56fh179zyoyqpIUC4NwklghgvNoQ7NYchN6Lm152iJGDt2JYPxiYlRB
-        J15lHYMtdRRUKgJIsH8dBNOZH5wtluju3fXd8vzuZei12tJzRbGhBGFzYqNx
-        MSHw17CMTqKpHyyQP0X+7Ps0eBUsX83O/oaYtAvK9UVOjl9/Duv3C+rIayPB
-        J/unSudiGSwWi9miSSdIV0xpgwTO6KGroOR4XJfILMdi59DQDDPukD/RWDPj
-        spWnUrjkK7wdJMDruhXGjHMo49ZFl5Hf76E2ilIoE0IU1doVgq2hgthUjEK4
-        TDBnxmVe0TXcQVecJFw2Xl4X53mhZtVu3J1KbVcjzPMUT49CzZ5DiQKywZJh
-        pjrJAZ9WhSCuG9VqdF3mWCm86ykhkJ3m5DKSY2UYhEZTYzjNKFze/gqX8X0X
-        e858x2yMTZI6MSnL8/9r8T9ai93s1J0RrRjlRNe1sNGIKiUVghjlUmjqdK3E
-        dVzvo6MrGFq/BDQm+llzW/klpnRjsxmuHAotdA2D4QnvQPODVlUOs0YPExvm
-        SiawG8ShuR24hDuDsQf3dwx83w+9Me3ISgOFGr3JQbOxtGIMUUaQEGZPBTEe
-        wgan3EiW2DysIL+wAkokpmroS2GHP+xSzfARlMFbVNESp4puaZY34zqWklMs
-        JtEKc20pUQto6AF4gRKsmlls5CMV0ZxkZrcDePmv0sTMdQXLhjF3XQmwiewh
-        nO0gZ6rKaSaFSaPQG4gGyB3Fqg8sJfVu9UBGto0Yd7ewJ0olLyPrbgksw2uK
-        CsWj1Jhcv/I8rKHt6tNYYSbsVahr+BR6oZfjne3GDxmFIiUPXK6lV4hHIZ/E
-        aS7Wr6nYMCWFxVxoLEgst0B62i3qFqZojoEJ3VYLbc1VgkqdUsxNCiene0RH
-        VoEIjZnZ66u/tapQkDcovHXBLS/roA41bZO3FBTm2B7akdWHxjsleQfRCOow
-        al1Am4MxJR73mJ603zblClktFgnt7jpUNjGTpEhKht0JWyurQIVgPwta3yEQ
-        QxYYNNvBdbKXk4pMIk0eRy5Nq6/JX//S1O8RlDIoQbXrzfh2PpYICobqxNib
-        BiwaFFl+JLNu8a2FXz6ESsTYW6aKkAYC21b2H81TxtY28HjdkHZ71A4z0RKa
-        FI1wzuBIQ3nlsHfocSupo1S1O47dTKeIdaJYPsqEOvq2OZU0D+UweSVBQDaQ
-        jacj2QdIOJYyTiwc+WAf2/MRtHcHjSNMl/Xq1NHKimya1Uj3GXuBQLMYnq1v
-        FCiSfcyCXyMl3Oqrtg8vTEF5dCM5I4WGkq4FFc9UGzusVpSOjRm7t3xCVUoH
-        WohFXChdUVVCDbzEdNOOeip3gjo81719HzN4xB8Jp1vrNPRi5T6G5fxQrsDO
-        XAaLJHHQWEjLiO/W87ww1FUf9RxBTADbKqp3g/1yAfIc84f6Q0DojeH6XKbj
-        a5/ydOnMKOh5WyUBes5Wy5JMCq0FwTWz9Ufh6CvpeDdZP5/lHwCDRl4+7NvP
-        Lg9xAcK2dUF86/bVBbfLq+iR6Nube3R2vZxNp8H85m3wcj73p/ef33369uen
-        +06Ym0nSJ6Eg9r98PZsHy+DdfDZfzs78j9BaDzG/i1BUwTmeT8DwL9b2AKvV
-        bE6I78ezVUBLUlDJ98GkaOwrSfdt4mpUZXDB1tfF7NPd7fT+9q/pt/sm6L09
-        FNo/N6Ob9mPZQNVd0b5Bo7c2uw16L+6C64F3d3l99eHq8n0D7s5BuP6cgwxK
-        1tQPj1p99fXy89XHq7efL6HZj4Ea8pibsoJdARn9sHAwO8dbqgN4TGNrpoCD
-        8IZec696czp68S8AAAD//wMAzuOdY4sVAAA=
+        H4sIANCEA1kAA6xYW3PaOBR+769geFeMDQnQcdylabqTtrPTgaSz2ZeMbAtQ
+        Y0teSSawv36PfEPGckJn+obP+SSd+wX/wz5NBjsiJOXseuhejIYDwiIeU7a5
+        Hj7cf0az4Yfgna8EZhJHClDBu8HAp3HAIvw836uN78CHpkmFVS4DnKstF/Q/
+        EvtORdJcdchIIHFCfKf4qWlRLgS8dkBUcgSPkuBh9cl3umQNxinPmQq8+cV8
+        7jvVl2akRERbzBTCUaSJCOSRiqQhT5Tv2LiFtHmILLwBo8n1UImcDJ3ydgx3
+        ibOgXMSAhPuX3pV7Ofe8+Rj9WH6/uVksb3yn4RaaC4IViRFWA22N62EMn4qm
+        ZBh4I3eKRhPkze7d2fvR9P1o9g/YpDlQnM+z+Ozzrgfnjwcqy0vFQSf9Ubrz
+        yp16njudurU/gbymQirEcEpOdQVmgvt5EU8zzA4WDkkxTSz0FxJKqmx3ZVvO
+        bPQ13nc84Jh6+SFNEojjRkfbJb9fQ6kEIRAncSyIlDYT7BVhsfZFLyThEU6o
+        sl0vyAaS0GYnDtmWFPlilReCVhz61SnZ+jTCSbbF3lmo8VsoloM3aNT1lOEc
+        0Gmds9iWUg1HVnGOhcCHFhMMaVQn2yUZFoqCaSRRKiEpgextn7Bdfixjb11v
+        XBtiFW2tmC3NsrNjMVgeMPMdg3ASkMFHuoHCe/z+taAM3Ml4sHrBbLAq6LpQ
+        t/i/HKjBCi77wiVU94Zkxmtws/Cd6mcnXIP5pTuGumOSulEbPDAoEDGIDIVM
+        Dvh6sChCC0PWm7DegIbmcoSa9N7ghhML25HxK5EezCajkzM1p4h7MxKqMozW
+        lCSxrOJuJxERggsEJs84k8Sa0gXOMFgbHdxBh3wVUF/Rdrz9llcxhRq7Xfdk
+        l6ihG3DeCz4A5ycpMwoam+wWND8TPILXwA51JuICbjXGEdx+0R2NwBl93J6T
+        CuI+WGTA2ekZpg9RWDCOqZYKbNyFdaTccRppP6zBv3ACwiIkoqtLricNeKUc
+        GHpQCu9ROQNZWWRP0qyeDULOE4LZMFjjRGfoEVDPIqAFirCo+77iz4QF8/1h
+        PP0J8OKr5ITU1nqKOjSxtQK4E2khrG0wo6L0acqZ2ga+0yF1kAeCRRtYUKrX
+        quaPdAlS9i6pJdrypLCsvRXSFG8IykUSbJXK5HvHwRJKvLwIBaZMp0IVwxdQ
+        bp0MH3Tlf0oJBGn8lPANd3L2zPgLu8jY5gNhOyo405hriVkc8j0MWM0TVS0U
+        JMMwdT2UB3XMlYSSvSU4UVuQnBwRBq0ExSSk6sgvPytWLsBvEHibPNFDoIE6
+        5TR9RM+70DOPUINWCY0PgicGoiZUZpQyhzIHLZE9HzEtaruI8jXSXMwiYr7a
+        ZdY243EeFeO8YbaGVoJyRv/NSZVDQAYvUCi2nXTSyUlYypGMn3uSpuFXg2Y7
+        abQ1ssY0/fkDMBCkGIKbHeUpzIH4R/0JzU3p0CoM2oCb48WcAQp+Xzwid/LZ
+        G83nV1+XV6PLq8vx/bfbj49f7he+YwDLk+0iquf9q9WVO5t6y9HMnczGkyXU
+        +lPM70qI0jjn5wMEb77RAhCMp9GUuBiv41ER1CX9aEyC+jYKs7faxuXCuHDX
+        X9Px1x8P3uPD3973x9rorTcEMiaxVbNZdljmCWNU096t0acTW0mt1uQft8u7
+        z3e3n2rwcXsupswkARqEuKoaZ8W+/Xb3593Hb7cwWvRB6tKXqVwQy3j62giu
+        w9mYf9dgcXvfsQA7i7zlTExkJGhmK9e+c8yq6t8FtKXgVXFoDezNjFsgCGRq
+        Vfm0SLATAyPNztyTG3xzw6t/a5S51fPPRFmCJGyjTaY0WV5meMFsRDWsJzlM
+        ASTAGQWRuvRSYedU44ZSWamsTAm2ry152Fj+LX7T/YudDWUwzvIYwXKAtD0t
+        Xj1BglhCWbEg8sk7eqhCMD9ZdrKYyqIhWHlVHPF6Guhp731/J0D16crWvhSS
+        REc06NXTIxp+OVdtMWMkCVY8oXEuoWdUhHJpFDs9Dfbnk6/f5i9VDne4YIsw
+        F7LcO2OioAjWid5m2R1kLK296WxgzslkG5zstdJQ3IVdDF10IFztJVrmUWRZ
+        O8EtPbprzbNcb4fd+Gg6IoN1Ji//BND/Q5Yl5qn6W8/onCe49rJg6NreKcx9
+        oRf09l3FhvHWXc0aorZQWhCkmY4/KPBszdtGaxWR4N3/AAAA//8DACB56Rf2
+        FQAA
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:18:39 GMT
+  recorded_at: Fri, 28 Apr 2017 18:07:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/paypal/one_touch_checkout.yml
+++ b/spec/fixtures/cassettes/paypal/one_touch_checkout.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:46:19 GMT
+      - Fri, 28 Apr 2017 18:07:33 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,48 +50,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"3582e9106fb5772bc7f5a0be36296ca8"
+      - W/"8c3ee7dca9734c79dc3159a8f7059f32"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 28259cf4-86d2-4a85-bd73-3ca1d09dfd58
+      - 5ccd8830-3331-4996-b29e-96076f479253
       X-Runtime:
-      - '0.091276'
+      - '0.135148'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAFuBklgAA6RWXW+jOBR9n19R9X12wAzdRurMqE0CwQrOhBCD/QZ2WiA2
-        yeYDAr9+r+luP6TuaKR9QInw9b3H55x7zd2Pi1ZXzeZwLHf1t2v7D+v6alOL
-        nSzrp2/X69j7fHv94/unO6HKTX36fNptN/X3T1dXd02mzpvvmw4jnuI+S0bn
-        oNp18zEuZBrtcgfvN9qzzPtIqzNHtBMzvM/rZbkoA8T9EJH+qSNJcAn7pR32
-        qmT91GF9YPHJsiUJ0aSf9qxiHUNhH/ZPFonvrdBnPa/WXaiZS/plGybMZb3S
-        rML60ScdTzyLJ9EjS5ejsLq/kM5qwxIeBbGTnUWq3WWx+uqQeNqRydohfXAI
-        J/dt6F1s+O2ItpXQZMcS10qR2v6MZcd94YZ65zBtOVwf7WxChIxhT8VbmeBj
-        lpDHDFH3Z2I7mT4dNjNZiUkIuE+7XLMSOKly5OoskVToFs6Pd3IWtaLfNXPk
-        tdnK7aHelunR17nGHUvUWc6w4okspE8dlm7PDI1Oi2pphd3oBHxXme9BTNgQ
-        B295v+2ySpZ5LHXW0x3EVLmvVF4bHh72c4dd5og0ueZ77tCOpdE+R18HXJDn
-        mPvU6NMH1T5PV23JExdlKYZ4Wz3rhV/wBWVbMnTZQ4y1hNw0xUfQvcxmkSVm
-        4c28GxXC354F8s7cx81m7JZCe6B7BNrQGmoriTx3rgFPDHpMwiZPABMqCojp
-        5/1HfIfNvzXTga/gGGivF4hawqZdPg5uAl1YcvbQL8rbhqWk5ynk+gWXwzlS
-        amXeR/vh/dhFUO+Ud7+nzZAvcYt8psDzxHD5Z1B/kPufc8wT78ySiyt9VYnf
-        rPEf3JSPoJn0C8PvdI1oJVOsIsDC9EVxqA+5bA4xwvdceI6/Whtw62gvnIcj
-        S9WCJbYy+q6dSOUJeGK2fPbzs7+wyRFsvUIg3pAtLnlFbqhSjCrsr6d7bxEr
-        N5litKx3Np8UBzq9dcQU/GlDr3peK2M8i6cjuq5wJzxlxWtcRLH3c+OTajEN
-        ughFjZxGf/EeL7KJIoZnM0ek9qoNfcvvvfGe2vjeSfgXNfhrNWrFGLxSU/AD
-        fuCO4dR4OnrXh0YXnoL/0ocjX7nQq1Yj/VE/aAo+4/T/eOw57oM+gd6jVYZG
-        thy7LXDdsqR92cd9BXoSa/mmfl7TYz42Prscc0cGBjvoZYmaKtAEzsX3Qo/O
-        0E9nOXWbWFNLolGXdcEN195RoDX0Daxp1cE8OhkfGkw54hr0PPPVwBWswz6f
-        buOXvoQZoDl4m5g6b/t58s4H2i4E+ATmJ8xEyAPeNPEZ4M0St14m0uwZ6gqL
-        gv/xkSfvcr/OtqlXARf2S+6awFy3AevFGniFOSbgLMxRWKDRJEfR4FNKyTSo
-        LTgnaaCm4f9dL7zy8DrnV8lwJzlCR/Uixn8RhE8E8QNJngYPAB/A6a3xS8Of
-        53khZuAV+lBsVsEN3IG99D1LpqGJOeWIHJ7n5IC/26xJw/21WaPrzswuYosa
-        9NLEXaLRFni/CRSNI+PVd7giw+2ea6VEOfD7sjavSZHrqMydJ6O3kka/7u2s
-        XZ/Fa8+eM8APuHuZPrRwN5s7cgG+dOD/QYA/ErjHs5QUBneeeHAeo73X8QGT
-        B7o8mf1biKlyhwMeLB9T69vdl+fvgE93X95/IfwNAAD//wMAhxF5WlgIAAA=
+        H4sIAOWEA1kAA6RWXW+jOhB9319R9X3vgim9jdTdVRMCAQWzIcSA38BOC8SG
+        bD4g8OvvmO7th9S7Wuk+RIri8cyZc86Mc//9IsVVuz0cy6b+eq3/pV1fbWvW
+        8LJ++nq9iezPd9ffv326Z6Lc1qfPp2a3rb99urq6bzNx3n7b9h6iiTdk8eTs
+        Vk2/nHkFT8ImN7z9Vtqa+j2U4kwR6dnC2+f1qgxKr6LxyqDWqkuHQqYR2VEn
+        NdMqlL71dPGrp5sgxoJaocTwHTt0l0pS+RHTfYsh37LLwCEicMISD15Jranw
+        I1w9Orinsa3ROHxMk9XErx4uuNc6PNP6wF5dAqvp8NAMfn8zBNbmEkQpwoN/
+        8K2HzrcvkPuhx1IXTOImjU0tQWL3I+I9dZjpy8ZIpWZQedQzCzMewZ2Kdjz2
+        jlmMHzNEzB+xbmTydNgueMUsv0/RqcllWgInVY5MmcWcMNmp/hu+CDs2NO0S
+        2V22NgeoBz1ObpbS69NYnPnCEzTmBXeIkSa7c4omp6BaaX4/OQHfVebYEOO3
+        2PB2dNj1WcXLPOIyG0gDMVXuCJHXiofpfmmklyXCbS7pnhqkT5Nwn6ObERfk
+        OeYOUfoMbrXPk3VX0thEWeJBvC5+6fWCzy27MkWXPcRoK8hNEu8IupfZItTY
+        wr9d9pOCObszQ/aZOl67nZklkzboHoI2pIbagiPbXErAEzUatvw2jwETKgqI
+        GZbDR3z77b81k5Ev9+hKe2CIaEwnfT5zb11ZaHwxHYLyrk0TPNAEcv2Gy7GP
+        hGiZ/dF9+H1mIqh3yvs/02bMF5tFvhDgeay4/NutP8j9q49lbJ/T+GJyR1Ts
+        D2v8BzflI2jGnULxO98gUvHEEyFgSeVFUKgPuXQKMcyxTfgcf3c24pbhnhnT
+        Y5qIII11ofTdGKHIY/DEYvXs52d/eSqHu7MLhmiLdzCLFb4lQqREeM5mvreD
+        SJjx3EOrutGpVRzI/M5gc/CnDrNq2x2PvEU0n5BN5fXMFlq08Yowsn9sHVwF
+        c7cPUdjyefiTDl6QWQIrntUe4dKutuQtvw/Ke2Lr2CfmXMTor/WkYzPwSk3A
+        D96UGopT5enw3RwqXWgC/kumR7o2YVa1ljuTYdQUfEbJ//HYc9wHcwKzR6oM
+        TXQ+Mzvgukvj7uUedQToibXVm/p5TY75TPnscswN7irsoJfGaiJAE+iL7pmc
+        nGGeznxutpEkGkeTPuvdWyrtI0MbmBs4k6KHfXRSPlSYckQl6Hmm65ErOId7
+        DtlFL3MJO0BS8DZWdd7Os/XOB1IvGPgE9ifsRMgD3lTxGeDNYrNexVzdGesy
+        jYD/vSO8A29zv+62uV0BF/pL7hrDXtcB60UbeYU9xqCX1BAeQxMrR+HoU0Lw
+        3K016BO3UFPx/24WXnl43fNrhaF0DSbDOoi8nxh5J4zoAcdPoweAD+D0Tvml
+        pc/7vGAL8AqZFtu1ewtv4MAdW+OJr2JOOcKH5z054u+3G9xSZ6POyKZXuwvr
+        rAa9JDZXaLID3m9dQaJQefUdrlBxu6dSCFaO/L6cLWtc5DIsc+NJ6S240q9/
+        u2s3Z/Y6s+cM8APugSfTDt5m9UYG4EsDvh8Y+COGdzxLcKFw57EN/Sjt7Z6O
+        mGzQ5Und30FMlRsU8Hj8MdG+3n95/h/w6f7L+38I/wAAAP//AwAbp88JWAgA
+        AA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:46:19 GMT
+  recorded_at: Fri, 28 Apr 2017 18:07:33 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -100,7 +101,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <customer>
-          <payment-method-nonce>3094c537-269d-0b00-127d-0fccb61c921c</payment-method-nonce>
+          <payment-method-nonce>1f1aa058-81d2-0858-1762-4d1cf2b289af</payment-method-nonce>
         </customer>
     headers:
       Accept-Encoding:
@@ -108,7 +109,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -121,7 +122,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:46:40 GMT
+      - Fri, 28 Apr 2017 18:07:54 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -142,32 +143,33 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"51443365a1fab9c1b92facb1fd053617"
+      - W/"96bd9e5f9042240fe9c97d1318c6f2f5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - aa14cb19-02a5-436b-b6ff-36e303c5cc1e
+      - 9a4f84db-5383-486d-806d-f5708d943c77
       X-Runtime:
-      - '0.344772'
+      - '0.362077'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAHCBklgAA6RTTW+jMBC951cg7o4JSUMbEbLaw/6CVivtJRrwAN76A9mm
-        Df9+DYSkDelhVYnLvPdmBr+ZSQ8nKYI3NJZrtQ9XyygMUBWacVXtw5fnX+Qx
-        PGSLtGit0xJNtgiClLNsHUfJNo6ilPqgxzxX1KAc8XFiWPUU/01ymZSvD/U6
-        pR/ZXl1yYx1RIDFQXOxDZ1oM6UAJ+IoptGxAdTMcJXAxQ5taq3mNEk4z7B1z
-        y92dfgbBISPgAtc1uA+ZDx2XGGZxtEpIFPvvOYp2m+1uE/1J6TVhyG8b9n/5
-        14Sx/+A5KTkKZi+/xLgjBRhmz0XBGOimN0PXgCBQFLpV7rOiF8wkI+jhnAvh
-        R06gMogSx0n9JA8vyfYpirfxarPZrB/j3ym9q5zKfNOyscZ51cinNfuITkqG
-        JbRiapVrLRBUmPUjTOmZvIiHLcmsQ5lr4Y5526H5MYUOrVv6/UrpKJuSuIQK
-        SWtEVjvX2B2lYC06u8wNcOW8A5X//Xfo+mTqve0NOUp0tWZHoStNR7+XjaoO
-        qN640aqX7C0oluuTP59Lh6mnbXNbGN44f5F3hjxonH5FlVXNmrEupWM0cd9c
-        u/HdlvT3qlAQrrjjPX9rcwnCep/vSS91/Ov7kalS317XQAsued+5tUi0YcN0
-        58KUzpf2FrMDCIwZ9AOa2Xbdn2zxDwAA//8DACigL1bzBAAA
+        H4sIAPqEA1kAA6RTwY6bMBC95ysQd8eEJBAiQqoe+gFVKq16iQY8EHeNjWyz
+        Sf6+BkJ2N6RSqx7nvTcz9puZdH+phfeG2nAld/5iHvgeykIxLqud/+PwjWz8
+        fTZLi9ZYVaPOZp6XcpZFcRTFyzBKUuqiDnRkcQJpiYtjzaok/BXndVy+rk/L
+        lH5kO3XJtbFEQo2e5GLnW92iT3tKwJ+YQtUNyOsExxq4mKDNSclpjRIuE+yM
+        ueH2ST+NYJERsJ69NrjzmQstr9HPwmARk2BFws1hsdkG8Xa9/JnS94Q+v23Y
+        3+evXP57wtC/N52UHAUz9ycxbkkBmplbUdAaruOf4dqAIFAUqpX2s6ITTCQD
+        6OCcC+FmTqDSiDUOk/pKopeXMEiC5HsUJItkFR5S+lQ5lvlPy4Yat10jn/fs
+        IzxKGZbQirFXrpRAkH7WzTClN/Iu7tckMxbrXAl7zNsr6i9jaNHYuVuwlA6y
+        MYnXUCFptchO1jZmSykYg9bMcw1cWmdB5d5/hmuXTJ25nSPHGu1JsaNQlaKD
+        4fNGVnuUb1wr2Ul2BiTL1cXdz73D2NO0uSk0b6y7ySdT7jVWvaLMqvM62qxS
+        OkQj9097t5zs3fBvQ7qDlSgIl9zyjn+0uQRhnM/PpPc67vfdyGSpHs+rpwWv
+        ede5NUiUZv10p8KUTrf2ETM9CIxpdAOa2Pa+P9nsNwAAAP//AwDrEADR9QQA
+        AA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:46:40 GMT
+  recorded_at: Fri, 28 Apr 2017 18:07:54 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -177,13 +179,22 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
           <amount>29.99</amount>
-          <order-id>R079769781-EN6U75DY</order-id>
+          <order-id>R799239658-CR3JSZWQ</order-id>
           <channel>Solidus</channel>
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>gp3ddy</payment-method-token>
-          <customer-id>32076200</customer-id>
+          <payment-method-token>gw5684</payment-method-token>
+          <shipping>
+            <first-name>Stembolt</first-name>
+            <last-name>Buyer</last-name>
+            <street-address>1 Main St</street-address>
+            <locality>San Jose</locality>
+            <postal-code>95131</postal-code>
+            <region>CA</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
+          <customer-id>676673269</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -192,7 +203,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -205,7 +216,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:46:49 GMT
+      - Fri, 28 Apr 2017 18:07:59 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -226,53 +237,55 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"353cc9d61a8d89a047a18c7f001976dc"
+      - W/"4083a20cf042bdef6f9293629c96bea6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d31ad075-c4e7-4243-a42f-1e421e5e31f2
+      - ac775417-411e-4ec8-bb99-8c75e28fb6cc
       X-Runtime:
-      - '8.964461'
+      - '4.608623'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAHmBklgAA+xYS3PbNhC+51d4dIdJPWxZGZppHk5HjevJJHGm7sUDkisJ
-        NQiwAChL/fVd8CVSBGMdcuihMz5Yux8W2Ad2PzB4s0v52RaUZlJcj8bn/ugM
-        RCwTJtbXo/tvH8nV6E34KjCKCk1jg6jw1dlZwJJwtY8XAJdR4OEPK9OGmlyH
-        NDcbqdg/kAReJbJas88g1JRD4BX/WlmcK4W77QnTkuCmEN5//RB4fbEF01Tm
-        woSTxfliEXjVL6tIQcUbKgyhcWyFBM+jDaSR5CbwXNritHlEHLozwfj1yKgc
-        Rl5pnaItdRJUqgSRaP+LP1/MLxfzqzG5ubu8n198eAi8Rlt4roAaSAg1ZzYa
-        16MEfxqWwiic+OM58Sf49833X88uX8/8PzEmzYJifZ4lp69f4PrDgiry2kj0
-        yf4o0zmd+PPLie/X6UTpiiltiKApHLuKSk6HdbFMMyr2Dg2klHGH/BkizYzL
-        VraRwiVf0V0vAV7brSBinGMZNy66jPx8D7VRAFgmSaJAa1cIdgZEYlMxCOEy
-        ppwZl3kFa7yDrjhJvGy8uC7O82LNqv2wO6XariaUZxs6OQk1fQklcswGi/uZ
-        aiUHfVrlInHdqEajqzKnStF9R4mBbDUnl5GMKsMwNBqM4ZACXt7uCpfxQxd7
-        yXzLbERNvHFiNizL/q/F/2gttrNTdUayYsATXdXCVhNQSiqCMcqk0OB0rcC1
-        XO+iwyUOrR8CahPdrLmt/BBTuLHd9lf2hRa6xsHwTPeo+QvKKsdZo/uJDTIl
-        Y9wN41DfDlrAncE4gLs7jn07Y4a0AysNFmr4NkPN1tKKIUQRwSRh9lQY4z6s
-        d8qtZLHNwwrziyuwRCJQfV9yO/xxl3KGD6AM3ZGSljhVsIM0q8d1JCUHKkbh
-        inJtKVEDqOkBekFiqupZbOQTiHCdTZNkj/DiV6mJmOsKFg1j5roSaJPYQzjb
-        QcZUmdNUCrMJA68n6iH3QFUXWEiq3aqBTGwbMe5uYU+0kbyIrLslsJSugeSK
-        hxtjMv3a86jGtqvPI0WZsFehquFz7IVeRve2Gz+mgEWaPHK5ll4unoR8FueZ
-        WL8BsWVKCou51lQkkdwh6Wm2qFqYgowiE7ovF9qaKwWlegOUmw2eHA6IlqwE
-        JRAxc9CXPytVrjBvWHjrnFte1kIda5ombykozrEDtCWrDk33SvIWohZUYdQ6
-        xzaHY0o8HTAdabdtyhWxWipiaO/aV9Yxk0keFwy7FbZGVoJywf7OobpDKMYs
-        MGy2vetkLyeIVBKdPA1cmkZfkb/upaneI2TDsATVvjPjm/lYIAANVYmxNw1Z
-        NCrS7ERm3eAbCz98CBWIobdMGSGNBLap7F/qp4ytbeTxuibt9qgtZqIlNikI
-        acbwSH156bB37HEjqaJUtjtO3Uwnj3SsWDbIhFr6pjkVNI9kOHllQpBsEBtP
-        R7KPkHgsZZxYPPLRPrbnE2zvDhqXMF3Uq1MHpRVZN6uB7jP0AsFm0T9b1yhS
-        JPuYRb8GSrjRl20fX5gCePhVcpbkGku6EpQ8U23tsFoBDI0Zu7d8JmVKe1qM
-        RZQrXVLVBAy+xHTdjjoqd4JaPNe9fRfTe8SfCIeddRp7sXIfw3J+LFdkZy6D
-        eRw7aCymZcB363mWG3DVRzVHCBPItvLy3WC/XKA8o/yx+hAQeEO4Lpdp+dql
-        PG06Mwh62VZBgF6y1bAks8HWQvCa2foDPPpKOt5N1s8X+QfCsJEXD/vms8tj
-        lKOwaV0Y36p9tcHN8jJ6Sfj57QOZvP809eeTyZfPvn9xsZjd3b7/bfl+tmyF
-        uZ4kXRKK4ou3v19dTmeL2c10cTWZXIyxtR5jfhahKINzOp/A4Z+v7QGmER1f
-        0sV8Pp2O5wUpKOWHYAIZ+krSfpu4GlURXLR1N59++n4/ebj/Y/L5oQ56Zw9F
-        Ds/N8Gvzsaynaq9o3qDhO5vdGn0Qt8HVwPt+82X5cXnzoQa35yBef85RhiVr
-        qodHpV7e3dwuf12+u73BZj8EqsljZooKdgVk8MPC0ewcbqkO4CmNrZ4CDsIb
-        ePW96szp8NW/AAAA//8DAK44St6LFQAA
+        H4sIAP+EA1kAA6xYSXPbNhS+51dodIcparHEDM3USZyO3bSTxnEa5+IBSUhE
+        TQIsAMpSfn0fuAkUQVuZyU167wPw9oX+m12WjrZESMrZxdg9m4xHhEU8pmxz
+        Mb778gGtxm+CV74SmEkcKUAFr0Yjn8ZB7iov3v/AvgN/NE0qrAoZ4EIlXNAf
+        JPadmqS5ap+TQOKU+E75U9OiQgh4bY+o5AgeJcHd7Xvf6ZM1GGe8YCqYemee
+        5zv1P83IiIgSzBTCUaSJCOSRimQhT5Xv2LiltEWILLwRo+nFWImCjJ3qdgx3
+        iZOgXMSAhPs/Lz1vOvPOFyv07vPs5vb7P3/7TsstNRcEKxIjrEbaGhfjGP4q
+        mpFxMJ24SzSZo+nqi7t6PVm+Xiy+g03aA+X5Io9PP+/B+cOB2vJScdBJ/6nc
+        eb48P1/Opude408gr6mQCjGckWNdgZniYV7EsxyzvYVDMkxTC/2JhJIq2115
+        wpmNvsa7ngccUy8/pGkKcdzqaLvk12solSAE4iSOBZHSZoKdIizWvhiEpDzC
+        KVW26wXZQBLa7MQh29IyX6zyQtCK/bA6FVufRjjNEzw9CTV7CcUK8AaN+p4y
+        nAM6rQsW21Kq5cg6zrEQeN9hgiGN6mS7JMdCUTCNJEqlJCOQvd0TtssPZeyl
+        641rQ6yixIpJaJ6fHIvBbVu+DOJRUAZviz0RvnMg/FxkBu7oT0zZ6FbpOt3h
+        /HScBreYjW64hOLeksxwDd5d+k79sxetgbdwZ67vmKR+0AZ3DOpDDOJCHZMj
+        vh5dlpEF/acDG4xn6C0HqEkfjG04cWk7Mnsm0IPVfHJ0puGUYW8GQl2F0ZqS
+        NJZ12G0lIkJwgcDkOWeSWDO6xBkG66KDa2iQzwKaK7qOt9/yLKZUY7vtn+wT
+        NXQDznvCe+D8S6qEgr4m+/XMzwWP4DWwQ5OIuIRbjXEAd190JxNwxhB34KSC
+        uA8uc+Bs9QgzhCgtGMdUSwU27sN6Um45jbQf1uBfOAFhERLR16XQgwa8Us0L
+        AyiFd6gagawssiNZ3owGIecpwWwcrHGqM/QAaEYR0AJFWDRtX/FHwoLN0+J8
+        NQd4+a/ihNTWecoKNLd1ArgTaSGsXTCnovJpxplKAt/pkXrIPcGiCywp9Wt1
+        70e6BCl7k9QSJTwtLWvvhDTDG4IKkQaJUrl87ThYQoWXZ6GAaqlToY7hMyi0
+        To73uvA/ZASCNH5I+YY7BXtk/Imd5WzzhrAtFZxpzIXELA75Duar9om6FgqS
+        Yxi67qqDOuYqQsVOCE5VApKTA8KgVaCYhFQd+NXfmlUI8BsE3qZI9QxooI45
+        bQfR4y60zAPUoNVC473gqYFoCLUZpSygzEFHZI8HTIfaLaJ8jTQXs4iYr/aZ
+        jc14XETlNG+YraVVoILR/wpS5xCQwQsUim0vnXRyEpZxJOPHgaRp+fWc2U0a
+        bY28Nc1w/gAMBCln4HZFeQh1H/+t+QvNTenQKg3agtvj5ZgBCn66vEfLD/er
+        +dSdfHNn3nLlLtyPV2/vb5aXvmMAq5PdIgrkxcJbzRaLxfLGm89n0/kXqPXH
+        mF+VEJVxTs8HCN5iowVYzuYT13XnxPVm6zKoK/rBmAQNLRRmb7VNy6Vx4a6/
+        lrM/vt5N7+++TT/dN0bvvCGQdTLrscwTvSntmGyC6y3569Xn6w/XV+8b8GF5
+        LofMNAUahLiqG2fNvvp4/fv1249XMFoMQZrSl6tCEMt0+twErsPZGH/XYHF7
+        37EAe3u85UxMZCRobivXvnPIqvrjAkooeFXsO/N6O92WCAKZWlc+LRKsxMDI
+        8hPX5Bbf3vDsV40qtwY+TFQlSMIy2mZKm+VVhpfMVlTDepLDFEACnFMQqU+v
+        FHaONW4ptZWqypRi+9ZShK3lX+K33b9c2VAO4yyPESwHSNvT4tUjJIgllBUL
+        Ih+9o4cqBPOTZSWLqSwbgpVXxxFvpoGB9j70NQGqT1+27qWQJDqiQa+BHtHy
+        q7kqwYyRNLjlKY0LCT2jJlQ7o9jqaXA4n3z9Nn+qc7jHBVuEhZDV2hkTBUWw
+        SfQuy+4gY2cdTGcDc0om2+Bkp5WG4i7sYuiiA+FqL9GyiCLL2gluGdBda54X
+        ejvsx0fbERmsM0X1DUB/hqxKzEP9Vc/onEe47rJg6NrdKcx9YRD08l3lhvHS
+        Xe0aohIoLQjSTMcfFHi25l2jdYpI8Op/AAAA//8DALu30471FQAA
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:46:49 GMT
+  recorded_at: Fri, 28 Apr 2017 18:07:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/order_ready_for_payment.rb
+++ b/spec/support/order_ready_for_payment.rb
@@ -3,7 +3,7 @@ shared_context 'order ready for payment' do
 
   let(:user) { create :user }
   let(:line_item) { create :line_item, price: 50 }
-  let(:address) { create :address, country: country }
+  let(:address) { create :address, zipcode: "90210", country: country }
 
   before do
     create :shipping_method, cost: 5

--- a/spec/support/order_ready_for_payment.rb
+++ b/spec/support/order_ready_for_payment.rb
@@ -3,7 +3,7 @@ shared_context 'order ready for payment' do
 
   let(:user) { create :user }
   let(:line_item) { create :line_item, price: 50 }
-  let(:address) { create :address, zipcode: "90210", country: country }
+  let(:address) { create :address, zipcode: "90210", lastname: "Doe", country: country }
 
   before do
     create :shipping_method, cost: 5


### PR DESCRIPTION
In order to be eligible for seller protection with PayPal, we need to submit the shipping address we've collected with the Transaction#sale call as per the documentation here:
https://developers.braintreepayments.com/guides/paypal/server-side/ruby#shipping-addresses

This is dependent on #73 which fixes the spec failures that were happening on this branch