### PR TITLE
Set source payment_type in cc hosted fields

### DIFF
--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -21,5 +21,6 @@
   </div>
 
   <div class="clear"></div>
+  <input type="hidden" name="<%= prefix %>[payment_type]" value="<%= SolidusPaypalBraintree::Source::CREDIT_CARD %>">
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
 </div>

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -10,7 +10,7 @@ module SolidusPaypalBraintree
 
     initializer "register_solidus_paypal_braintree_gateway", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
-      Spree::PermittedAttributes.source_attributes << :nonce
+      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type]
     end
 
     def self.activate

--- a/spec/features/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/braintree_credit_card_checkout_spec.rb
@@ -38,7 +38,7 @@ describe 'entering credit card details', type: :feature, js: true do
   context "with valid credit card data", vcr: { cassette_name: 'checkout/valid_credit_card' } do
     include_context "checkout setup"
 
-    it "checks out successfully" do
+    before do
       within_frame("braintree-hosted-field-number") do
         fill_in("credit-card-number", with: "4111111111111111")
       end
@@ -48,13 +48,19 @@ describe 'entering credit card details', type: :feature, js: true do
       within_frame("braintree-hosted-field-cvv") do
         fill_in("cvv", with: "123")
       end
-
       click_button("Save and Continue")
       within("#order_details") do
         expect(page).to have_content("CONFIRM")
       end
       click_button("Place Order")
+    end
+
+    it "checks out successfully" do
       expect(page).to have_content("Your order has been processed successfully")
+    end
+
+    it "sets the payment type of source to CreditCard", :pending do
+      expect(SolidusPaypalBraintree::Source.last.payment_type).to eq('CreditCard')
     end
   end
 

--- a/spec/features/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/braintree_credit_card_checkout_spec.rb
@@ -59,7 +59,7 @@ describe 'entering credit card details', type: :feature, js: true do
       expect(page).to have_content("Your order has been processed successfully")
     end
 
-    it "sets the payment type of source to CreditCard", :pending do
+    it "sets the payment type of source to CreditCard" do
       expect(SolidusPaypalBraintree::Source.last.payment_type).to eq('CreditCard')
     end
   end


### PR DESCRIPTION
The hosted fields does not set the payment_type value on credit card
sources. This leads to sources which type can’t be recognized anymore.