### PR TITLE
Asset pipeline fixes

### DIFF
--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -19,8 +19,6 @@ module SolidusPaypalBraintree
       end
     end
 
-    config.assets.precompile += ["spree/backend/solidus_paypal_braintree"]
-
     config.to_prepare(&method(:activate).to_proc)
 
     def self.frontend_available?
@@ -42,6 +40,7 @@ module SolidusPaypalBraintree
     end
 
     if backend_available?
+      config.assets.precompile += ["spree/backend/solidus_paypal_braintree"]
       paths["app/controllers"] << "lib/controllers/backend"
       paths["app/views"] << "lib/views/backend"
     end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -31,16 +31,16 @@ module SolidusPaypalBraintree
 
     if frontend_available?
       config.assets.precompile += [
-        'spree/frontend/solidus_paypal_braintree',
-        'spree/frontend/paypal_button',
-        'spree/checkout/braintree'
+        'spree/frontend/solidus_paypal_braintree.js',
+        'spree/frontend/paypal_button.js',
+        'spree/checkout/braintree.js'
       ]
       paths["app/controllers"] << "lib/controllers/frontend"
       paths["app/views"] << "lib/views/frontend"
     end
 
     if backend_available?
-      config.assets.precompile += ["spree/backend/solidus_paypal_braintree"]
+      config.assets.precompile += ["spree/backend/solidus_paypal_braintree.js"]
       paths["app/controllers"] << "lib/controllers/backend"
       paths["app/views"] << "lib/views/backend"
     end


### PR DESCRIPTION
Without having an extension Rails refuses to precompile the assets
and raises an error in development mode.