### PR TITLE
Use flashes for displaying frontend errors

### DIFF
--- a/app/assets/javascripts/spree/checkout/braintree.js
+++ b/app/assets/javascripts/spree/checkout/braintree.js
@@ -5,7 +5,7 @@ $(function() {
    * submission if tokenization fails, we need to manually re-enable the
    * submit button. */
   function braintreeError (err) {
-    alert(err.name + ": " + err.message);
+    SolidusPaypalBraintree.braintreeErrorHandle(err);
     enableSubmit();
   }
 

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_braintree.js
@@ -3,6 +3,15 @@
 window.SolidusPaypalBraintree = {
   APPLE_PAY_API_VERSION: 1,
 
+  // Override to provide your own error messages.
+  braintreeErrorHandle: function(braintreeError) {
+    var $contentContainer = $("#content");
+    var $flash = $("<div class='flash error'>" + braintreeError.name + ": " + braintreeError.message + "</div>");
+    $contentContainer.prepend($flash);
+
+    $flash.show().delay(5000).fadeOut(500);
+  },
+
   fetchToken: function(tokenCallback) {
     Spree.ajax({
       dataType: 'json',

--- a/spec/features/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/braintree_credit_card_checkout_spec.rb
@@ -64,10 +64,8 @@ describe 'entering credit card details', type: :feature, js: true do
     # Attempt to submit an empty form once
     before(:each) do
       expect(page).to have_selector("iframe[type='number']")
-      message = accept_prompt do
-        click_button "Save and Continue"
-      end
-      expect(message).to eq "BraintreeError: All fields are empty. Cannot tokenize empty card fields."
+      click_button "Save and Continue"
+      expect(page).to have_text "BraintreeError: All fields are empty. Cannot tokenize empty card fields."
       expect(page).to have_selector("input[type='submit']:enabled")
     end
 
@@ -76,15 +74,8 @@ describe 'entering credit card details', type: :feature, js: true do
       it "displays an alert with a meaningful error message" do
         expect(page).to have_selector("input[type='submit']:enabled")
 
-        # Ensure there are no timing issues with the javascript
-        aggregate_failures do
-          5.times do
-            message = accept_prompt do
-              click_button "Save and Continue"
-            end
-            expect(message).to eq "BraintreeError: All fields are empty. Cannot tokenize empty card fields."
-          end
-        end
+        click_button "Save and Continue"
+        expect(page).to have_text "BraintreeError: All fields are empty. Cannot tokenize empty card fields."
       end
     end
 


### PR DESCRIPTION
Allows users to override by replacing the javascript function before
rendering the page.

This is not great, and is being replaced on my js refactor branch, but
it's required for projects now.