### PR TITLE
Attempt to stop infinite dep resolution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -240,6 +240,9 @@ Metrics/PerceivedComplexity:
 Bundler/OrderedGems:
   Enabled: false
 
+Bundler/DuplicatedGem:
+  Enabled: false
+
 AmbiguousBlockAssociation:
   Exclude:
     - "spec/**/*.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
     - travis_phantomjs
 before_install:
   - "gem install bundler -v 1.14.6"
+  - "bundler -v"
   - "phantomjs --version"
   - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
   - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 if branch == "master" || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
+  # Temporary until bundler fixes bundlers infinite resolution issues
+  gem "rails", "~> 5.0.3", group: :test
 else
   gem "rails", "~> 4.2"
   gem "rails_test_params_backport", group: :test


### PR DESCRIPTION
For some reason bundlers depedency graph has been terribly slow to
resolve. 20 minutes slow. Maybe this is fixed with the pre release, I
have no idea.

Bundler keeps breaking all the things sans changes to the project.