### PR TITLE
Always use the same zipcode in address factory

### DIFF
--- a/lib/solidus_paypal_braintree/factories.rb
+++ b/lib/solidus_paypal_braintree/factories.rb
@@ -4,3 +4,14 @@ FactoryGirl.define do
   # Example adding this to your spec_helper will load these Factories for use:
   # require 'solidus_paypal_braintree/factories'
 end
+
+FactoryGirl.modify do
+  # The Solidus address factory randomizes the zipcode.
+  # The OrderWalkThrough we use in the credit card checkout spec uses this factory for the user addresses.
+  # For credit card payments we transmit the billing address to braintree, for paypal payments the shipping address.
+  # As we match the body in our VCR settings VCR can not match the request anymore and therefore cannot replay existing cassettes.
+  #
+  factory :address do
+    zipcode '21088-0255'
+  end
+end

--- a/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:16 GMT
+      - Mon, 08 May 2017 07:28:14 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,48 +50,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"45cd5142d5334ed8197cfb02cf8377ad"
+      - W/"8009b27669a694e81106c9aa7a073c72"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f16c99ab-9227-4e74-92fd-24f206939064
+      - b625a1c3-aceb-4fd4-ac3e-ed968e30cca6
       X-Runtime:
-      - '0.133506'
+      - '0.085657'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALjxlFgAA6RW226jSBB9n6+I8j470IRskDIzii9gkGmPMW6g36DbCZdu
-        8PgChq/fajKbi5QdjbSKrFh0ddWpc04Vvv9+keKq3R2ORVN/vdb/0q6vdjVr
-        eFE/fb3ehvbnu+vv3z7dM1Hs6tPnU1Pt6m+frq7u21Scd992vYdo7A1pZJ3d
-        sumXUy/ncdBkhrffSVtTzwMpzhSRni28fVavi1Xh5X750Pvl1vQdKrB0TR/R
-        HA80p7PKTIY8x7O8wMNDv5pNch/BXzi/SeAOddaaH7l9grCgkV3hGS1olBgJ
-        IuWjg3t4ptEoeEzitQU1LrjXOr+Aj77u/bC5+LPmgosbpGqvwmpYhcnBnz10
-        vn3R4X+PpS6YxE0SmVqMRPUj5FCTmb5sjERqBpVHPZ1hxkO4U9KOR94xjfBj
-        ioj5I9KNVJ4OuwUv2cwHjKcmk0kBnJQZMmUaccJkp/pv+CLo2NC0S2R36cYc
-        oF6VSOtmKb0+icSZLzzoj+fcIUYSV+cEWadVCb331gn4LlPHhhi/xYZX0aHq
-        05IXWchlOpAGYsrMESKrFQ+T/dJILkuE20zSPTVIn8TBPkM3Iy7Ic8wcovQZ
-        3HKfxZsO+DRRGnsQr4tfer3gc4uuSNBlDzHaGnKT2DuC7kW6CDS28G+XvZUz
-        pzozZJ+p47W7qVkwaYPuAWhDaqgtOLLNpQQ8YaPhmd9mEWBCeQ4xw3L4iG+/
-        /bdmPPLlHl1pDwwRjemkz6burStzjS8mw6q4a5MYnBRDrt9wOfYREy21P7oP
-        z6cmgnqnrP8zbcZ8kZlnCwGex4rLv936g9y/+lhG9jmJLiZ3RMn+sMZ/cFM8
-        gmbcyRW/8y3MAY89EQCWRF4EhfqQS6cQwxzbhM/xd2cjbhnsmTE5JrFYJZEu
-        lL5bIxBZBJ5YrJ/9/OwvT+VwKztniLa48gpa4lsiREKE52zne3sVCjOae2hd
-        Nzqd5QcyvzPYHPypw6zadsdDbxHOLbItvZ7ZQgu3Xh6E9o+dg8vV3O0DFLR8
-        Hvykg7dKZwIrntUe4dIud+Qtvw/Ke2Ln2CfmXMTor43VsSl4pSbgB29CDcWp
-        8nTwbg6VLjQG/8WTI92YMKtayx1rGDUFn1Hyfzz2HPfBnMDskTJFls6nZgdc
-        d0nUvdyjjgA9sbZ+Uz+ryTGbKp9djpnBXYUd9NJYTQRoAn3RPZPWGebpzOdm
-        G0qicWT1ae/eUmkfGdrC3MCZFD3so5PyocKUISpBzzPdjFzBOdxzSBW+zCXs
-        AEnB21jVeTvPs3c+kHrOwCewP2EnQh7wpopPAW8amfU64urOWJdpBPzvHWn0
-        LvfrbpvbJXChv+SuMex1HbBetJFX2GMMekkM4TFkzTIUjD4lBM/dWoM+cQs1
-        Ff/vZuGVh9c9v1EYCtdgMqhXofcTI++EET3g6Gn0APABnN4pv7T0eZ/nbAFe
-        IZN8t3Fv4R04cMfWeOyrmFOG8OF5T474+90Wt9TZqjOy7dXuwjqrQS+JzTWy
-        KuD91hUkDJRX3+EKFLd7KoVgxcjvy9myxnkmgyIznpTegiv9+re7dntmrzN7
-        TgE/4B54POng3azekSvwpQHfDwz8EcF7PI1xrnBnkQ39KO3tno6YbNDlSd2v
-        IKbMDAp4PP4Ya1/vvzz/Dvh0/+X9L4R/AAAA//8DAPp+PzVYCAAA
+        H4sIAA4eEFkAA6RWXW+jOBR9n19R9X12wAzdRurMqE0CAQVnQogNfgM7LR82
+        ZJsEAr9+r8luP6TuaKR9iIjw9b3H55x7zd2Ps5JX7e75UDT1t2vzD+P6alfz
+        RhT107frbeR8vr3+8f3THZfFrj5+PjbVrv7+6erqrk3lafd91/uIxf6Q0snJ
+        K5t+OfVzEYdNZvn7nXIM/T5U8sQQ6fnC32f1ulgVno3V3GbRfEgGp2KzxAgG
+        zw4ifk4GVrDIQ5gGVkJxtYrW52DGe4g3E7U1gzIscflkJGViYLo1VhGsIc9i
+        5VP/6OKeUcdgNHxM4vUkKO/PuDc6vDG6lbPu8ND0q1lzxtOvA44qazW7t/CQ
+        PAez+y5wziY8oY4pucJNQm0jRrL6GYmeudwOVGMlyrCYOpjpDHMRwZ6SdYL6
+        h5TixxQR+yc1rVQdn3cLUfJZ0Cfo2GQqKYCTMkO2SqkgXHVwfr8Ri7DjQ9Mu
+        kdOlG3uAelWiJl+Xyu8TKk9i4UtGRS5cYiVxdUrQ5Lgq10bQT47Ad5m6DsQE
+        Lbb8ig1Vn5aiyCKh0oE0EFNmrpRZrXl42C+t5LxEuM0U2zOL9Ekc7jP0dcQF
+        eQ6ZS7Q+g1fus3jTFYzaKI19iDflRS//BZ9XdEWCznuIMdaQm8T+AXQv0kVo
+        8EVws+wnOXerE0fOibl+u5vaBVcO6B6CNqSG2lIgx14qwBM1Bp4FbUYBE8pz
+        iBmWw0d8B+2/NeORL+/gKWfgiBjcJH029W48lRti8TCsits2ifHAYsj1Cy7H
+        c8TESJ2P9sP7qY2g3jHrf0+bMR+182whwfNYc/mnV3+Q+59zLKlzSujZFq4s
+        +W/W+A9uikfQTLi55ne+RaQUsS9DwJKos2RQH3KZDGK469jwO/xqbcStwj23
+        Hg5JLFcJNaXWd2uFMqPgicX64ueLv3ydw6ucnCPW4sovWIlviJQJkb67ne+d
+        VSRtOvfRum5MNsufyfzW4nPwpwm96jidiPxFNJ+Qben33JFGtPXzMHJ+7lxc
+        ruZeH6KwFfPwLzb4q3QmseZZzxGhnHJH3vJ7r70nd65z5O5Zjv7aTDo+Ba/U
+        BPzgPzBLc6o9Hb7rQ60Li8F/8cOBbWzoVaMV7mQYNQWfMfJ/PHaJ+6BPoPdI
+        maKJKaZ2B1x3Ce1e9jFXgp7YWL+pn9XkkE21z86HzBKexg56GbwmEjSBc7E9
+        V5MT9NNJzO02UsQQaNKnvXfDlHPgaAt9A2tK9jCPjtqHGlOGmAI9T2wzcgXr
+        sM8lVfTSlzADFANvY13nbT/P3vlAmTkHn8D8hJkIecCbOj4FvCm16zUVes9Y
+        lxsE/O8fGH2X+3W2zZ0SuDBfctcY5roJWM/GyCvMMQ5nSSzpczSZZSgcfUoI
+        nnu1AefELdTU/L/rhVceXuf8ho53ksVVWK8i/y+M/CNG7BnTp9EDwAdweqv9
+        0rLLPM/5ArxCHvLdxruBO3AQrmOIONAxxwzh58ucHPH3uy1umbvVa2Tb69mF
+        TV6DXgrbazSpgPcbT5Io1F59hyvU3O6ZkpIXI78va8sa55kKi8x60npLofXr
+        387a7Ym/9uwpBfyAexDxQwd3s74jV+BLC/4/c/AHhXs8jXGucWfUgfNo7Z2e
+        jZgc0OVJ768gpswsBnh88Rgb3+6+XL4DPt19ef+F8DcAAAD//wMAscaBIFgI
+        AAA=
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:16 GMT
+  recorded_at: Mon, 08 May 2017 07:28:14 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -108,7 +109,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -121,7 +122,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:17 GMT
+      - Mon, 08 May 2017 07:28:17 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -142,40 +143,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"b20f948bc9aff9b11600d5b0944a922c"
+      - W/"efdbb1e8ef2843da468e28a8669a20c7"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e0046eb2-a15b-414b-a4d5-aa5db64f63a8
+      - 5e8a998c-30b9-4d7a-8313-0bd00923abc1
       X-Runtime:
-      - '0.354531'
+      - '0.366375'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALnxlFgAA6xVy3ajMAzd9yty2DtAHiXtIe5ulrOZdhaz6TFYBE+Mzdim
-        Tf5+bMIrTUjTk+7Q1ZUtpGspftoVfPIGSjMp1l44DbwJiFRSJjZr7+X5B1p5
-        T/guTittZAEK300mMaN4HkTR4n4ZxL41HGZ9aU6EQdaOFN08zP5GSRFl22U+
-        j/2h17EzprRBghQwEYyvPaMq8PzaxcmYJ5VFScT+BIeCMH6ClrkUp2dkZHeC
-        vUOimTlznwJigCJiJmZfwtqj1jSsAA/PgjBCwQwF8+dZ+BgGj2H0J/b7gDq+
-        KunX4vuAw/11zVHGgFPdpUSZQSlRVDeHEqXI3nPeY/8BsVjCOLfdRIRSBVq3
-        +KGPYt52sMHaRqOjJg/RnjvexYYw2sv2svMdbbzaKADT5j1Cgp0BQV3RLtK4
-        TAlnZuwqBRur/xFnKbUhHNlHAfhhEQZR7A+h4e9Uwqh9DSPCy5zMRn/8I3N+
-        DVNUtgcs/YR6qeC3Sbo55UZh12f4I7K0chV4EYSz1cpxRIc7TSN3Hf7NNLGZ
-        dfaQkUtOrUzHSuAU52YRIxy/iK2Q78Ke1GM97VBKmSGmdUVECtgRT9Eu4vbK
-        Xv/2eqbTtbHSxS+/BswObfkUEmb6Pz6YvTMjFW/zTqTkQISHXeUctXb25ErZ
-        riD7YCru8h8c+tHThsCuZKrOBxVSmByHs9g/Ac+w90CUrd4sOKLX6BEb6Mfc
-        M8I1NFGDTHIg3ORWJ9CnPcBaGivIBlClOM6NKfWj7xOtwehpoggTbipt7A++
-        k/3USscvyb4AYV4LMLmkr1xupP9mJTotxeYJxBtTUjjCWhNBE7mzA7c7v7vR
-        ysk9hoSIbZ/aEdpS65m6wOFqFcZ+Y7Q+m4qSfCDtFugICkpidfRTWl/z3fsk
-        rdJ6RffxPdbSdJXoVLHS9eJ4B/WvzMgtCDyfp5mwr/hgtb5KsH9VPcqSWtO2
-        MsyuOIVJtlxGi4ds+ZCFGZ2v6H2apaEFssVylWRWM6Oh3dnfMJjeQBQSabod
-        0VTnH0Qom8bhxZ2tSP3Yh3v5CKhHX9yMQTi71j/OyJPF/YXRcXlpX17Zlxb2
-        Fev6qmV9cVVfWNRXrulrl/S1K/rqBf3pev6WFXLzC4j9gdg6A6zZywnf/QcA
-        AP//AwDVQHlhNwwAAA==
+        H4sIABEeEFkAA6xVTXObMBC951d4uCuAYxecwcqtx16a9NBLR6DFqBYSlYRj
+        //tKmC/HxnEmubFv30rL7tNu8rQv+WwHSjMp1l54H3gzEJmkTGzW3svzdxR7
+        T/guyWptZAkK381mCaN4GXyL42i5WiS+tRxonVlBhEHWjhTdrOZ/o7SM8u2y
+        eEj8sdexc6a0QYKUMBOMrz2javD8xsXJlCeTZUXE4QyHkjB+hlaFFOdn5GR/
+        hr1Cqpm5cJ8CYoAiYmbmUMHao9Y0rAQPz4MwQsESBfFzED3O48cw+p34Q0AT
+        X1f0Y/FDwPH+pugoZ8Cp7lOizKCMKKrbQ4lS5OA576n/iFgsZZzbdiJCqQKt
+        O/zYyKroOthiXafRaZfH8ECebmNLmGxmd9vllrZebRSA6RKfIMHegKCualdp
+        XGaEMzN1lYKNfQETzkpqQziyzwLwahEGUeKPofHv1MKoQwMjwquCzCd//C3z
+        4RamqG0PWPYO9VrBP6fp9pRPKrs5w5/QpdWrwIsgnMex44ged6JG7jr8i2li
+        M+vtMaOQnFqZTpXAKc4NI0Y4fhFbIV+FPWnABtqxlDJHTOuaiAywI56jfcTn
+        K/uBxzdQnbCN1S5++Tli9mjHp5AyM/zy0RycOal5l3gqJQciPOxK56iNcyDX
+        yrYF2RdTc/cDo0PferoQ2FdMNfmgUgpT4HCe+GfgBfYBiLLlmwcn9AY9YQN9
+        m3tOuIY2apRJAYSbwgoFhrRHWEdjJdkAqhXHhTGVfvR9ojUYfZ8qwoQbSxv7
+        g6/kcG+141fkUIIwf0owhaR/uNxIf2c1el+JzROIHVNSOMJaE0FTubcjtz+/
+        v9Hqyb2GlIjtkNoJ2lGbobrAYRyHid8anc+moiQfabsDeoKCilgd/ZDW134P
+        PknrrFnSQ/yAdTRdpzpTrHK9ON1CwzMzcgsCF/GuNFbAR6vz1YL9q5tZljaa
+        tpVhdskpTPLlMlqs8uUqD3P6ENNvWZ6FFsgXyzjNrWYmQ/uzv2Ay7UCUEmm6
+        ndBU7x9FKJvG8cVdrEjz2seb+QRoZl/SzkG4uNjfDsmz1f2R2XF9bV9f2tdW
+        9g0L+6Z1fXVZX1nVNy7qW9f0rUv65hX97oL+kiXy6SeQ+CO19QZYc5ATvvsP
+        AAD//wMAGlQS/DsMAAA=
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:17 GMT
+  recorded_at: Mon, 08 May 2017 07:28:17 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -190,8 +191,8 @@ http_interactions:
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>33cfn8</payment-method-token>
-          <customer-id>30774650</customer-id>
+          <payment-method-token>h8vmt4</payment-method-token>
+          <customer-id>506887594</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -200,7 +201,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -213,7 +214,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:19 GMT
+      - Mon, 08 May 2017 07:28:19 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -234,49 +235,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d5d092c889dffbb68179a05880c8a89d"
+      - W/"ef79d88bc176db2adaade05612d562e3"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6fdf7e53-6323-489a-a1c0-44dc34e8bbe4
+      - de6b5641-3250-4f07-aceb-d1a3befb57ef
       X-Runtime:
-      - '0.517359'
+      - '0.457375'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALvxlFgAA9xY32+kNhB+v78i2ncH2E0um4hwvV5VqVKvUptLVfXlZPCw
-        uAGb2maz27++YwwsLCZJHypVzdMy83ns+eGZz4k/HKryYg9KcynuV9FluLoA
-        kUnGxe5+9fjle7JdfUjexUZRoWlmEJW8u7iIOUs27/OcVjSKA/ywMm2oaXRC
-        G1NIxf8CFgedyGrNsYZE0xLioP1pZVmjFO52JFxLgptC8vjwXRzMxRZMK9kI
-        k6zDyzCMg+7LKipQWUGFITTLrJDgebSBKpWliQOftj1tkxKP7kLw8n5lVAOr
-        wFmnaEu9CSoVQyTa/+XW/ZFovfn47ac4GDSt1wqoAUaoubCRuF8x/DS8ghU6
-        F92QcE3CzZd1dBeFd9H2d4zHsKBd39Tsn60/Leiiro1Ef+xHl8rw5ubq/XXY
-        pxKlOVfaEEErOHcTlSVd1mWyqqk4ejRQUV565M+Qam58tupCCp88p4dZ8IOx
-        W3HKyxJL+OSi2Py7zmmjALA6GFOgtc/7gwHBbBYWIaXMaMmNz7yCHV49X4gk
-        3rHS3ZLbqyi8iYOxqD82Vqw6Lnvl1HYFoWVd0PWbUJvXUKLBfPBsnqtRetC1
-        vBHMd58Gje4KnSpFjxMlxnPUmnxGaqoMx3BoMKaECvDqTlf4jJ962GvmR2ZT
-        arLCiyl4XY+r0VfS/8uSfKFA/jO1OM5O1xtJzqFkuquFvSaglFQEY1RLocHr
-        WosbuT5FJ59xZL0I6E1Ms3YG+sFZeRHTurHfz1fOhRa6w9HwTI+o+QNcleO0
-        0fPExrWSGe6GcehvB23hraXfPv+4+fQz9p6XQFMr06NEoZ3qS9qFlQYrOPlY
-        o2Zv2cYSog0tY9yeBIM/h8183Uue2QTlmHhcgbWTgppHpLGcAHdx430BZeiB
-        OLbiVcEBqrqf5KmUJVCxSnJaasuUBkDPHNALklHVTzIjn0Akm02Wiy3C2y+n
-        SblIrsJovd3adivGneQqibZb5G3dR3dZ0ChpmdmvXFOsluG7bxY1Vy6ZlRSm
-        SKJ1HMyEM+wRqEJasg4n4Fba7duNbWJbTcsvHx9Ow/wkPZ2ykGUbbn8D4RXd
-        AWlUmRTG1PouCKjGJq0vU0W5sBenq/hL7JxBTY+2d3+tAKuVfS3lTgZ79P+y
-        FrsPIPZcSWEB95oKlsoDkojBftftFNQUmcVP0hag++00BdDSFHhipLXiSchn
-        EQcjmQMxSLk56d1np2oUJg6rcNeUlr+NUOeaYRRYmorT7gQdybrz0qOS5QjR
-        C7rwad1gM8RhJp5OmIl02lxlTqyWigwSu91c2sdJsiZr6fdp65PMgRrB/2yg
-        u0koxshz7MUqofn19c3VbX59m0c522zZ+yzPIhTkV9fbNMdSXFzqLO9BVJJo
-        9rRw0wZ9RyanN61725CCY1mq44QxDNO2RQAa6hJoryeyclRU9RuZ+oAfLLz4
-        qGoRS+8iF1CNERgq/5v+WWRrH0Om+/DYo454jpbY2SChNccjzeXO4eDc40HS
-        Rcn1yJL6eVOT6kzxepFXjfRDR2tJI6lxjktGkLoQG09PDzhD4rGU8WLxyGf7
-        2EFBcCZ4SCHjui1vrw6cFdnX20J3WnrRYD+Zn21qFAmXfRijXwslPOjdrMDX
-        qoAyeZAlZ43Gku4EjrWqvZ1wOcDSbLJ7y2fiUjrTYizSRmlHfBkYfNnpvm1N
-        VP4EjVizf/spZvYPgTfC4WCdxnat/MewLwgsV+R6PoNNlnlIMaZlwXfred0Y
-        8NVHN2cIF8jdGvcKsbPV9Zmvts/EwRJoyn5Gjk5J0pgALYJet9VSptdsDbzK
-        FNhXCN4xW3yAR8/lNGKTDpK8+xsAAP//AwC1lKvKcRIAAA==
+        H4sIABMeEFkAA9xYTW/jNhC9768IfGdkO/bGCRSl2xZFC7RF0ey2QC8LShxZ
+        bChSJSnH3l/foSjJUkQl6aFA0Zysmcch54Mzj4nvj6W4OIA2XMm7xepyubgA
+        mSnG5f5u8enjd2S3uE/exVZTaWhmEZW8u7iIOUs2Txu9X39ZxxF+OJmx1NYm
+        obUtlOZfgMVRK3Jae6ogMVRAHDU/nSyrtcbdToQbRXBTSD49fBtHU7ED01LV
+        0ibr5eVyGUftl1OUoLOCSktoljkhwfMYC2WqhI2jkLY5bZ2SgO5CcnG3sLqG
+        ReStU7Sl3wRVmiES7f964//Ian314etv4qjXNF5roBYYofbCReJuwfDT8hIW
+        6Nzqmiy3ZLn7uLy+Xe9uVzd/YDz6Bc36umL/bP15QRt1YxX64z58KrfL97vd
+        9fZm0+USxTnXxhJJS3juJyoFnddlqqyoPAU0UFIuAvInSA23IVtVoWRIntPj
+        JPrR0K845UJgDZ99rIp/1zljNQCWB2MajAl5f7QgmUvDLESojApuQ+Y17PHu
+        hUKk8JIJf01uNqvldRwNRd2xsWT1ad4rr3YrCBVVQddvQl29hpI15oNn01wN
+        0oOu5bVkoQvVa0xb6VRrehopMZ6D3hQyUlFtOYbDgLUCSsC7O14RMn5uYq+Z
+        H5hNqc2KIKbgVTWsxlBJ/y9L8oUC+c/U4jA7bXMkOQfBTFsLB0NAa6UJxqhS
+        0kDQtQY3cH2MTn7CmfUioDMxztoz0A/eyouYxo3DYbpyKnTQPc6GJ3pCzZ/g
+        qxzHjZkmNq60ynA3jEN3O2gDbyw9/PL799c/Yu95CTS2Mj7KaunG+px2ZqXF
+        Ck4+VKg5OLoxh2hCyxh3J8HgT2ETXw+KZy5BOSYeV2DtpKCnEakdKcBd/Hyf
+        QVl6JJ6uBFVwhLLqRnmqlAAqF0lOhXFUqQd01AG9IBnV3SSz6hFkUuwOpcXp
+        7b+8JuUy2SxX693OtVs57CSbZLXbreKo/WgvCxolDTX7jRuK1dJ/d82i4ton
+        s1TSFskKqd9EOMGegGrkJevlCNxI233bsU1cq2kI5qeH8zA/S8+nLJRowh1u
+        ILykeyC1FklhbWVuo4gabNLmMtWUS3dx2oq/xM4ZVfTkevfnErBa2Weh9io6
+        oP+XldzfgzxwraQD3BkqWaqOSCJ6+22301BRZBY/K1eA/rfXFECFLfDEyGvl
+        o1RPMo4GMg9ikHJ71vvPVlVrTBxW4b4WjsANUM81/ShwPBWn3Rk6kLXnpSet
+        xADRCdrwGVNjM8RhJh/PmJF03FxVTpyWygwSt91U2sVJsTpr+Pd567PMg2rJ
+        /6qhvUkoxshz7MU6ofl2e725ybc3+SpnVzv2PsuzFQryzXaX5liKs0u95QPI
+        UhHDHmduWq9vyeT4prWPG1JwLEt9GjGGfto2CEBDbQLd9URajoqyeiNV7/G9
+        hRdfVQ1i7mHkA2owAn3lf9W9i1ztY8hMFx531AHPMQo7GyS04nikqdw7HD33
+        uJe0UfI9UtAwb6pTk2lezfKqgb7vaA1pJBXOccUIUhfi4hnoAc+QeCxtg1g8
+        8rN93KAgOBMCpJBx05R3UAfeiurqbaY7zb1osJ9MzzY2ioTLvYzRr5kS7vV+
+        VuBzVYJIHpTgrDZY0q3As1Z9cBMuB5ibTW5v9UR8SidajEVaa+OJLwOLLzvT
+        ta2RKpygAWsObz/GTP4j8EY4HJ3T2K51+BjuBYHlilwvZLDOsgApxrTM+O48
+        r2oLofpo5wzhErlb7V8hbrb6PvPZ9Zk4mgON2c/A0TFJGhKgWdDrthrK9Jqt
+        nlfZAvsKwTvmig/w6LkaR2zUQZJ3fwMAAP//AwB6rFllchIAAA==
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:19 GMT
+  recorded_at: Mon, 08 May 2017 07:28:19 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/checkout/valid_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/valid_credit_card.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:10 GMT
+      - Mon, 08 May 2017 07:28:03 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -50,48 +50,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"50758b9c074776fa4e5447f02831a27d"
+      - W/"21932142d9ae0f3421c922bda2f3a8a1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 558ce29d-f7b9-4d9e-b8aa-875726c7e62d
+      - ed88a57f-b834-4ce5-972e-5a3c76a1de43
       X-Runtime:
-      - '0.207785'
+      - '0.177070'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALLxlFgAA6RWXW+jOBR9n19R9X12wJRukTozaj4gWMGZEGLAb2CnBWKT
-        TD4g8Ovnmu72Q+qORtoHlAhf33t8zrnX3H+/KHnVbA7Hcld/vTb/Mq6vNjXf
-        ibJ++nq9jtzPd9ffv32657Lc1KfPp912U3/7dHV132TyvPm26TBiCe6z2Dn7
-        1a6bj3EhknCXW3i/Ua6h34dKnhmiHZ/hfV4vy0XpX4gKVaqITFGAFtHUDmIf
-        scm2TStXsopI0vsmi2hB4ulNWvntInroAuQjgtZ9MOFtEKU3ZPLQsii9kIgj
-        0gf2o0c6FrsGi8PHNFk6QfVwIZ3RBiU85rILot0lmMAzvrGC3u/IZNnDcwgg
-        T+BeTPjtiDIlV2SXxraRILn9EYmOedwO1M5KlWExdTSzCeEigj0Va0WMj1lM
-        HjNE7R+xaWXqdNjMRMUnQZei0y5XaQmcVDmyVRYLylUL58c7MQtb3u+aOXLb
-        bGX3UG+bKudmrnCXxvIsZliyWBTCo1aabM8pck6LamkEnXMCvqvMcyEmaIiF
-        t6zfdlklyjwSKuvpDmKq3JMyrzUPo/3cSi9zRJpcsT2zaJcm4T5HNwMuyHPM
-        Par16f1qnyertmSxjbIEQ7wpn/XCL/j8si1TdNlDjLGE3DTBR9C9zGahwWfB
-        7bxzCu5tzxy5Z+bhZjO2S65c0D0EbWgNtaVArj1XgCfaGWQSNHkMmFBRQEw/
-        7z/iO2j+rZkMfPlHX7k9R9TgJu3ysX/rq8IQs1G/KO+aNCE9SyDXb7gczpFQ
-        I3M/2g/vxzaCeqe8+zNthnyxXeQzCZ4nmsu//fqD3P+cYx675zS+2MKTFf/D
-        Gv/BTfkImgmv0PxO14hWIsEyBCypukgG9SGXySCGe64Nz/F3awNuFe65NTqm
-        iVyksSm1vmsrlHkMnpgtn/387C+sc/hbt+CINWSLS+jdWyplSiX21tO9u4ik
-        HU8xWtY7k02KA53eWXwK/jShV123FRGeRVOHrivccVca0RoXYeT+2HikWkz9
-        LkRhI6bhT9bjRTaRRPOs54hQbrWhb/l90N6TG889ce8iB3+tnJaPwSs1BT/g
-        EbM0p9rT4bs+1LqwBPyXjI5sZUOvGo3wnH7QFHzG6P/x2HPcB30CvUerDDmm
-        GNstcN2mcfuyj3kS9CTG8k39vKbHfKx9djnmlvA1dtDL4DWVoAmci+25cs7Q
-        T2cxtZtIUUMgp8s6/5Yp98jRGvoG1pTsYB6dtA81phwxBXqe2WrgCtZhn0e3
-        0UtfwgxQDLxNdJ23/Tx55wNlFhx8AvMTZiLkAW/q+AzwZrFdL2Oh9wx1uUHB
-        //jI4ne5X2fb1K2AC/Mld01grpuA9WIMvMIc43CW1JKYI2eSo3DwKaVk6tcG
-        nJM0UFPz/64XXnl4nfOreLiTLK7CehHhnwThE0HsQOKnwQPAB3B6p/3SsOd5
-        XvAZeIWOis3Kv4U7sBeea4gk0DGnHJHD85wc8HebNWmYt9ZrdN3p2UVMXoNe
-        ithL5GyB91tf0ijUXn2HK9Tc7pmSkpcDvy9r85oUuQrL3HrSekuh9eveztr1
-        mb/27DkD/IC7F8mohbtZ35EL8KUF/w8c/BHDPZ4lpNC489iF82jt3Y4NmFzQ
-        5Unv30JMlVsM8GDxmBhf7788fwd8uv/y/gvhFwAAAP//AwCHSPd7WAgAAA==
+        H4sIAAMeEFkAA6RWXW+jOBR9n19RzfvsgCndRurMqG0CAQUzIWCD38BOC8SG
+        bJNA4NfvNd3th9QdjbQPSAhf33t8zrnX3Pw4K3nRbZ8OVdt8+2z+YXy+2Da8
+        FVXz+O1zEjtfrj//+P7phstq2xy/HNvdtvn+6eLipsvlaft9O/iIpf6Y09nJ
+        q9thde+XIo3awvL3W+UY+nuk5IkhMvClvy+adRVW3hnHjxaO12PgBnYQe2Yw
+        X/QYJZfZWKoMBWNAcRXSxID3czB3yoBmFqZsl8VYYuqNGUqMMF6bzM16Fid2
+        FsvqwcUDo47BaPSQpetZUN+e8WD0eGP0obPu8dgO4bztg+FyCOMFCmpuhnP+
+        FMxv+8A5A4bbAStTcoXbjNpGiuTuZywG5nI7UK2VKcNi6mDmc8xFDHtq1gvq
+        H3KKH3JE7J/UtHJ1fNouRc3nwZChY1uorAJO6gLZKqeCcNXD+f1WLKOej223
+        Qk6fb+wR6u0yNbtcKX/IqDyJpS8ZFaVwiZWlu1OGZsewXhvBMDsC33XuOhAT
+        dNjyd2zcDXktqiIWKh9JCzF14UpZNJqHu/3Kys4rhLtCsT2zyJCl0b5AlxMu
+        yHMoXKL1Gb16X6SbvmLURnnqQ7wpn/XyX/B5VV9l6LyHGGMNuUnqH0D3Kl9G
+        Bl8GV6thVnJ3d+LIOTHX77b3dsWVA7pHoA1poLYUyLFXCvDErYHnQVdQwITK
+        EmLG1fgR30H3b8104ss7eMoZOSIGN8lQ3HtXnioNsbwbw+q6y1I8shRy/YLL
+        6RwpMXLno/3w/d5GUO9YDL+nzZSP2mWxlOB5rLn802s+yP3POVbUOWX0bAtX
+        1vw3a/wHN9UDaCbcUvO7SBCpRerLCLBk6iwZ1IdcJoMY7jo2PIdfrU24VbTn
+        1t0hS2WYUVNqfRMrkgUFTyzXz35+9pevc3g7p+SIdXjnV6zGV0TKjEjfTRZ7
+        J4ylTRc+WjetyeblE1lcW3wB/jShVx2nF7G/jBczktT+wB1pxIlfRrHzc+vi
+        Olx4Q4SiTiyiv9joh/lcYs2zniNCOfWWvOX3VntPbl3nyN2znPy1mfX8HrzS
+        EPCDf8cszan2dPSuD7UuLAX/pXcHtrGhV41OuLNx0hR8xsj/8dhz3Ad9Ar1H
+        6hzNTHFv98B1n9H+ZR9zJeiJjfWb+kVDDsW99tn5UFjC09hBL4M3RIImcC62
+        52p2gn46iYXdxYoYAs2GfPCumHIOHCXQN7Cm5ADz6Kh9qDEViCnQ88Q2E1ew
+        Dvtcsotf+hJmgGLgbazrvO3n+TsfKLPk4BOYnzATIQ94U8fngDendrOmQu+Z
+        6nKDgP/9A6Pvcr/OtoVTAxfmS+4Gw1w3AevZmHiFOcbhLJklfY5m8wJFk08J
+        wQuvMeCcuIOamv93vfDKw+uc39DpTrK4ipow9v/CyD9ixJ4wfZw8AHwAp9fa
+        Lx17nuclX4JXyF253XhXcAeOwnUMkQY65lgg/PQ8Jyf8wzbBHXMTvUaSQc8u
+        bPIG9FLYXqPZDni/8iSJI+3Vd7gize2eKSl5NfH7srZqcFmoqCqsR623FFq/
+        4e2sTU78tWdPOeAH3KNI73q4m/UdGYIvLXh/4uAPCvd4nuJS4y6oA+fR2jsD
+        mzA5oMuj3r+DmLqwGODxxUNqfLv5+vwf8Onm6/s/hL8BAAD//wMAJDYkD1gI
+        AAA=
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:10 GMT
+  recorded_at: Mon, 08 May 2017 07:28:03 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/customers
@@ -108,7 +109,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -121,7 +122,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:12 GMT
+      - Mon, 08 May 2017 07:28:07 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -142,40 +143,40 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d15fdef02465289f1cf37cf27a7dbc82"
+      - W/"622c6e958b6d93fef071f38a520983b1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b99c9cfd-cb44-47cf-a8e8-d25767c5d549
+      - db433ab2-6b82-422a-bf6e-f2689fcf614f
       X-Runtime:
-      - '0.440498'
+      - '0.567220'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALTxlFgAA6xVy3bbIBDd5yt8tCd62K7lHJnsuuymTRfd9CAxsqgRqIAS
-        ++8Lsl5+yHFOuhN3LjCaucxNnvcln72C0kyKjRc+Bt4MRCYpE9uN9/LjK4q9
-        Z/yQZLU2sgSFH2azhFG8itfzVRTEiW8XDrOxrCDCIBdUdLuO/qzScpXvlsU8
-        8cdRx86Z0gYJUsJMML7xjKrB85sQJ1ORTJYVEYcLHErC+AVaFVJcnpGT/QX2
-        Bqlm5sp9CogBioiZmUMFG4/apWEleDgKwhUKIhTMf0ThUxg8hdGvxB82NPvr
-        in5s/7DheH9Tc5Qz4FT3KVFmUEYU1e2hRCly8Fz0NH5ELJYyzm03EaFUgdYd
-        fuzj+kvXwRbrGo1OmjxGB+50F1vCZC+7y653tI1qowBMl/cECfYGBHVFu0nj
-        MiOcmamrFGyt/ieCldSGcGQfBeD1IgxWiT+Gxr9TC6MODYwIrwoSTf74OXN+
-        D1PUtgcse4d6q+Cfk3R7yieF3ZzhT8jSylXgRRBGcew4osedppG7Dv9kmtjM
-        +vWYUUhOrUynSuAU52YRIxy/iJ2Qb8KeNGAD7VhKmSOmdU1EBtgRL9F+x+cr
-        e//bG5hO18ZKF798HzF7tONTSJkZ/vi4HII5qXmXdyolByI87CrnqE1wINfK
-        dgXZB1Nzl//o0PNItwX2FVNNPqiUwhQ4jBL/ArzCPgBRtnpRcEJv0BM20PPc
-        c8I1tLtGmRRAuCmsTmBIe4R1NFaSLaBacVwYU+kn3ydag9GPqSJMuKm0tT/4
-        Rg6PVjp+RQ4lCPO7BFNI+pvLrfRfrUQfK7F9BvHKlBSOsNFE0FTu7cDtz+9v
-        tHJyjyElYjekdoJ21GamLnAYx2Hit4suZlNRko+k3QE9QUFFrI6+SRtrv4eY
-        pHXWWPSwf8A6mq5TnSlWuV6cetDwyozcgcBxvn3bm8Q/rrpYLdjfuhllaaNp
-        WxlmLU5hki+Xq8U6X67zMKfzmH7J8iy0QL5YxmluNTO5tT/7PwymVxClRJru
-        JjTVx0c7lE3j+OKuVqR57GNfPgGa0Ze0YxCu2vr5jLww7g+Mjtumfduybxn2
-        HXZ9l1nftOobRn2nTd9r0vda9N0G/a49/xcL+fQLSPyR2PoF2OUgJ/zwDwAA
-        //8DADuGuhw3DAAA
+        H4sIAAceEFkAA6xVTXOjOBC951e4uCuAY8Ykhcltj3PZyR72MiVQY7QWEiMJ
+        x/7328J8OTYepzI3+vVrqel+6k5eD5VY7EEbruTGCx8DbwEyV4zL7cZ7+/EX
+        ib3X9CHJG2NVBTp9WCwSztJ4GYTRU7R8Sny0HIjOvKTSErTXmm2fl/+ts2pd
+        7KISSVOvYxdcG0skrWAhudh4Vjfg+a1L0DlPrqqayuMFDhXl4gKtSyUvzyjo
+        4QJ7h8xwe+U+DdQCI9Qu7LGGjcfQtLwCL8XfX5MgIkH8I1i/LOOX4Nu/iT8G
+        tPFNzT4XPwac7m+LTgoOgpkhJcYtyalmpjuUak2PnvOe+08IYhkXAttJKGMa
+        jOnxUyNz03eww/pOk/MuT+GRPN/GjjDbzP626y3tvMZqANsnPkOCgwXJXNVu
+        0oTKqeB27ioNW3wBM85aGUsFwWcB6fMqDNaJP4Wmv9NIq48tTKioS7qc/fGP
+        zKd7mLLBHvD8N9RbBf+aprtTvqjs9gx/RpeoV5mugnAZx44jB9yJmrjr0n+4
+        oZjZYE8ZpRIMZTpXAqc4N4w4Femb3En1LvGkERtpp1KqgnBjGipzSB3xEh0i
+        vl7ZTzy+keqEbVG76dvfE+aA9nwGGbfjL5/M0VnQRvSJZ0oJoNJLXekctXWO
+        5EZjWwi+mEa4H5gc+tHTh8Ch5rrNh1RK2jINl4l/AV5hH4FqLN8yOKO36Bkb
+        2MfcCyoMdFGTTEqgwpYoFBjTnmA9jVd0C6TRIi2trc2L71NjwJrHTFMu3Vja
+        4g++0+Mjasev6bECaX9WYEvFfgq1Vf4eNfpYy+0ryD3XSjrCxlDJMnXAkTuc
+        P9yIenKvIaNyN6Z2hvbUdqiu0jCOw8TvjN6HqWglJtrugYGgoaaoo+8Kfd33
+        6FOsydslPcaPWE8zTWZyzWvXi/MtND4zq3YgUxbty71N/JPV+xrJfzXtLMta
+        TWNlOC45ndIiitar5yJ6LsKCPcXsW17kIQLFKoqzAjUzGzqc/Qcm0x5kpYhh
+        uxlNDf5JhMY0Ti/uakXa1z7dzGdAO/uSbg7C1cX+cUherO7PzI7ba/v20r61
+        su9Y2Het65vL+saqvnNR37um713Sd6/o3y7oP7JEvvwEEn+itsEANEc5pQ//
+        AwAA//8DAE5H8SY7DAAA
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:12 GMT
+  recorded_at: Mon, 08 May 2017 07:28:07 GMT
 - request:
     method: post
     uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
@@ -190,8 +191,8 @@ http_interactions:
           <options>
             <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
           </options>
-          <payment-method-token>8fgwxt</payment-method-token>
-          <customer-id>78937208</customer-id>
+          <payment-method-token>d5vhvt</payment-method-token>
+          <customer-id>820153523</customer-id>
           <type>sale</type>
         </transaction>
     headers:
@@ -200,7 +201,7 @@ http_interactions:
       Accept:
       - application/xml
       User-Agent:
-      - Braintree Ruby Gem 2.72.0
+      - Braintree Ruby Gem 2.74.0
       X-Apiversion:
       - '4'
       Authorization:
@@ -213,7 +214,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 03 Feb 2017 21:10:13 GMT
+      - Mon, 08 May 2017 07:28:09 GMT
       Content-Type:
       - application/xml; charset=utf-8
       Transfer-Encoding:
@@ -234,49 +235,49 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d576a1749ea44f1a80b0a7c9236bfc03"
+      - W/"e9ecb43ca68b72941aeef420c489b06e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - cc872171-246c-4919-bf75-0ba9df7b5603
+      - 467d662f-e265-4b12-8fd1-c80b4d59af3a
       X-Runtime:
-      - '0.518970'
+      - '0.500569'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIALXxlFgAA9xY32+kNhB+v78i2ncH2CSX3YiQ3rWq2krXh+ZSVX2JDB4W
-        N2BT22x2+9d3jIGFYJL0oVLVPC0zn8eeH575nPjuUJVne1CaS3G7is7D1RmI
-        TDIudrerh6/fk83qLvkQG0WFpplBVPLh7CzmLCme6qw6XudxgB9Wpg01jU5o
-        Ywqp+F/A4qATWa051pBoWkIctD+tLGuUwt2OhGtJcFNIHu6/i4O52IJpJRth
-        knV4HoZx0H1ZRQUqK6gwhGaZFRI8jzZQpbI0ceDTtqdtUuLRnQle3q6MamAV
-        OOsUbal3QaViiET7v2zdH4nWF58+fxsHg6b1WgE1wAg1ZzYStyuGn4ZXsELn
-        omsSrkl48XUd3UThTXTxO8ZjWNCub2r2z9afFnRR10aiP/bDpfJ6s724Xoeb
-        PpUozbnShghawUs3UVnSZV0mq5qKo0cDFeWlR/4MqebGZ6supPDJc3qYBT8Y
-        uxWnvCyxhE8ubj/+u85powCwOhhToLXP+4MBwWwWFiGlzGjJjc+8gh1ePV+I
-        JN6x0t2S7WUUXsfBWNQfGytWHZe9cmq7gtCyLuj6XaiLt1CiwXzwbJ6rUXrQ
-        tbwRzHefBo3uCp0qRY8TJcZz1Jp8RmqqDMdwaDCmhArw6k5X+Iyfethb5kdm
-        U2qywospeF2Pq9FX0v/LknylQP4ztTjOTtcbSc6hZLqrhb0moJRUBGNUS6HB
-        61qLG7k+RSdfcGS9CuhNTLP2AvSjs/IqpnVjv5+vnAstdIej4ZkeUfMHuCrH
-        aaPniY1rJTPcDePQ3w7awltL4Q+/ffn8E/ae10BTK9OjRKGd6kvahZUGKzj5
-        VKNmb9nGEqINLWPcngSDP4fNfN1LntkE5Zh4XIG1k4KaR6SxnAB3ceN9AWXo
-        gTi24lXBAaq6n+SplCVQsUpyWmrLlAZAzxzQC5JR1U8yI59AJJt893xAruO+
-        nCblIrkMo/VmY9utGHeSyyTabKI46D66y4JGScvMfuWaYrUM332zqLlyyayk
-        MEUSreNgJpxhj0AV0pJ1OAG30m7fbmwT22pafvlwfxrmJ+nplIUs23D7Gwiv
-        6A5Io8qkMKbWN0FANTZpfZ4qyoW9OF3Fn2PnDGp6tL37sQKsVvZYyp0M9uj/
-        eS12dyD2XElhAbeaCpbKA5KIwX7X7RTUFJnFz9IWoPvtNAXQ0hR4YqS14knI
-        ZxEHI5kDMUi5OendZ6dqFCYOq3DXlJa/jVAvNcMosDQVp90JOpJ156VHJcsR
-        ohd04dO6wWaIw0w8nTAT6bS5ypxYLRUZJHa7ubSPk2RN1tLv09YnmQM1gv/Z
-        QHeTUIyR59iLVULzq6vry21+tc2jnF1s2McszyIU5JdXmzTHUlxc6izvQVSS
-        aPa0cNMGfUcmpzete9uQgmNZquOEMQzTtkUAGuoSaK8nsnJUVPU7mfqAHyy8
-        +qhqEUvvIhdQjREYKv+b/llkax9Dpvvw2KOOeI6W2NkgoTXHI83lzuHgpceD
-        pIuS65El9fOmJtWZ4vUirxrph47WkkZS4xyXjCB1ITaenh7wAonHUsaLxSO/
-        2McOCoIzwUMKGddteXt14KzIvt4WutPSiwb7yfxsU6NIuOzDGP1aKOFB72YF
-        vlYFlMm9LDlrNJZ0J3CsVe3thMsBlmaT3Vs+E5fSmRZjkTZKO+LLwODLTvdt
-        a6LyJ2jEmv3bTzGzfwi8Ew4H6zS2a+U/hn1BYLki1/MZbLLMQ4oxLQu+W8/r
-        xoCvPro5Q7hA7ta4V4idra7PPNo+EwdLoCn7GTk6JUljArQIettWS5nesjXw
-        KlNgXyF4x2zxAR49l9OITTpI8uFvAAAA//8DAF/OfB5xEgAA
+        H4sIAAkeEFkAA9xYTW/jNhC9768IfGckO3bjLBRtty0K9NAemt2i6GVBiSOL
+        DUWqJOXY++s7FCVZiqgkPRQompM18zjkfHDmMcmHUyWujqANV/J+tb6OV1cg
+        c8W4PNyvPn/6kexXH9J3idVUGppbRKXvrq4SztJ4w7brr3KfRPjhZMZS25iU
+        NrZUmn8FlkSdyGntuYbUUAFJ1P50srzRGnc7E24UwU0h/fzwQxLNxQ5MK9VI
+        m27i6zhOou7LKSrQeUmlJTTPnZDgeYyFKlPCJlFI2562yUhAdyW5uF9Z3cAq
+        8tYp2tJvgirNEIn2f73zf2S9ufn43fdJNGharzVQC4xQe+Uicb9i+Gl5BSt0
+        bn1L4h2J95/i2/eb/fv47g+Mx7CgXd/U7J+tvyzoom6sQn/ch0/lHtftbnab
+        mz6XKC64NpZIWsFzP1Ep6LIuV1VN5TmggYpyEZA/QWa4DdmqSyVD8oKeZtGP
+        xn4lGRcCa/jiY27+XeeM1QBYHoxpMCbk/cmCZC4NixChciq4DZnXcMC7FwqR
+        wksm/DW5267j2yQai/pjY8nq87JXXu1WECrqkm7ehLp5DSUbzAfP57kapQdd
+        KxrJQhdq0Jiu0qnW9DxRYjxHvSlkpKbacgyHAWsFVIB3d7oiZPzSxF4zPzKb
+        UZuXQUzJ63pcjaGS/l+W5AsF8p+pxXF2uuZICg6Cma4WjoaA1koTjFGtpIGg
+        ay1u5PoUnf6MM+tFQG9imrVnoJ+8lRcxrRvH43zlXOigB5wNT/SMmj/BVzmO
+        GzNPbFJrleNuGIf+dtAW3lq62T9sf/wde89LoKmV6VHWsRvrS9qFlRYrOP1Y
+        o+bo6MYSog0tY9ydBIM/h818PSqeuwQVmHhcgbWTgZ5HpHGkAHfx830BZemJ
+        eLoSVMEJqrof5ZlSAqhcpQUVxlGlAdBTB/SC5FT3k8yqR5Ap2x3LI5Id/+U1
+        GZfpNl5v9nvXbuW4k2zT9X6/TqLuo7ssaJS01Ow3bihWy/DdN4uaa5/MSklb
+        putNEs2EM+wZqEZesokn4Fba7duNbeJaTUswPz9chvlFejllqUQb7nAD4RU9
+        AGm0SEtra/M+iqjBJm2uM025dBenq/hr7JxRTc+ud3+pAKuVfRHqoKIj+n9d
+        y8MHkEeulXSAe0Mly9QJScRgv+t2GmqKzOIX5QrQ//aaEqiwJZ4Yea18lOpJ
+        JtFI5kEMMm4vev/ZqRqNicMqPDTCEbgR6rlmGAWOp+K0u0BHsu689KyVGCF6
+        QRc+YxpshjjM5OMFM5FOm6sqiNNSmUPqtptL+zgp1uQt/75sfZF5UCP5Xw10
+        NwnFGHmOvVintNjtbrd3xe6uWBfsZs++yYt8jYJiu9tnBZbi4lJv+QiyUsSw
+        x4WbNug7Mjm9ad3jhpQcy1KfJ4xhmLYtAtBQl0B3PZGWo6Kq30jVB/xg4cVX
+        VYtYehj5gBqMwFD53/bvIlf7GDLTh8cddcRzjMLOBimtOR5pLvcOR889HiRd
+        lHyPFDTMm5rM5JrXi7xqpB86WksaSY1zXDGC1IW4eAZ6wDMkHkvbIBaP/Gwf
+        NygIzoQAKWTctOUd1IG3ovp6W+hOSy8a7Cfzs02NIuFyL2P0a6GEB72fFfhc
+        lSDSByU4a/D10ws8a9VHN+EKgKXZ5PZWT8SndKbFWGSNNp74MrD4sjN925qo
+        wgkasebw9lPM7D8Cb4TDyTmN7VqHj+FeEFiuyPVCBps8D5BiTMuC787zurEQ
+        qo9uzhAukbs1/hXiZqvvM19cn0miJdCU/YwcnZKkMQFaBL1uq6VMr9kaeJUt
+        sa8QvGOu+ACPXqhpxCYdJH33NwAAAP//AwDXYMt4chIAAA==
     http_version: 
-  recorded_at: Fri, 03 Feb 2017 21:10:13 GMT
+  recorded_at: Mon, 08 May 2017 07:28:09 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
The Solidus address factory randomizes the zipcode. The OrderWalkThrough we use in the credit card checkout spec uses this factory for the user addresses.

For credit card payments we transmit the billing address to braintree, for paypal payments the shipping address.

As we match the body in our VCR settings VCR can not match the request anymore and therefore cannot replay existing cassettes. This leads to sporadic failing tests.

By modifying the spree address factory we ensure that the zipcode is always the same.