### PR TITLE
Set source payment_type in cc hosted fields

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -10,6 +10,8 @@ module SolidusPaypalBraintree
 
     belongs_to :customer, class_name: "SolidusPaypalBraintree::Customer"
 
+    validates :payment_type, inclusion: [PAYPAL, APPLE_PAY, CREDIT_CARD]
+
     scope(:with_payment_profile, -> { joins(:customer) })
     scope(:credit_card, -> { where(payment_type: CREDIT_CARD) })
 

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -21,5 +21,6 @@
   </div>
 
   <div class="clear"></div>
+  <input type="hidden" name="<%= prefix %>[payment_type]" value="<%= SolidusPaypalBraintree::Source::CREDIT_CARD %>">
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
 </div>

--- a/db/migrate/20170508085402_add_not_null_constraint_to_sources_payment_type.rb
+++ b/db/migrate/20170508085402_add_not_null_constraint_to_sources_payment_type.rb
@@ -1,0 +1,11 @@
+class AddNotNullConstraintToSourcesPaymentType < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        SolidusPaypalBraintree::Source.where(payment_type: nil).
+          update_all(payment_type: 'CreditCard')
+      end
+    end
+    change_column_null(:solidus_paypal_braintree_sources, :payment_type, false)
+  end
+end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -10,7 +10,7 @@ module SolidusPaypalBraintree
 
     initializer "register_solidus_paypal_braintree_gateway", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
-      Spree::PermittedAttributes.source_attributes << :nonce
+      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type]
     end
 
     def self.activate

--- a/spec/controllers/solidus_paypal_braintree/checkouts_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/checkouts_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SolidusPaypalBraintree::CheckoutsController, type: :controller do
               "payment_method_id" => payment_method.id,
               "source_attributes" => {
                 "nonce" => "fake-paypal-future-nonce",
-                "payment_type" => "PayPal"
+                "payment_type" => SolidusPaypalBraintree::Source::PAYPAL
               }
             }
           ],

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
       {
         transaction: {
           nonce: "fake-valid-nonce",
-          payment_type: "MonopolyMoney",
+          payment_type: SolidusPaypalBraintree::Source::PAYPAL,
           phone: "1112223333",
           email: "batman@example.com",
           address_attributes: {

--- a/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:14 GMT
+      - Mon, 15 May 2017 19:31:02 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,49 +50,48 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"8009b27669a694e81106c9aa7a073c72"
+      - W/"4dfda217dbad176bfe753551e79574f5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b625a1c3-aceb-4fd4-ac3e-ed968e30cca6
+      - 20c51301-e9a8-44e8-90e9-ee0be7a47416
       X-Runtime:
-      - '0.085657'
+      - '0.188835'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAA4eEFkAA6RWXW+jOBR9n19R9X12wAzdRurMqE0CAQVnQogNfgM7LR82
-        ZJsEAr9+r8luP6TuaKR9iIjw9b3H55x7zd2Ps5JX7e75UDT1t2vzD+P6alfz
-        RhT107frbeR8vr3+8f3THZfFrj5+PjbVrv7+6erqrk3lafd91/uIxf6Q0snJ
-        K5t+OfVzEYdNZvn7nXIM/T5U8sQQ6fnC32f1ulgVno3V3GbRfEgGp2KzxAgG
-        zw4ifk4GVrDIQ5gGVkJxtYrW52DGe4g3E7U1gzIscflkJGViYLo1VhGsIc9i
-        5VP/6OKeUcdgNHxM4vUkKO/PuDc6vDG6lbPu8ND0q1lzxtOvA44qazW7t/CQ
-        PAez+y5wziY8oY4pucJNQm0jRrL6GYmeudwOVGMlyrCYOpjpDHMRwZ6SdYL6
-        h5TixxQR+yc1rVQdn3cLUfJZ0Cfo2GQqKYCTMkO2SqkgXHVwfr8Ri7DjQ9Mu
-        kdOlG3uAelWiJl+Xyu8TKk9i4UtGRS5cYiVxdUrQ5Lgq10bQT47Ad5m6DsQE
-        Lbb8ig1Vn5aiyCKh0oE0EFNmrpRZrXl42C+t5LxEuM0U2zOL9Ekc7jP0dcQF
-        eQ6ZS7Q+g1fus3jTFYzaKI19iDflRS//BZ9XdEWCznuIMdaQm8T+AXQv0kVo
-        8EVws+wnOXerE0fOibl+u5vaBVcO6B6CNqSG2lIgx14qwBM1Bp4FbUYBE8pz
-        iBmWw0d8B+2/NeORL+/gKWfgiBjcJH029W48lRti8TCsits2ifHAYsj1Cy7H
-        c8TESJ2P9sP7qY2g3jHrf0+bMR+182whwfNYc/mnV3+Q+59zLKlzSujZFq4s
-        +W/W+A9uikfQTLi55ne+RaQUsS9DwJKos2RQH3KZDGK469jwO/xqbcStwj23
-        Hg5JLFcJNaXWd2uFMqPgicX64ueLv3ydw6ucnCPW4sovWIlviJQJkb67ne+d
-        VSRtOvfRum5MNsufyfzW4nPwpwm96jidiPxFNJ+Qben33JFGtPXzMHJ+7lxc
-        ruZeH6KwFfPwLzb4q3QmseZZzxGhnHJH3vJ7r70nd65z5O5Zjv7aTDo+Ba/U
-        BPzgPzBLc6o9Hb7rQ60Li8F/8cOBbWzoVaMV7mQYNQWfMfJ/PHaJ+6BPoPdI
-        maKJKaZ2B1x3Ce1e9jFXgp7YWL+pn9XkkE21z86HzBKexg56GbwmEjSBc7E9
-        V5MT9NNJzO02UsQQaNKnvXfDlHPgaAt9A2tK9jCPjtqHGlOGmAI9T2wzcgXr
-        sM8lVfTSlzADFANvY13nbT/P3vlAmTkHn8D8hJkIecCbOj4FvCm16zUVes9Y
-        lxsE/O8fGH2X+3W2zZ0SuDBfctcY5roJWM/GyCvMMQ5nSSzpczSZZSgcfUoI
-        nnu1AefELdTU/L/rhVceXuf8ho53ksVVWK8i/y+M/CNG7BnTp9EDwAdweqv9
-        0rLLPM/5ArxCHvLdxruBO3AQrmOIONAxxwzh58ucHPH3uy1umbvVa2Tb69mF
-        TV6DXgrbazSpgPcbT5Io1F59hyvU3O6ZkpIXI78va8sa55kKi8x60npLofXr
-        387a7Ym/9uwpBfyAexDxQwd3s74jV+BLC/4/c/AHhXs8jXGucWfUgfNo7Z2e
-        jZgc0OVJ768gpswsBnh88Rgb3+6+XL4DPt19ef+F8DcAAAD//wMAscaBIFgI
-        AAA=
+        H4sIAPYBGlkAA6RWXXObOBR976/I9L1bECUbz6TtJLHBaIxcYxCgN5Cc8CGB
+        G9tg+PV7Rbr5mMl2OrMPjD3o6t6jc8694vr7WcmLbvd4KNvm60fzL+Pjxa7h
+        rSibh68fo9D5dPXx+7cP11yWu+b46djWu+bbh4uL6y6Tp9233YARS/CYxbOT
+        V7XD6g4XIgna3ML7nXIM/T5Q8sQQHfgS7/NmU65LXJExtdOKSjKPzix0CqKi
+        Ye3imoSRRUZuwzOkMZZpxQq/iux0rMf1/Oa8nj+YBNE6DbmVjrTy56yCNZvE
+        jrx3ycBix2BxcJ8mm5lf3ZzJYPRka5wJ3ZzXYTv6Ydv75ZfBDx8sP0xNEm4e
+        /flN7ztnE34HokzJFWnT2DYSJOsfoRiYy21ftVaqDIupg5nNCRch7KlYL2J8
+        yGJynyFq/4hNK1PHx91SVHzuDyk6trlKS+CkypGtslhQrnp9/lYsg56PbbdC
+        Tp9t7RHq1amafVkpDOeWJ7HEksWiEC610qQ+pWh2XFcbwx9mR+C7ylwHYvyO
+        WLhmYz1klSjzUKhspC3EVLkrZd5oHm73Kys9rxDpcsX2zKJDmgT7HH2ZcEGe
+        Q+5Src/oVfs82fYli22UJRjiTflLr2d8XtmXKTrvIcbYQG6a4APoXmbLwOBL
+        /3I1zAru1ieOnBNzcbe7s0uuHNA9AG1oA7WlQI69UoAnbA0y97s8BkyoKCBm
+        XI3v8e13/9ZMJr68g6eckSNqcJMO+Z136anCEMvbcV1edWlCRpZArt9wOZ0j
+        oUbmvLcf3t/ZCOod8+HPtJnyxXaRLyV4nmgu//aad3L/Oscqdk5pfLaFKyv+
+        hzX+g5vyHjQTbqH5XUSIViLBMgAsqTpLBvUhl8kghruODc/hd2sTbhXsuXV7
+        SBO5TmNTan0jK5B5DJ5Ybp78/OQvrHN4tVNwxDpS45JV5JJKmVKJ3Wixd9ah
+        tOMFRpumNdm8eKSLK4svwJ8m9Krj9CLEy3Axo1GFB+5II4xwEYTOj51LqvXC
+        GwIUdGIR/GQjXmdzSTTPeo4I5VQ7+prfG+09uXOdI3fPcvLXdtbzO/BKQ8EP
+        +JZZmlPt6eBNH2pdWAL+S24PbGtDrxqdcGfjpCn4jNH/47GnuHf6BHqPVhma
+        meLO7oHrPo37533MlaAnMTav6ucNPeR32mfnQ24JT2MHvQzeUAmawLnYnqvZ
+        CfrpJBZ2FypqCDQbssG7ZMo5cBRB38CakgPMo6P2ocaUI6ZAzxPbTlzBOuxz
+        aR0+9yXMAMXA20TXed3P8zc+UGbBwScwP2EmQh7wpo7PAG8W280mFnrPVJcb
+        FPyPDyx+k/tlti2cCrgwn3M3BOa6CVjPxsQrzDEOZ0ktiTmazXMUTD6llCy8
+        xoBzkg5qav7f9MILDy9zfqsxlJ7FVdCsQ/yTIHwkiD2S+GHyAPABnF5pv3Ts
+        aZ4XfAleobfFbutdwh04CtcxROLrmGOOyOPTnJzwD7uIdMyN9BqNBj27iMkb
+        0EsRe4NmNfB+6UkaBtqrb3AFmts9U1LycuL3eW3VkCJXQZlbD1pvKbR+w+tZ
+        G534S8+eMsAPuEeR3PZwN+s7cg2+tOD/Iwd/xHCPZwkpNO48duA8WntnYBMm
+        B3R50PtriKlyiwEeLO4T4+v156fvgA/Xn99+IfwDAAD//wMAe5L6NVgIAAA=
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:14 GMT
+  recorded_at: Mon, 15 May 2017 19:31:02 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -109,7 +108,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -122,7 +121,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:17 GMT
+      - Mon, 15 May 2017 19:31:05 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -143,40 +142,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"efdbb1e8ef2843da468e28a8669a20c7"
+      - W/"8868cb69d64f43aa16d25b566315a54e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5e8a998c-30b9-4d7a-8313-0bd00923abc1
+      - 20dbcc3d-7bb2-43ac-a08b-6214f3183d26
       X-Runtime:
-      - '0.366375'
+      - '0.346159'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIABEeEFkAA6xVTXObMBC951d4uCuAYxecwcqtx16a9NBLR6DFqBYSlYRj
-        //tKmC/HxnEmubFv30rL7tNu8rQv+WwHSjMp1l54H3gzEJmkTGzW3svzdxR7
-        T/guyWptZAkK381mCaN4GXyL42i5WiS+tRxonVlBhEHWjhTdrOZ/o7SM8u2y
-        eEj8sdexc6a0QYKUMBOMrz2javD8xsXJlCeTZUXE4QyHkjB+hlaFFOdn5GR/
-        hr1Cqpm5cJ8CYoAiYmbmUMHao9Y0rAQPz4MwQsESBfFzED3O48cw+p34Q0AT
-        X1f0Y/FDwPH+pugoZ8Cp7lOizKCMKKrbQ4lS5OA576n/iFgsZZzbdiJCqQKt
-        O/zYyKroOthiXafRaZfH8ECebmNLmGxmd9vllrZebRSA6RKfIMHegKCualdp
-        XGaEMzN1lYKNfQETzkpqQziyzwLwahEGUeKPofHv1MKoQwMjwquCzCd//C3z
-        4RamqG0PWPYO9VrBP6fp9pRPKrs5w5/QpdWrwIsgnMex44ged6JG7jr8i2li
-        M+vtMaOQnFqZTpXAKc4NI0Y4fhFbIV+FPWnABtqxlDJHTOuaiAywI56jfcTn
-        K/uBxzdQnbCN1S5++Tli9mjHp5AyM/zy0RycOal5l3gqJQciPOxK56iNcyDX
-        yrYF2RdTc/cDo0PferoQ2FdMNfmgUgpT4HCe+GfgBfYBiLLlmwcn9AY9YQN9
-        m3tOuIY2apRJAYSbwgoFhrRHWEdjJdkAqhXHhTGVfvR9ojUYfZ8qwoQbSxv7
-        g6/kcG+141fkUIIwf0owhaR/uNxIf2c1el+JzROIHVNSOMJaE0FTubcjtz+/
-        v9Hqyb2GlIjtkNoJ2lGbobrAYRyHid8anc+moiQfabsDeoKCilgd/ZDW134P
-        PknrrFnSQ/yAdTRdpzpTrHK9ON1CwzMzcgsCF/GuNFbAR6vz1YL9q5tZljaa
-        tpVhdskpTPLlMlqs8uUqD3P6ENNvWZ6FFsgXyzjNrWYmQ/uzv2Ay7UCUEmm6
-        ndBU7x9FKJvG8cVdrEjz2seb+QRoZl/SzkG4uNjfDsmz1f2R2XF9bV9f2tdW
-        9g0L+6Z1fXVZX1nVNy7qW9f0rUv65hX97oL+kiXy6SeQ+CO19QZYc5ATvvsP
-        AAD//wMAGlQS/DsMAAA=
+        H4sIAPkBGlkAA6xVTXObMBC951d4uCsY2wQ7g5Vbj7206aGXjkALqBYSlURi
+        99dXwnw5No4z6Y19+1Zadp9246d9yWcvoDSTYusF93NvBiKVlIl86z1//4LW
+        3hO+i9NaG1mCwnezWcwoXkfRwzyMlg+xby0HWmdaEGGQtSNF883id5SUUbYL
+        i2Xsj72OnTGlDRKkhJlgfOsZVYPnNy5OpjypLCsiDmc4lITxM7QqpDg/IyP7
+        M+wVEs3MhfsUEAMUETMzhwq2HrWmYSV4eDEPIjQPURB+DzaPy+BxHv6M/SGg
+        ia8r+rH4IeB4f1N0lDHgVPcpUWZQShTV7aFEKXLwnPfUf0QsljDObTsRoVSB
+        1h1+bGRedh1ssa7T6LTLY3ggT7exJUw2s7vtcktbrzYKwHSJT5Bgb0BQV7Wr
+        NC5TwpmZukpBbl/AhLOS2hCO7LMAvFkF8yj2x9D4d2ph1KGBEeFVQRaTP/6W
+        ubyFKWrbA5a+Q71W8M9puj3lk8puzvAndGn1KvBqHizWa8cRPe5Ejdx1+AfT
+        xGbW22NGITm1Mp0qgVOcG0aMcPwsdkK+CnvSgA20YyllhpjWNREpYEc8R/uI
+        z1f2A49voDphG6td/PxtxOzRjk8hYWb45aM5ODNS8y7xREoORHjYlc5RG+dA
+        rpVtC7IvpubuB0aHvvV0IbCvmGryQaUUpsDBIvbPwAvsAxBly7eYn9Ab9IQN
+        9G3uGeEa2qhRJgUQbgorFBjSHmEdjZUkB1QrjgtjKv3o+0RrMPo+UYQJN5Zy
+        +4Ov5HBvteNX5FCCML9KMIWkv7jMpf9iNXpfifwJxAtTUjjCVhNBE7m3I7c/
+        v7/R6sm9hoSI3ZDaCdpRm6G6wsF6HcR+a3Q+m4qSfKTtDugJCipidfRVWl/7
+        PfgkrdNmSQ/xA9bRdJ3oVLHK9eJ0Cw3PzMgdCLz7u4xyGvtHq/PVgv2pm1mW
+        NJq2lWF2ySlMsjCMVpss3GRBRpdr+pBmaWCBbBWuk8xqZjK0P/s/TKYXEKVE
+        mu4mNNX7RxHKpnF8cRcr0rz28WY+AZrZF7dzEC4u9rdD8mx1f2R2XF/b15f2
+        tZV9w8K+aV1fXdZXVvWNi/rWNX3rkr55Rb+7oP/LEvn0E4j9kdp6A6w5yAnf
+        /QMAAP//AwDmt1Y1OwwAAA==
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:17 GMT
+  recorded_at: Mon, 15 May 2017 19:31:05 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -191,8 +190,17 @@ http_interactions:
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>h8vmt4</payment-method-token>
-          <customer-id>506887594</customer-id>
+          <payment-method-token>kz37gd</payment-method-token>
+          <billing>
+            <first-name>John</first-name>
+            <last-name nil="true"/>
+            <street-address>10 Lovely Street Northwest</street-address>
+            <locality>Herndon</locality>
+            <postal-code>21088-0255</postal-code>
+            <region>AL</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </billing>
+          <customer-id>877605736</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -201,7 +209,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -214,7 +222,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:19 GMT
+      - Mon, 15 May 2017 19:31:08 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -235,49 +243,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"ef79d88bc176db2adaade05612d562e3"
+      - W/"bc0d285088ade8dc8acb5652e1087994"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - de6b5641-3250-4f07-aceb-d1a3befb57ef
+      - 0233c771-1d31-4c22-b6d5-9905ab346c6e
       X-Runtime:
-      - '0.457375'
+      - '0.553925'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIABMeEFkAA9xYTW/jNhC9768IfGdkO/bGCRSl2xZFC7RF0ey2QC8LShxZ
-        bChSJSnH3l/foSjJUkQl6aFA0Zysmcch54Mzj4nvj6W4OIA2XMm7xepyubgA
-        mSnG5f5u8enjd2S3uE/exVZTaWhmEZW8u7iIOUs2Txu9X39ZxxF+OJmx1NYm
-        obUtlOZfgMVRK3Jae6ogMVRAHDU/nSyrtcbdToQbRXBTSD49fBtHU7ED01LV
-        0ibr5eVyGUftl1OUoLOCSktoljkhwfMYC2WqhI2jkLY5bZ2SgO5CcnG3sLqG
-        ReStU7Sl3wRVmiES7f964//Ian314etv4qjXNF5roBYYofbCReJuwfDT8hIW
-        6Nzqmiy3ZLn7uLy+Xe9uVzd/YDz6Bc36umL/bP15QRt1YxX64z58KrfL97vd
-        9fZm0+USxTnXxhJJS3juJyoFnddlqqyoPAU0UFIuAvInSA23IVtVoWRIntPj
-        JPrR0K845UJgDZ99rIp/1zljNQCWB2MajAl5f7QgmUvDLESojApuQ+Y17PHu
-        hUKk8JIJf01uNqvldRwNRd2xsWT1ad4rr3YrCBVVQddvQl29hpI15oNn01wN
-        0oOu5bVkoQvVa0xb6VRrehopMZ6D3hQyUlFtOYbDgLUCSsC7O14RMn5uYq+Z
-        H5hNqc2KIKbgVTWsxlBJ/y9L8oUC+c/U4jA7bXMkOQfBTFsLB0NAa6UJxqhS
-        0kDQtQY3cH2MTn7CmfUioDMxztoz0A/eyouYxo3DYbpyKnTQPc6GJ3pCzZ/g
-        qxzHjZkmNq60ynA3jEN3O2gDbyw9/PL799c/Yu95CTS2Mj7KaunG+px2ZqXF
-        Ck4+VKg5OLoxh2hCyxh3J8HgT2ETXw+KZy5BOSYeV2DtpKCnEakdKcBd/Hyf
-        QVl6JJ6uBFVwhLLqRnmqlAAqF0lOhXFUqQd01AG9IBnV3SSz6hFkUuwOpcXp
-        7b+8JuUy2SxX693OtVs57CSbZLXbreKo/WgvCxolDTX7jRuK1dJ/d82i4ton
-        s1TSFskKqd9EOMGegGrkJevlCNxI233bsU1cq2kI5qeH8zA/S8+nLJRowh1u
-        ILykeyC1FklhbWVuo4gabNLmMtWUS3dx2oq/xM4ZVfTkevfnErBa2Weh9io6
-        oP+XldzfgzxwraQD3BkqWaqOSCJ6+22301BRZBY/K1eA/rfXFECFLfDEyGvl
-        o1RPMo4GMg9ikHJ71vvPVlVrTBxW4b4WjsANUM81/ShwPBWn3Rk6kLXnpSet
-        xADRCdrwGVNjM8RhJh/PmJF03FxVTpyWygwSt91U2sVJsTpr+Pd567PMg2rJ
-        /6qhvUkoxshz7MU6ofl2e725ybc3+SpnVzv2PsuzFQryzXaX5liKs0u95QPI
-        UhHDHmduWq9vyeT4prWPG1JwLEt9GjGGfto2CEBDbQLd9URajoqyeiNV7/G9
-        hRdfVQ1i7mHkA2owAn3lf9W9i1ztY8hMFx531AHPMQo7GyS04nikqdw7HD33
-        uJe0UfI9UtAwb6pTk2lezfKqgb7vaA1pJBXOccUIUhfi4hnoAc+QeCxtg1g8
-        8rN93KAgOBMCpJBx05R3UAfeiurqbaY7zb1osJ9MzzY2ioTLvYzRr5kS7vV+
-        VuBzVYJIHpTgrDZY0q3As1Z9cBMuB5ibTW5v9UR8SidajEVaa+OJLwOLLzvT
-        ta2RKpygAWsObz/GTP4j8EY4HJ3T2K51+BjuBYHlilwvZLDOsgApxrTM+O48
-        r2oLofpo5wzhErlb7V8hbrb6PvPZ9Zk4mgON2c/A0TFJGhKgWdDrthrK9Jqt
-        nlfZAvsKwTvmig/w6LkaR2zUQZJ3fwMAAP//AwB6rFllchIAAA==
+        H4sIAPwBGlkAA6xYbXOjNhD+fr/C4+8KYMexc0O4pu102s7dzc29tNN+uRGw
+        GDUgUUk49v36rhBgMCJJp80ns/topV3ty6OEb45lsTiAVEzwu2Vw5S8XwBOR
+        Mr6/W375/BPZLd9Er0ItKVc00YiKXi0WIUujqrzdV8FNFnr4YWRKU12riNY6
+        F5J9gzT0WpHR6lMFkaIFhF7z08iSWkrc7USYEgQ3hejLpx9Dbyo2YFqKmuto
+        5V/5fui1X0ZRgkxyyjWhSWKEBM+jNJSxKHToubTNaeuYOHQLzoq7pZY1LD1r
+        naIt+SKokCki0f7HW/tHgtX6/vsfQq/XNF5LoBpSQvXCROJumeKnZiUs0blg
+        S/wNCTafg9vX6+C1v/0T49EvaNbXVfrv1p8XtFFXWqA/5sNe5W67vfE32/VN
+        d5cozphUmnBawqWfqCzovC4RZUX5yaGBkrLCIX+EWDHtslXlgrvkGT1Oou8N
+        /QpjVhSYw2cf96XTuehXkfPQGwj+i4dKSwDMkTSVoFQU+Iu34gDFafGpUSze
+        C6nzR1DalMYI2kboqIGn5qqs2BV6kdCC6VP0M0ieCjx7L7EACXtTpfdvQ6/9
+        2cZSYDUWtp5Wgb/bEX+12YTeUN75hwkuTzYcXzheTYoOYAqphcgW9xhillCM
+        9xA2XmmMEVpUOV1hSZ+hQ/ncijWuuHctWbuW8Lo5TrS79i/WdJomNwbpgAHK
+        ap66CrjXqLayqJT0NFLi3Qx6octIRaVmGFAFWhdQAvaK8QqX8XPTfM78wGxM
+        dZI7MTmrqmH2u0ro/6/vcUq7GsDL09uhstns6hLnDHae95ymT6gHqfki1Po5
+        VJt/0z41vJ22GZOMQZGqNhcOioCUQhKMUSW4AqdrDW7g+hgdvcMZ+SSgMzG+
+        NbeVJzGNG4fDhfQXLMeJ0ED32Ege6Qk1f4HNchxvanqxYSVFgrthHLrqoA28
+        sbT58Me73z9i93oKNLYyPkrgGxoxp51ZqTGDo/sKNQdDb+YQTWjTlJmTYPCn
+        sImvB8ESc0EZXjyuwNyJQU4jUhsSgrtYPjGD0vRILD1yquAIZdVRh1iIAihf
+        RhktlKFmPaCjKugFSajsJqcWD8Cjh2/r7R4DYL+sJmY8uvaD1W5n2i0fdpLr
+        KNjtApxU9qMtFjRKGir4G1NmnPTfXbOomLSXWQqu8yhYhd5EOMGegErkQSt/
+        BG6k7b4tTSCm1TSEtplQE+n5lLkomnC7Gwgr6R5ILYso17pSrz2PKmzS6iqW
+        lHFTOG3GX2Hn9Cp6Mr37awmYrenXQuyFd0D/ryq+fwP8wKTgBnCnKE9jcUTS
+        0ttvu52EiiKTeS9MAtrfVpMDLXSOJzZT+4GLRyQHA5kFpRAzfdbbz1ZVS7w4
+        zMJ9XRjCOEBdavpRYHgxTrszdCBrz0tPUhQDRCdow6dUjc0Qhxl/OGNG0nFz
+        FRkxWsoTiM4jfyjt4iTSOmn4/nnrs8yCas7+rqGtJBRj5Bn2YhnRbLPZXt9m
+        m9ssyNL1Lr1JsiRAQXa92cUZpuLsUmv5ALwURKUPM5XW61vyOq609jFFcoZp
+        KU8jxtBP2wYBaKi9QFOe+AxARVm98GnQ43sLT77iGsTcQ8wGVGEE+sz/rnuH
+        mdzHkKkuPOaoA56jBHY2iGjF8EhTuXXYu/S4l7RRsj2yoG7eVMcqkaya5VUD
+        fd/RGtJIKpzjIiVIXYiJp6MHXCDxWFI7sXjki33MoCA4ExykMGWqSW+nDqwV
+        0eXbTHeae0FhP5mebWwUCZd5iaNfMync6+2swOcxhyL6JAqW1gpTuhVY1ioP
+        ZsJlAHOzyewtHom90okWYxHXUlnim4LGl2T3aBqr3Bc0YM3u7ceYyX8gXgiH
+        o3Ea27V0H8O8IDBdkeu5DNZJ4iDFeC0zvhvPq9o8y6b50c4Zwjhyt9q+Qsxs
+        tX3mq+kzoTcHGrOfgaNjkjQkQLOg5201lOk5Wz2v0jn2FYI1ZpIP8OiZGEds
+        1EGiV/8AAAD//wMA8td0guISAAA=
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:19 GMT
+  recorded_at: Mon, 15 May 2017 19:31:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/checkout/valid_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/valid_credit_card.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:03 GMT
+      - Mon, 15 May 2017 19:30:51 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,49 +50,48 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"21932142d9ae0f3421c922bda2f3a8a1"
+      - W/"f7c5c3940fcbc7074b9be33cb7df027a"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ed88a57f-b834-4ce5-972e-5a3c76a1de43
+      - 79068a08-2208-4b56-9f36-2834f82bb6d2
       X-Runtime:
-      - '0.177070'
+      - '0.182847'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAMeEFkAA6RWXW+jOBR9n19RzfvsgCndRurMqG0CAQUzIWCD38BOC8SG
-        bJNA4NfvNd3th9QdjbQPSAhf33t8zrnX3Pw4K3nRbZ8OVdt8+2z+YXy+2Da8
-        FVXz+O1zEjtfrj//+P7phstq2xy/HNvdtvn+6eLipsvlaft9O/iIpf6Y09nJ
-        q9thde+XIo3awvL3W+UY+nuk5IkhMvClvy+adRVW3hnHjxaO12PgBnYQe2Yw
-        X/QYJZfZWKoMBWNAcRXSxID3czB3yoBmFqZsl8VYYuqNGUqMMF6bzM16Fid2
-        FsvqwcUDo47BaPSQpetZUN+e8WD0eGP0obPu8dgO4bztg+FyCOMFCmpuhnP+
-        FMxv+8A5A4bbAStTcoXbjNpGiuTuZywG5nI7UK2VKcNi6mDmc8xFDHtq1gvq
-        H3KKH3JE7J/UtHJ1fNouRc3nwZChY1uorAJO6gLZKqeCcNXD+f1WLKOej223
-        Qk6fb+wR6u0yNbtcKX/IqDyJpS8ZFaVwiZWlu1OGZsewXhvBMDsC33XuOhAT
-        dNjyd2zcDXktqiIWKh9JCzF14UpZNJqHu/3Kys4rhLtCsT2zyJCl0b5AlxMu
-        yHMoXKL1Gb16X6SbvmLURnnqQ7wpn/XyX/B5VV9l6LyHGGMNuUnqH0D3Kl9G
-        Bl8GV6thVnJ3d+LIOTHX77b3dsWVA7pHoA1poLYUyLFXCvDErYHnQVdQwITK
-        EmLG1fgR30H3b8104ss7eMoZOSIGN8lQ3HtXnioNsbwbw+q6y1I8shRy/YLL
-        6RwpMXLno/3w/d5GUO9YDL+nzZSP2mWxlOB5rLn802s+yP3POVbUOWX0bAtX
-        1vw3a/wHN9UDaCbcUvO7SBCpRerLCLBk6iwZ1IdcJoMY7jo2PIdfrU24VbTn
-        1t0hS2WYUVNqfRMrkgUFTyzXz35+9pevc3g7p+SIdXjnV6zGV0TKjEjfTRZ7
-        J4ylTRc+WjetyeblE1lcW3wB/jShVx2nF7G/jBczktT+wB1pxIlfRrHzc+vi
-        Olx4Q4SiTiyiv9joh/lcYs2zniNCOfWWvOX3VntPbl3nyN2znPy1mfX8HrzS
-        EPCDf8cszan2dPSuD7UuLAX/pXcHtrGhV41OuLNx0hR8xsj/8dhz3Ad9Ar1H
-        6hzNTHFv98B1n9H+ZR9zJeiJjfWb+kVDDsW99tn5UFjC09hBL4M3RIImcC62
-        52p2gn46iYXdxYoYAs2GfPCumHIOHCXQN7Cm5ADz6Kh9qDEViCnQ88Q2E1ew
-        Dvtcsotf+hJmgGLgbazrvO3n+TsfKLPk4BOYnzATIQ94U8fngDendrOmQu+Z
-        6nKDgP/9A6Pvcr/OtoVTAxfmS+4Gw1w3AevZmHiFOcbhLJklfY5m8wJFk08J
-        wQuvMeCcuIOamv93vfDKw+uc39DpTrK4ipow9v/CyD9ixJ4wfZw8AHwAp9fa
-        Lx17nuclX4JXyF253XhXcAeOwnUMkQY65lgg/PQ8Jyf8wzbBHXMTvUaSQc8u
-        bPIG9FLYXqPZDni/8iSJI+3Vd7gize2eKSl5NfH7srZqcFmoqCqsR623FFq/
-        4e2sTU78tWdPOeAH3KNI73q4m/UdGYIvLXh/4uAPCvd4nuJS4y6oA+fR2jsD
-        mzA5oMuj3r+DmLqwGODxxUNqfLv5+vwf8Onm6/s/hL8BAAD//wMAJDYkD1gI
-        AAA=
+        H4sIAOsBGlkAA6RW246jOBB9n69o9fvsgGl6O1LPjCYXCFZwJoQY8BvY6QZi
+        QzYXCHz9lsluX6Te0Uj7EBHhctXxOafKPH6/KHnTbA/Hoq6+3pp/GLc324rX
+        oqiev95uQufzw+33b58euSy21enzqd5tq2+fbm4em1Set9+2HUYsxn0ajc5e
+        WXeLCc5FHNSZhfdb5Rj6faDkmSHa8TneZ9WqWBaetZwmJlN+l4T84rtOwab8
+        jk1J6U8DycrkkoRYETRr4U27DD2blEGeRLPedwPp93lJwlyxcmaykuwI8tEy
+        9I0nl3QscgwWBU9JvBr55Y8L6YyWrI0LoavLMqx7f1qb/vquJ71vLKcby++f
+        D/70R+s7FxOeHVGm5IrUSWQbMZK7n6HomMttX9VWogyLqaOZTgkXIewpWSsi
+        fEwj8pQiav+MTCtVp8N2Lko+hbOhU52ppABOygzZKo0E5aqF8+NazIOW93Wz
+        QE6bru0e6u0SNbpbKNwlkTyLOZYsErlwqZXEu3OCRqdluTL8bnQCvsvUdSDG
+        b4iFd6zfdWkpiiwUKu1pDTFl5kqZVZqH8X5hJZcFIk2m2J5ZtEviYJ+huwEX
+        5DlmLtX69F65z+J1W7DIRmmMId6UV73wCz6vaIsEXfYQY6wgN43xEXQv0nlg
+        8Ll/v+hGOXd3Z46cM3Nxs53YBVcO6B6ANrSC2lIgx14owBPWBpn6TRYBJpTn
+        ENMv+o/49pt/a8YDX97RU07PETW4Sbts4t17KjfEfNwvi4cmiUnPYsj1Cy6H
+        c8TUSJ2P9sP7iY2g3inrfk+bIV9k59lcgueJ5vJPr/og9z/nWETOOYkutnBl
+        yX+zxn9wUzyBZsLNNb+zDaKliLEMAEuiLpJBfchlMojhrmPD7/irtQG3Cvbc
+        Gh+TWC6TyJRa340VyCwCT8xXVz9f/YV1Dm/n5ByxhuxwAf14T6VMqMTuZrZ3
+        lqG0oxlGq6o22TQ/0NmDxWfgTxN61XFaEeJ5OBvRTYk77kgj3OA8CJ2fW5eU
+        y5nXBShoxCz4i/V4mU4l0TzrOSKUU27pW35/aO/JreucuHuRg7/Wo5ZPwCsV
+        BT/gMbM0p9rTwbs+1LqwGPwXj49sbUOvGo1wR/2gKfiM0f/jsWvcB30CvUfL
+        FI1MMbFb4LpNovZlH3Ml6EmM1Zv6WUWP2UT77HLMLOFp7KCXwSsqQRM4F9tz
+        NTpDP53FzG5CRQ2BRl3aefdMOUeONtA3sKZkB/PopH2oMWWIKdDzzNYDV7AO
+        +1y6C1/6EmaAYuBtouu87efpOx8oM+fgE5ifMBMhD3hTx6eAN43sahUJvWeo
+        yw0K/sdHFr3L/TrbZk4JXJgvuSsCc90ErBdj4BXmGIezJJbEHI2mGQoGn1JK
+        Zl5lwDlJAzU1/+964ZWH1zm/jq53EldBtQzxXwThE0HsQKLnwQPAB3D6oP3S
+        sOs8z/kcvELH+Xbt3cMd2AvXMUTs65hThsjhOicH/N12QxrmbvQa3XR6dhGT
+        V6CXIvYKjXbA+70naRhor77DFWhu90xJyYuB35e1RUXyTAVFZj1rvaXQ+nVv
+        Z+3mzF979pwCfsDdi3jcwt2s78gl+NKC/wcO/ojgHk9jkmvcWeTAebT2TscG
+        TA7o8qz37yCmzCwGeLB4io2vj1+u3wGfHr+8/0L4GwAA//8DADuzVdlYCAAA
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:03 GMT
+  recorded_at: Mon, 15 May 2017 19:30:51 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -109,7 +108,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -122,7 +121,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:07 GMT
+      - Mon, 15 May 2017 19:30:55 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -143,40 +142,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"622c6e958b6d93fef071f38a520983b1"
+      - W/"8b64f7eafdc0345149641c0aae8255e4"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - db433ab2-6b82-422a-bf6e-f2689fcf614f
+      - e761aa74-5955-4e1c-8b96-6e407f261ff7
       X-Runtime:
-      - '0.567220'
+      - '0.357624'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAceEFkAA6xVTXOjOBC951e4uCuAY8Ykhcltj3PZyR72MiVQY7QWEiMJ
-        x/7328J8OTYepzI3+vVrqel+6k5eD5VY7EEbruTGCx8DbwEyV4zL7cZ7+/EX
-        ib3X9CHJG2NVBTp9WCwSztJ4GYTRU7R8Sny0HIjOvKTSErTXmm2fl/+ts2pd
-        7KISSVOvYxdcG0skrWAhudh4Vjfg+a1L0DlPrqqayuMFDhXl4gKtSyUvzyjo
-        4QJ7h8xwe+U+DdQCI9Qu7LGGjcfQtLwCL8XfX5MgIkH8I1i/LOOX4Nu/iT8G
-        tPFNzT4XPwac7m+LTgoOgpkhJcYtyalmpjuUak2PnvOe+08IYhkXAttJKGMa
-        jOnxUyNz03eww/pOk/MuT+GRPN/GjjDbzP626y3tvMZqANsnPkOCgwXJXNVu
-        0oTKqeB27ioNW3wBM85aGUsFwWcB6fMqDNaJP4Wmv9NIq48tTKioS7qc/fGP
-        zKd7mLLBHvD8N9RbBf+aprtTvqjs9gx/RpeoV5mugnAZx44jB9yJmrjr0n+4
-        oZjZYE8ZpRIMZTpXAqc4N4w4Femb3En1LvGkERtpp1KqgnBjGipzSB3xEh0i
-        vl7ZTzy+keqEbVG76dvfE+aA9nwGGbfjL5/M0VnQRvSJZ0oJoNJLXekctXWO
-        5EZjWwi+mEa4H5gc+tHTh8Ch5rrNh1RK2jINl4l/AV5hH4FqLN8yOKO36Bkb
-        2MfcCyoMdFGTTEqgwpYoFBjTnmA9jVd0C6TRIi2trc2L71NjwJrHTFMu3Vja
-        4g++0+Mjasev6bECaX9WYEvFfgq1Vf4eNfpYy+0ryD3XSjrCxlDJMnXAkTuc
-        P9yIenKvIaNyN6Z2hvbUdqiu0jCOw8TvjN6HqWglJtrugYGgoaaoo+8Kfd33
-        6FOsydslPcaPWE8zTWZyzWvXi/MtND4zq3YgUxbty71N/JPV+xrJfzXtLMta
-        TWNlOC45ndIiitar5yJ6LsKCPcXsW17kIQLFKoqzAjUzGzqc/Qcm0x5kpYhh
-        uxlNDf5JhMY0Ti/uakXa1z7dzGdAO/uSbg7C1cX+cUherO7PzI7ba/v20r61
-        su9Y2Het65vL+saqvnNR37um713Sd6/o3y7oP7JEvvwEEn+itsEANEc5pQ//
-        AwAA//8DAE5H8SY7DAAA
+        H4sIAO8BGlkAA6xVy3ajMAzd9yty2DuEPJrQQ9zdLGcz7SxmM8dgEdwYm7FN
+        m/z92IRXHqTpSXfo6soW0rUUPe9yPnoHpZkUay8YT7wRiERSJjZr7/XlB1p5
+        z/ghSkptZA4KP4xGEaM4eJyEj9PpPIx8aznQOpOMCIOsvVR0E07flnG+TLeL
+        bBb5fa9jp0xpgwTJYSQYX3tGleD5lYuTIU8i84KI/RkOOWH8DC0yKc7PSMnu
+        DPuAWDNz4T4FxABFxIzMvoC1R61pWA4enk6CJZosULB4CcKn2eRpMf8T+V1A
+        FV8W9GvxXcDh/qroKGXAqW5TosyghCiq60OJUmTvOe+x/4BYLGac23YiQqkC
+        rRv80Mj5tulgjTWdRsdd7sMdebiNNWGwmc1tl1tae7VRAKZJfIAEOwOCuqpd
+        pXGZEM7M0FUKNvYFDDgLqQ3hyD4LwOE8mCwjvw/1f6cURu0rGBFeZGQ6+OOn
+        zNktTFHaHrDkE+q1gt+n6fqUO5VdneEP6NLqVeD5JJiuVo4jWtyJGrnr8G+m
+        ic2stfuMTHJqZTpUAqc4N4wY4fhVbIX8EPakDutoh1LKFDGtSyISwI54jrYR
+        91f2C4+vozphG6td/Pqrx2zRhk8hZqb75YPZOVNS8ibxWEoORHjYlc5RK2dH
+        LpVtC7IvpuTuB3qHnnqaENgVTFX5oFwKk+FgGvln4AX2Hoiy5ZtOjugVesQG
+        epp7SriGOqqXSQaEm8wKBbq0e1hDYznZACoVx5kxhX7yfaI1GD2OFWHCjaWN
+        /cEPsh9b7fgF2ecgzN8cTCbpXy430n+3Gh0XYvMM4p0pKRxhrYmgsdzZkdue
+        395o9eReQ0zEtkvtCG2o1VCd42C1CiK/NhqfTUVJ3tN2A7QEBQWxOvopra/+
+        7nySlkm1pLv4Dmtouox1oljhenG8hbpnZuQWBH4LQxXTyD9Yja8U7F9ZzbK4
+        0rStDLNLTmGSLhbLeZguwjRI6WxFH5M0CSyQzherOLWaGQxtz/6GyfQOIpdI
+        0+2Aplp/L0LZNA4v7mJFqtfe38xHQDX7onoOwsXFfjokz1b3V2bH9bV9fWlf
+        W9k3LOyb1vXVZX1lVd+4qG9d07cu6ZtX9KcL+luWyN1PIPJ7amsNsGYnJ/zw
+        HwAA//8DALmSa3A7DAAA
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:07 GMT
+  recorded_at: Mon, 15 May 2017 19:30:55 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -191,8 +190,17 @@ http_interactions:
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>d5vhvt</payment-method-token>
-          <customer-id>820153523</customer-id>
+          <payment-method-token>j99rbd</payment-method-token>
+          <billing>
+            <first-name>John</first-name>
+            <last-name nil="true"/>
+            <street-address>10 Lovely Street Northwest</street-address>
+            <locality>Herndon</locality>
+            <postal-code>21088-0255</postal-code>
+            <region>AL</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </billing>
+          <customer-id>160962249</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -201,7 +209,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.74.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -214,7 +222,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 May 2017 07:28:09 GMT
+      - Mon, 15 May 2017 19:30:57 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -235,49 +243,52 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"e9ecb43ca68b72941aeef420c489b06e"
+      - W/"86b1a17cf292f240bee3d9f027ac4cb8"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 467d662f-e265-4b12-8fd1-c80b4d59af3a
+      - 9759f085-6ec5-49c5-8f74-17f0eb6bd08b
       X-Runtime:
-      - '0.500569'
+      - '0.538724'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAkeEFkAA9xYTW/jNhC9768IfGckO3bjLBRtty0K9NAemt2i6GVBiSOL
-        DUWqJOXY++s7FCVZiqgkPRQompM18zjkfHDmMcmHUyWujqANV/J+tb6OV1cg
-        c8W4PNyvPn/6kexXH9J3idVUGppbRKXvrq4SztJ4w7brr3KfRPjhZMZS25iU
-        NrZUmn8FlkSdyGntuYbUUAFJ1P50srzRGnc7E24UwU0h/fzwQxLNxQ5MK9VI
-        m27i6zhOou7LKSrQeUmlJTTPnZDgeYyFKlPCJlFI2562yUhAdyW5uF9Z3cAq
-        8tYp2tJvgirNEIn2f73zf2S9ufn43fdJNGharzVQC4xQe+Uicb9i+Gl5BSt0
-        bn1L4h2J95/i2/eb/fv47g+Mx7CgXd/U7J+tvyzoom6sQn/ch0/lHtftbnab
-        mz6XKC64NpZIWsFzP1Ep6LIuV1VN5TmggYpyEZA/QWa4DdmqSyVD8oKeZtGP
-        xn4lGRcCa/jiY27+XeeM1QBYHoxpMCbk/cmCZC4NixChciq4DZnXcMC7FwqR
-        wksm/DW5267j2yQai/pjY8nq87JXXu1WECrqkm7ehLp5DSUbzAfP57kapQdd
-        KxrJQhdq0Jiu0qnW9DxRYjxHvSlkpKbacgyHAWsFVIB3d7oiZPzSxF4zPzKb
-        UZuXQUzJ63pcjaGS/l+W5AsF8p+pxXF2uuZICg6Cma4WjoaA1koTjFGtpIGg
-        ay1u5PoUnf6MM+tFQG9imrVnoJ+8lRcxrRvH43zlXOigB5wNT/SMmj/BVzmO
-        GzNPbFJrleNuGIf+dtAW3lq62T9sf/wde89LoKmV6VHWsRvrS9qFlRYrOP1Y
-        o+bo6MYSog0tY9ydBIM/h818PSqeuwQVmHhcgbWTgZ5HpHGkAHfx830BZemJ
-        eLoSVMEJqrof5ZlSAqhcpQUVxlGlAdBTB/SC5FT3k8yqR5Ap2x3LI5Id/+U1
-        GZfpNl5v9nvXbuW4k2zT9X6/TqLuo7ssaJS01Ow3bihWy/DdN4uaa5/MSklb
-        putNEs2EM+wZqEZesokn4Fba7duNbeJaTUswPz9chvlFejllqUQb7nAD4RU9
-        AGm0SEtra/M+iqjBJm2uM025dBenq/hr7JxRTc+ud3+pAKuVfRHqoKIj+n9d
-        y8MHkEeulXSAe0Mly9QJScRgv+t2GmqKzOIX5QrQ//aaEqiwJZ4Yea18lOpJ
-        JtFI5kEMMm4vev/ZqRqNicMqPDTCEbgR6rlmGAWOp+K0u0BHsu689KyVGCF6
-        QRc+YxpshjjM5OMFM5FOm6sqiNNSmUPqtptL+zgp1uQt/75sfZF5UCP5Xw10
-        NwnFGHmOvVintNjtbrd3xe6uWBfsZs++yYt8jYJiu9tnBZbi4lJv+QiyUsSw
-        x4WbNug7Mjm9ad3jhpQcy1KfJ4xhmLYtAtBQl0B3PZGWo6Kq30jVB/xg4cVX
-        VYtYehj5gBqMwFD53/bvIlf7GDLTh8cddcRzjMLOBimtOR5pLvcOR889HiRd
-        lHyPFDTMm5rM5JrXi7xqpB86WksaSY1zXDGC1IW4eAZ6wDMkHkvbIBaP/Gwf
-        NygIzoQAKWTctOUd1IG3ovp6W+hOSy8a7Cfzs02NIuFyL2P0a6GEB72fFfhc
-        lSDSByU4a/D10ws8a9VHN+EKgKXZ5PZWT8SndKbFWGSNNp74MrD4sjN925qo
-        wgkasebw9lPM7D8Cb4TDyTmN7VqHj+FeEFiuyPVCBps8D5BiTMuC787zurEQ
-        qo9uzhAukbs1/hXiZqvvM19cn0miJdCU/YwcnZKkMQFaBL1uq6VMr9kaeJUt
-        sa8QvGOu+ACPXqhpxCYdJH33NwAAAP//AwDXYMt4chIAAA==
+        H4sIAPEBGlkAA6xYS3PbNhC+51dodIdJylIiZWimbjN9ZJJMp4l76MUDkksR
+        MQmwAChL+fVdECRFiqDtTuuTuPthgV3s44PDd8eyWBxAKib4zTK48pcL4IlI
+        Gd/fLO++/ky2y3fRq1BLyhVNNKKiV4tFyNKo3B2DMv7OQw8/jExpqmsV0Vrn
+        QrLvkIZeKzJafaogUrSA0Gt+GllSS4m7nQhTguCmEN19eR96U7EB01LUXEcr
+        /8r3Q6/9MooSZJJTrglNEiMkeB6loYxFoUPPpW1OW8fEoVtwVtwstaxh6Vnr
+        FG3JF0GFTBGJ9v/Y2T8SrK5vf/wp9HpN47UEqiElVC9MJG6WKX5qVsISnQve
+        EH9Dgs3XYPf22n+7efMXxqNf0Kyvq/TfrT8vaKOutEB/zIe9yuC1v3u9Wq13
+        3V2iOGNSacJpCZd+orKg87pElBXlJ4cGSsoKh/wRYsW0y1aVC+6SZ/Q4ib43
+        9CuMWVFgDp99XD84nYs+iBxTeCD4Lx4qLQEwR9JUglJR4C8+igMUp8WXRrH4
+        LKTOH0FpUxojaBuhowaemquyYlfoRUILpk/RryB5KvDsvcQCJOxNld5+DL32
+        ZxtLgdVY2HpaBf52S/zVZhN6Q3nnHya4PNlw3HG8mhQdwBRSC5EtbjHELKEY
+        7yFsvNIYI7SocrrCkj5Dh/K5Fde44ta15Nq1hNfNcaLt2r9Y02ma3BikAwYo
+        q3nqKuBeo9rKolLS00iJdzPohS4jFZWaYUAVaF1ACdgrxitcxs9N8znzA7Mx
+        1UnuxOSsqobZ7yqh/7++xyntagAvT2+Hymazq0ucM9h53nOaPqEepOaLUNfP
+        odr8m/ap4e20zZhkDIpUtblwUASkFJJgjCrBFThda3AD18fo6BPOyCcBnYnx
+        rbmtPIlp3DgcLqS/YTlOhAa6x0bySE+o+QY2y3G8qenFhpUUCe6Gceiqgzbw
+        xtL2/S8ffseSfxI0tjI+SuD7o+XTgzp0GjM4uq1QczD0Zg7RhDZNmTkJBn8K
+        m/h6ECwxF5ThxeMKzJ0Y5DQitSEhuIvlEzMoTY/E0iOnCo5QVh11iIUogPJl
+        lNFCGWrWAzqqgl6QhMpucmrxADz6ttvJGANgv6wmZjxa+8FquzXtlg87yToK
+        ttsAJ5X9aIsFjZKGCv7JlBkn/XfXLCom7WWWgus8ClahNxFOsCegEnnQyh+B
+        G2m7b0sTiGk1DaFtJtREej5lLoom3O4Gwkq6B1LLIsq1rtRbz6MKm7S6iiVl
+        3BROm/FX2Dm9ip5M774vAbM1vS/EXngH9P+q4vt3wA9MCm4AN4ryNBZHJC29
+        /bbbSagoMpnPwiSg/W01OdBC53hiM7UfuHhEcjCQWVAKMdNnvf1sVbXEi8Ms
+        3NeFIYwD1KWmHwWGF+O0O0MHsva89CRFMUB0gjZ8StXYDHGY8YczZiQdN1eR
+        EaOlPIHoPPKH0i5OIq2Thu+ftz7LLKjm7O8a2kpCMUaeYS+WEc02mzfrXbbZ
+        ZUGWXm/T10mWBCjI1pttnGEqzi61lg/AS0FU+jBTab2+Ja/jSmsfUyRnmJby
+        NGIM/bRtEICG2gs05YnPAFSU1QufBj2+t/DkK65BzD3EbEAVRqDP/B+6d5jJ
+        fQyZ6sJjjjrgOUpgZ4OIVgyPNJVbh71Lj3tJGyXbIwvq5k11rBLJqlleNdD3
+        Ha0hjaTCOS5SgtSFmHg6esAFEo8ltROLR77YxwwKgjPBQQpTppr0durAWhFd
+        vs10p7kXFPaT6dnGRpFwmZc4+jWTwr3ezgp8HnMooi+iYGmtMKVbgWWt8mAm
+        XAYwN5vM3uKR2CudaDEWcS2VJb4paHxJdo+mscp9QQPW7N5+jJn8B+KFcDga
+        p7FdS/cxzAsC0xW5nstgnSQOUozXMuO78byqzbNsmh/tnCGMI3er7SvEzFbb
+        Z+5Nnwm9OdCY/QwcHZOkIQGaBT1vq6FMz9nqeZXOsa8QrDGTfIBHz8Q4YqMO
+        Er36BwAA//8DAF9z/mPiEgAA
     http_version: 
-  recorded_at: Mon, 08 May 2017 07:28:09 GMT
+  recorded_at: Mon, 15 May 2017 19:30:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/transaction/import/valid/capture.yml
+++ b/spec/fixtures/cassettes/transaction/import/valid/capture.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:43 GMT
+      - Mon, 15 May 2017 19:31:24 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,40 +50,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"c45b4bddf0676baa6e2859c3c3d22cb9"
+      - W/"d776dc374b4a739b4e8624154b4a2129"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ff2c3b6f-0079-489a-8e27-9cf6186ffa82
+      - 21aaed1a-4483-496f-a9be-6305376b8519
       X-Runtime:
-      - '0.419086'
+      - '0.314869'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAK+BklgAA6xVTXPiMAy991cwuZuQACXtBPe2x71su4e9dJxYIV4cO2s7
-        Lfz7tUO+KITSoTMc0NOTrUjPUvy0K/jkDZRmUqy9YDrzJiBSSZnYrL2X5x8o
-        8p7wXZxW2sgCFL6bTGJG8TyMgmC+jGLfGg6zvjQnwiBrrxTdPIR/V0mxyrbL
-        fB77Q69jZ0xpgwQpYCIYX3tGVeD5tYuTMU8qi5KI/QkOBWH8BC1zKU7PyMju
-        BHuHRDNz5j4FxABFxEzMvoS1R61pWAEeDmfBCs1C+3uezR4Xq8dF+Cf2+4A6
-        virp1+L7gMP9dc1RxoBT3aVEmUEpUVQ3hxKlyN5z3mP/AbFYwji33USEUgVa
-        t/ihj7TrYIO1jUZHTR6iPXe8iw1htJftZec72ni1UQCmzXuEBDsDgrqiXaRx
-        mRLOzNhVCjZW/yPOUmpDOLKPAvDDIpitYn8IDT+nEkbtaxgRXuYkHP3wj8z5
-        NUxR2R6w9BPqpYLfJunmlBuFXZ/hj8jSylXgxSwIo8hxRIc7TSN3Hf7NNLGZ
-        dfaQkUtOrUzHSuAU52YRIxy/iK2Q78Ke1GM97VBKmSGmdUVECtgRT9Eu4vbK
-        Xv/2eqbTtbHSxS+/BswObfkUEmb6Lz6YvTMjFW/zTqTkQISHXeUctXb25ErZ
-        riD7YCru8h8c+tHThsCuZKrOBxVSmBwHYeyfgGfYeyDKVi+cHdFr9IgN9GPu
-        GeEamqhBJjkQbnKrE+jTHmAtjRVkA6hSHOfGlPrR94nWYPQ0UYQJN5U29gPf
-        yX5qpeOXZF+AMK8FmFzSVy430n+zEp2WYvME4o0pKRxhrYmgidzZgdud391o
-        5eQeQ0LEtk/tCG2p9Uxd4CCKgthvjNZnU1GSD6TdAh1BQUmsjn5K62v+9z5J
-        q7Re0X18j7U0XSU6Vax0vTjeQf0rM3ILAqfZytwvYv9gtb5KsH9VPcqSWtO2
-        MsyuOIVJtlyuFg/Z8iELMjqP6H2apYEFssUySjKrmdHQ7uxvGExvIAqJNN2O
-        aKrzDyKUTePw4s5WpH7sw718BNSjL27GIJxd6x9n5Mni/sLouLy0L6/sSwv7
-        inV91bK+uKovLOor1/S1S/raFX31gv50PX/LCrn5BcT+QGydAdbs5YTv/gMA
-        AP//AwAP/Dc/NwwAAA==
+        H4sIAAwCGlkAA6xVPXPjOAzt8ys86hlZjrW2MzLTXbnNba64ZgcSIYtnitSS
+        VGL/+yNlfTm2vM5kO+HhgYSARyB5OZRi9obacCW3QfQ4D2YoM8W43G2D1x9/
+        kXXwQh+SrDZWlajpw2yWcEaXm/m3dRxvlknoLA86Z1aAtMTZK812m8V/q7Rc
+        5fu4eErCsdezc66NJRJKnEkutoHVNQZh4xIw5clUWYE8XuBYAhcXaFUoeXlG
+        DocL7B1Tw+2V+zSCRUbAzuyxwm3AnGl5iQFdzKMVmcckin9Em+en6Hmx/DcJ
+        h4Amvq7Y5+KHgNP9TdFJzlEw06fEuCUZaGbaQ0FrOAbee+4/IQ5LuRCunQQY
+        02hMh58aKbOugy3WdZqcd3kMD+TpNraEyWZ2t11vaes1ViPaLvEJEh4sSuar
+        dpMmVAaC26mrNO7cC5hwVspYEMQ9C6SbZTRfJeEYGv9OLa0+NjABURWwmPzx
+        j8yne5iydj3g2W+otwr+NU23p3xR2c0Z4YQunV4lXc6jxXrtObLHvaiJv47+
+        ww24zHp7zCiUYE6mUyXwivPDiIOgr3Iv1bt0Jw3YQDuVUuWEG1ODzJB64iXa
+        R3y9sp94fAPVC9s67dLXv0fMHu34DFNuh18+mYMzh1p0iadKCQQZUF86T22c
+        A7nWri3EvZha+B8YHfrR04XgoeK6yYeUStqCRoskvACvsI8I2pVvMT+jN+gZ
+        G9nH3HMQBtuoUSYFgrCFEwoOaY+wjsZL2CGptaCFtZV5DkMwBq15TDVw6cfS
+        zv3gOxwfnXbCCo4lSvuzRFso9lOonQrfnEYfK7l7QfnGtZKesDUgWaoObuT2
+        5/c3Oj3515CC3A+pnaEdtRmqSxqt11EStkbnc6loJUba7oCeoLECp6Pvyvna
+        78GnWJ01S3qIH7COZurUZJpXvhfnW2h4ZlbtUdK0lHnlBHyyOl8t+a+6mWVp
+        o2lXGe6WnKaQx/FqucnjTR7l7GnNvmV5FjkgX8brNHeamQztz/4Dk+kNZamI
+        YfsJTfX+UYR2aZxe3NWKNK99vJnPgGb2Je0cxKuL/eOQvFjdn5kdt9f27aV9
+        a2XfsbDvWtc3l/WNVX3nor53Td+7pO9e0b9d0H9kiXz5CSThSG29gc4c5EQf
+        /gcAAP//AwAgxKQ+OwwAAA==
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:43 GMT
+  recorded_at: Mon, 15 May 2017 19:31:24 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -98,8 +98,17 @@ http_interactions:
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>cf7t64</payment-method-token>
-          <customer-id>32811358</customer-id>
+          <payment-method-token>bmnfp4</payment-method-token>
+          <shipping>
+            <first-name>John</first-name>
+            <last-name nil="true"/>
+            <street-address>10 Lovely Street Northwest</street-address>
+            <locality>Herndon</locality>
+            <postal-code>21088-0255</postal-code>
+            <region>AL</region>
+            <country-code-alpha2>US</country-code-alpha2>
+          </shipping>
+          <customer-id>490685594</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -108,7 +117,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -121,7 +130,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:43 GMT
+      - Mon, 15 May 2017 19:31:27 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -142,54 +151,57 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"7ae6b76174e0638e6ac152ee2188b68e"
+      - W/"fd33946a107248d7db19a42fed3ad4ba"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c14b01f0-08e3-44df-a9ce-be9792569d6c
+      - 0faa3132-2e5e-49a3-afca-304dfa4f1593
       X-Runtime:
-      - '0.347815'
+      - '0.398149'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAK+BklgAA9xY30/kNhB+v78C7bvJZtmFBYXQa09VK/UqtRyt1BfkxJON
-        S2KntrPs3l/fcZxkE+IAfahUFfFAZj6PPT8885no7lAWZ3tQmktxuwjPl4sz
-        EKlkXOxuFw9fvifbxV38ITKKCk1Tg6j4w9lZxFm82VQ6TL/SKMAPK9OGmlrH
-        tDa5VPwrsChoRVZrjhXEmhYQBc2fVpbWSuFuR8K1JLgpxA/3n6JgKrZgWspa
-        mDjcnC+XUdB+WUUJKs2pMISmqRUSPI82UCayMFHg0zanrRPi0Z0JXtwujKph
-        ETjrFG2pd0GlYohE+79edz/k47fffQpXF+so6LWN5wqoAUaoObPRuF0w/DS8
-        hEW8WoZXZLnC3y/L5c366mZ98QfGpF/QrK8r9s/Wnxa0kddGok/2w6XzYrUN
-        w4vNtksnSjOutCGClvDSVVQWdF6XyrKi4ujRQEl54ZE/Q6K58dmqcil88owe
-        JgkIhm5FCS8KLOOTi+xfdk4bBYAVwpgCrX3eHwwIZrMwCylkSgtufOYV7PD6
-        +UIk8Z4V7qZcr8PlVRQMRd2xsWrVcd4rp7YrCC2qnK7ehbp4CyVqzAdPp7ka
-        pAddy2rBfHeq1+i20KlS9DhSYjwH7clnpKLKcAyHBmMKKAGv73iFz/ipj71l
-        fmA2oSbNvZicV9WwGn0l/b8syVcK5D9Ti8PstL2RZBwKptta2GsCSklFMEaV
-        FBq8rjW4getjdPwZx9argM7EOGsvQD86K69iGjf2++nKqdBCdzganukRNX+C
-        q3KcNnqa2KhSMsXdMA7d7aANvLH00w+ff7n8HXvPa6CxlfFRwqWd7HPamZUG
-        Kzj+WKFmbxnHHKIJLWPcngSDP4VNfN1LntoEZZh4XIG1k4CaRqS2vAB3ceN9
-        BmXogTjG4lXBAcqqm+SJlAVQsYgzWmjLlnpAxxzQC5JS1U0yI59AxGl2ZS6R
-        Zrgvp0m4iNfLcLXd2nYrhp1kHYfbbRgF7Ud7WdAoadjZb1wjsTt9d82i4sol
-        s5TC5HG4ioKJcII9AlVIS1bLEbiRtvu2Y5vYVtNwzIf70zA/SU+nzGXRhNvf
-        QHhJd0BqVcS5MZW+CQKqsUnr80RRLuzFaSv+HDtnUNGj7d2PJWC1ssdC7mSw
-        R//PK7G7A7HnSgoLuNVUsEQekET09ttup6CiyCx+lrYA3d9OkwMtTI4nRmor
-        noR8FlEwkDkQg4Sbk959tqpaYeKwCnd1YfnbAPVS048CS1Vx2p2gA1l7XnpU
-        shggOkEbPq1rbIY4zMTTCTOSjpurzIjVUpFCbLebSrs4SVanDQU/bX2SOVAt
-        +F81tDcJxRh5jr1YxTTbbK7W19nmOgszdrFll2mWhijI1pttkmEpzi51lvcg
-        Skk0e5q5ab2+JZPjm9a+b0jOsSzVccQY+mnbIAANtQm01xNZOSrK6p1Mvcf3
-        Fl59WDWIubeRC6jGCPSV/033NLK1jyHTXXjsUQc8R0vsbBDTiuORpnLncPDS
-        417SRsn1yIL6eVOd6FTxapZXDfR9R2tII6lwjktGkLoQG09PD3iBxGMp48Xi
-        kV/sYwcFwZngIYWM66a8vTpwVmRXbzPdae5Fg/1keraxUSRc9nGMfs2UcK93
-        swJfrAKK+F4WnNUaS7oVONaq9nbCZQBzs8nuLZ+JS+lEi7FIaqUd8WVg8GWn
-        u7Y1UvkTNGDN/u3HmMk/Bd4Jh4N1Gtu18h/DviCwXJHr+QzWaeohxZiWGd+t
-        51VtwFcf7ZwhXCB3q90rxM5W12cebZ+JgjnQmP0MHB2TpCEBmgW9bauhTG/Z
-        6nmVybGvELxjtvgAj57JccRGHST+8DcAAAD//wMAGzhcs3USAAA=
+        H4sIAA8CGlkAA7RYwXLbNhC95ys0usMkZSmWPDRSJ5lO20kzbZP0kEsGJEAR
+        MQmwAChL/fouCJIiRdB2Z1qfxN2HBXbxsHhw/OZYFosDU5pLcbeMrsLlgolU
+        Ui72d8svn39E2+Ub/Co2ighNUgMo/GqxiDnF63WWm+/qOg7gw9q0IabWmNQm
+        l4r/zWgctCbrNaeKYU0KFgfNT2tLa6VgthPiWiKYlOEvn97HwdRswaSUtTA4
+        2lyFYRy0X9ZRMpXmRBhE0tQaEaxHG1YmsjBx4PM2q60T5PEtBC/ulkbVbBm4
+        6ARiqRdBpaKAhPh/7Lo/dP/23ftodb2Og97bZK4YMYwiYha2GndLCp+Gl2yJ
+        V2F0g8INijafo93tdXS7ev0VatIPaMbXFX35+BsYfx7QVl4bCTnZj3Y7d+Hr
+        7WazW3f7CeaMK22QICW7zBWcBZn3pbKsiDh5PKwkvPDYH1miufHFqnIpfPaM
+        HCc7EAzzihNeFMDjc44i/X+T00YxBhShVDGtfdkfDRPUbsMspJApKbjxhVds
+        D+fPVyIJB61wR2W3jsKbOBiaumUDbdVpPivntiMQKaqcrF6Eun4OJWrYD55O
+        92qwPZBaVgvqO1S9R7dMJ0qR08gJ9Rz0J1+QiijDoRyaGVOwksH5HY/wBT83
+        sufCD8ImxKS5F5Pzqhqy0UfpnpL4F5mLOBgY/jte4ihcfJAHVpwWnxrH4qNU
+        Jn9k2tiOPYL+a9rin5gSVMLae8uQvPj+Qxy0P6fcXUXhdovC1WbzHIHxFwHd
+        gkIC0NX0QmaL+4ZlBFrAEDbLbbhpztChfZbnMOLeN+T6CdLj7Tq8GNN5miMw
+        JEXbk1HGWUF1S8GDRkwpqRCUvZJCsybIhFwWNyjYGI1/hevySUAXYrz5F6Cf
+        XZQnMU0ah8N05NRooXvYvEdyAs935g4X3HJ62uLiSskUZoM6dIeSNPAm0m+/
+        v/367jMw5inQOMp4KVFoFcWcd2akgUOB7yvwHKzSmUM0paWU25VA8aewSa4H
+        yVO7QRlsPIwAviRMTStSWz0CszhZMYMy5IicUvK62JGVVacgEikLRsQSZ6TQ
+        VqX1gE6xQBYoJaq7QI18YAInpcgqEA3uy3kSLvA6jFbbre3yYti71jjabiPo
+        Du6jPToQFDWq8E+u7RHuv7v+U3HlNrOUwuQ4WsXBxDjBnhhRIIdW4QjcWNt5
+        W7WAbK9qtG3TFSbW8ypzWTTl9ndgXpI9Q7UqcG5MpW+DgGi4G/RVoggX9uC0
+        jL+CXh1U5GSvjG8lA7bSb4Xcy+AA+V9VYv+GiQNXUljAnSaCJvII2qWP3/ZO
+        xSoCguajtAR0v50nZ6QwOazYdsoHIR+hIQ9sDkRZws3Z7z5bV61g44CF+7qw
+        unGAuvT0l4+VyHDJnqEDW7teclKyGCA6Q1s+rWtohnCHioczZmQdt1qZIesl
+        ImX43GaH1q5OktZpI/3PU59tDlQL/lfN2pMEZqg8h16sMMk2m5v1Ltvssiij
+        11v6Os3SCAzZerNNMqDi7FAX+cBEKZGmDzMnrfe3GnZ80tp3Fco50FKdRkKl
+        v98bBINA7Qba4wmvAXCU1QtfCD2+j/Dkg65BzL3JXEE1VKBn/g/dk8xyH0qm
+        u/LYpQ7klZbQ2RgmFYclTe0u4eAy497SVsn1yIL45Vqd6FTxalbODfx9R2u0
+        Kqrg7pYUgRpCtp6eHnCBhGUp48XCki/msRcFgjvBo0Up1w29vT7mosiObzPd
+        ae4hBf1kurZxUFBv9lEOec1QuPe7uwJeyoIV+JMsOK01ULo1OLGsDvaGyxib
+        u5vs3PIRuS2deKEWSa2009uUGXhQdkJ17PJv0ECs+6cfYyb/jHghnB1t0tCu
+        lX8Z9uECdAWt5wtYp6lHZ8O2zORuM69qK4Wn/GjvGcQFaLfaPX7s3er6zDfb
+        Z+JgDjRWP4NExyJpKIBmQc/HaiTTc7F6XWVy6CsIzpglH4OlZ3JcsVEHwa/+
+        AQAA//8DAISWG8TtEgAA
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:43 GMT
+  recorded_at: Mon, 15 May 2017 19:31:27 GMT
 - request:
     method: put
-    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/55ps1cza/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/44fhtjr3/submit_for_settlement
     body:
       encoding: UTF-8
       string: |
@@ -203,7 +215,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.75.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -216,7 +228,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Feb 2017 00:47:44 GMT
+      - Mon, 15 May 2017 19:31:28 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -237,50 +249,53 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"aa50ea2fb1cc6d766950bdc820816e69"
+      - W/"f45910e6315a4cb0f1ff8907e72af612"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5ae949b6-96df-4e29-9e27-b6ef2a2f6c43
+      - bbf41c66-b91f-4e5f-b125-aafa0e452564
       X-Runtime:
-      - '0.347408'
+      - '0.447411'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALCBklgAA9xY227cNhB9z1cY+05rtd6N14GsNG1QtEAToE3SAn0xKHG0
-        Yi2RKkmtd/P1HYq6WpRtoCgQ1PCDNXM45Fw4c+jo7aksLo6gNJfidhVerlcX
-        IFLJuDjcrr58/pHsV2/jV5FRVGiaGkTFry4uIs7i3a7SYfqVRgF+WJk21NQ6
-        1nVScmOA3WVS3WkwpoAShImCFmCx5lxBrGkBUdD8aWVprRTufSZcS4JHgPjL
-        p/dRMBdbMC1lLUwc7i7X6yhov6yiBJXmVBhC09QKCZ5OGygTWeARfNrm7HVC
-        PLoLwYvblVE1rAJnnaIt9SKoVAyRaP+3m+6HvPv+h/fh5mobBb228VwBxYAR
-        ai5sNG5XDD8NL2EVb9bhNVlv8Pfzev1me/1me/UnxqRf0KyvK/by9VtcPyxo
-        I6+NRJ/sh0vu1WYfhle7fZdclGZcaUMELeGxq6gs6LIulWVFxdmjgZLywiN/
-        gERz47NV5VL45Bk9zRIQjN2KEl4UWNSDi+w/dk4bBYAVwpgCrX3enwwIZrOw
-        CClkSgtufOYVHPAy+kIk8Z4V7qbcbMP1dRSMRd2xsWrVedkrp7YrCC2qnG5e
-        hLp6DiVqzAdP57kapQddy2rBfHeq1+i20KlS9DxRYjxHzcpnpKLKcAzH0Joe
-        rfAZp7XJpeJfnzc/MptQk+ZeTM6ralyNvpL+X5bkEwXyzdTiODttbyQZh4Lp
-        thaOmoBSUhGMUSWFBq9rDW7k+hQdf8Cx9SSgMzHN2iPQz87Kk5jGjeNxvnIu
-        tNADjoYHekbNX+CqHKeNnic2qpRMcTeMQ3c7aANvLP3y04dfX/+Bvecp0NTK
-        9Cjh2k72Je3CSoMVHL+rUHME5l3dIJrQMsbtSTD4c9jM16PkqU1QhonHFVg7
-        Cah5RGrLC3AXN94XUIaeiGMsXhWcoKy6SZ5IWQAVqzijhbZsqQd0zAG9IClV
-        3SQz8h5EnGbX5jXSDPflNAkX8XYdbvZ7227FuJNs43C/D6Og/WgvCxolDTv7
-        nWukecN31ywqrlwySylMHoebKJgJZ9gzUIW0ZLOegBtpu287toltNQ3j/PJp
-        GOaDdDhlLosm3P4Gwkt6AFKrIs6NqfSbIKAam7S+TBTlwl6ctuIvsXMGFT3b
-        3n1XAlYruyvkQQZH9P+yEoe3II5cSWEBt5oKlsgTkojeftvtFFQUmcVHaQvQ
-        /e00OdDC5HhipLbiXsgHEQUjmQMxSLgZ9O6zVdUKE4dVeKgLy99GqMeafhRY
-        qorTboCOZO156VnJYoToBG34tK6xGeIwE/cDZiKdNleZEaulIoXYbjeXdnGS
-        rE4bCj5sPcgcqBb87xram4RijDzHXqximu1219ubbHeThRm72rPXaZaGKMi2
-        u32SYSkuLnWWjyBKSTS7X7hpvb4lk9Ob1r52SM6xLNV5whj6adsgAA21CbTX
-        E1k5KsrqhUy/x/cW2lfUQEjGD6sGsfQ2cgHVGIG+8r/rnka29jFkuguPPeqI
-        52iJnQ1iWnE80lzuHA7mHv/7IGyfCsJL3prfVkh6SVs4bmwU1E8l60SnileL
-        VHOk75t8w6NJhdRGMoJsjtjoetriIyQeSxkvFo/8aB87OwmOSQ9PZlw3N96r
-        A2dFdldwoWEvPfKwxc7PNjWKHNT+vwD9WrjVvd6NT3zECyjiT7LgrNZ4y1uB
-        I/LqaId+BrA0ru3e8oG4lM60GIukVtq9BRgYfOzqrpNPVP4EjR4S/u2nmNn/
-        SV4Ih5N1GieY8h/DPqqwXJH++gzWaep5J2BaFny3nle1AV99tKOXcIF0tnYP
-        M0s3XOu9s603CpZAU0I4cnTKG8eccBH0vK2GRT5nq6eaJse+QvCO2eIDPHom
-        pxGbdJD41T8AAAD//wMAa4J8u5YTAAA=
+        H4sIABACGlkAA8xYTXPbNhC951dodIdJylIseWikTjKdtpNm2ibpIRcPSIAm
+        YhJgAVCW+uu7IEiKFEHbnbYz9UncfVhgF/vx4PjNoSwWe6Y0l+JmGV2EywUT
+        qaRc3N8sv3z+Hm2Xb/Cr2CgiNEkNoPCrxSLmFK/XWW6+qcs4gA8r04aYWmNd
+        JyU3htG7TKo7zYwpWMmEiYMWYLHmWDGsScHioPlpZWmtFOx9RFxLBEdg+Mun
+        93EwFVswKWUtDI42F2EYB+2XVZRMpTkRBpE0tUIEp9OGlYks4Ag+bXP2OkEe
+        3ULw4mZpVM2WgbNOwJZ6EVQqCkiw/9uu+0O3b9+9j1aX6zjotY3nihEIGCJm
+        YaNxs6TwaXjJlngVRlco3KBo8znaXV9G16vXXyEm/YJmfV3Rl6/fwvrTgjby
+        2kjwyX60l7sLX283m926u10QZ1xpgwQp2bmvoCzIvC6VZUXE0aNhJeGFR/7I
+        Es2Nz1aVS+GTZ+QwuYFg6Fec8KKArD75KNL/1jltFGOQIpQqprXP+4Nhgtpr
+        mIUUMiUFNz7zit1DNfpCJKHQClcqu3UUXsXBUNQdG9JWHee9cmq7ApGiysnq
+        RajL51Cihvvg6fSuBtcDrmW1oL6i6jW6zXSiFDmOlBDPQbfyGamIMhzCcepN
+        Zyt8xkltcqn4n8+bH5hNiElzLybnVTXMRl9K9ymJf5K5iIOB4N/LSxyFiw9y
+        z4rj4lOjWHyUyuSPTDcdewT922mLf2BKUAln7yXD5MW3H+Kg/TnN3VUUbrco
+        XG02zyUw/iKgW1BwALqaXshscdtkGYEWMITN5jZMmhN0KJ/Nc1hx61ty+UTS
+        4+06PFvTaZoSGCZF25NRxllBdZuCe42YUlIhCHslhWaNkUlyWdwgYGM0/hnG
+        5ZOAzsT48s9APzorT2IaN/b76cqp0ELv4fIeyRE035grLphyetri4krJFHaD
+        OHRFSRp4Y+mXX99+ffcZMuYp0NjK+ChRaBnFnHZmpYGiwLcVaPaMelc3iCa0
+        lHJ7Egj+FDbxdS95ai8og4uHFZAvCVPTiNSWj8AujlbMoAw5IMeUvCp2YGXV
+        MYhEyoIRscQZKbRlaT2gYyzgBUqJ6gaokQ9M4KQUWQWkwX05TcIFXofRaru1
+        XV4Me9caR9ttBN3BfbSlA0ZRwwp/59qWcP/d9Z+KK3eZpRQmx9EqDibCCfbI
+        iAI6tApH4Eba7tuyBWR7VcN0m64wkZ5OmcuiCbe/A/OS3DNUqwLnxlT6OgiI
+        htmgLxJFuLCF02b8BfTqoCJHOzLuSgbZSu8KeS+DPfh/UYn7N0zsuZLCAm40
+        ETSRB+Auvf22dypWESA0H6VNQPfbaXJGCpPDiW2nfBDyERryQOZAlCXcnPTu
+        s1XVCi4OsvC+LixvHKDONf3wsRQZhuwJOpC15yVHJYsBohO04dO6hmYIM1Q8
+        nDAj6bjVygxZLREpw6c2O5R2cZK0Thvqf9r6JHOgWvA/atZWEogh8hx6scIk
+        22yu1rtss8uijF5u6es0SyMQZOvNNskgFWeXOst7JkqJNH2YqbRe33LYcaW1
+        ryyUc0hLdRwRlX6+NwgGhtoLtOUJrwFQlNULXghX8ELo8b2F9vV24kHDB12D
+        mHuTuYBqiECf+d91TzKb+xAy3YXHHnVAr7SEzsYwqTgcaSp3DgdTj/95ELZP
+        BeElb9z/V0h6SZs4bmwUxM9g60SnilezDHeg75t8Q99RBXRGUgQEEdnoetri
+        GRKOpYwXC0c+28fOTgRj0kPPKddNxXt1zFmRXQnONOy5tyW02OnZxkaB0Nr/
+        U4BfM1Xd6934zIkQrMCfZMFpraHKW4F7P6i9HfoZY3Pj2u4tH5G70okWYpHU
+        SrsnCGUG3tgddx+r/Bc0eL/4tx9jJv+feSGcHazTMMGU/xj2LQfpCvTXZ7BO
+        U8/TA65lxnfreVXb18E0P9rRi7gAOlu796ClG6713tnWGwdzoDEhHDg65o1D
+        TjgLet5WwyKfs9VTTZNDX0FQYzb5GBw9k+OIjToIfvUXAAAA//8DADZviHwO
+        FAAA
     http_version: 
-  recorded_at: Thu, 02 Feb 2017 00:47:44 GMT
+  recorded_at: Mon, 15 May 2017 19:31:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -364,10 +364,19 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       let(:other_payment_method) { FactoryGirl.create(:payment_method) }
 
       let(:source_without_profile) do
-        SolidusPaypalBraintree::Source.create!(payment_method_id: gateway.id, user_id: user.id)
+        SolidusPaypalBraintree::Source.create!(
+          payment_method_id: gateway.id,
+          payment_type: payment_type,
+          user_id: user.id
+        )
       end
+
       let(:source_with_profile) do
-        SolidusPaypalBraintree::Source.create!(payment_method_id: gateway.id, user_id: user.id).tap do |source|
+        SolidusPaypalBraintree::Source.create!(
+          payment_method_id: gateway.id,
+          payment_type: payment_type,
+          user_id: user.id
+        ).tap do |source|
           source.create_customer!(user: user)
           source.save!
         end
@@ -429,11 +438,19 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
           let(:user) { FactoryGirl.create(:user) }
 
           let!(:source_without_profile) do
-            SolidusPaypalBraintree::Source.create!(payment_method_id: gateway.id, user_id: user.id)
+            SolidusPaypalBraintree::Source.create!(
+              payment_method_id: gateway.id,
+              payment_type: payment_type,
+              user_id: user.id
+            )
           end
 
           let!(:source_with_profile) do
-            SolidusPaypalBraintree::Source.create!(payment_method_id: gateway.id, user_id: user.id).tap do |source|
+            SolidusPaypalBraintree::Source.create!(
+              payment_method_id: gateway.id,
+              payment_type: payment_type,
+              user_id: user.id
+            ).tap do |source|
               source.create_customer!(user: user)
               source.save!
             end

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::Source, type: :model do
-  it 'is invalid without a payment_type set', :pending do
+  it 'is invalid without a payment_type set' do
     expect(described_class.new).to be_invalid
+  end
+
+  it 'is invalid with payment_type set to unknown type' do
+    expect(described_class.new(payment_type: 'AndroidPay')).to be_invalid
   end
 
   describe '#payment_method' do

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::Source, type: :model do
+  it 'is invalid without a payment_type set', :pending do
+    expect(described_class.new).to be_invalid
+  end
+
   describe '#payment_method' do
     it 'uses spree_payment_method' do
       expect(described_class.new.build_payment_method).to be_a Spree::PaymentMethod

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -95,7 +95,8 @@ describe SolidusPaypalBraintree::TransactionImport do
     let(:transaction) do
       SolidusPaypalBraintree::Transaction.new nonce: 'fake-valid-nonce',
         payment_method: payment_method, address: transaction_address,
-        payment_type: "ApplePay", phone: '123-456-7890', email: 'user@example.com'
+        payment_type: SolidusPaypalBraintree::Source::PAYPAL,
+        phone: '123-456-7890', email: 'user@example.com'
     end
 
     before do


### PR DESCRIPTION
The hosted fields does not set the payment_type value on credit card
sources. This leads to sources which type can’t be recognized anymore.