### PR TITLE
Add translation for Credit Card payment type

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     token: Token
     payment_type:
       apple_pay_card: Apple Pay
+      credit_card: Credit Card
       pay_pal_account: PayPal
     configurations:
       title: Braintree Configurations

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
         expect(subject).to eq "Apple Pay"
       end
     end
+
+    context "when the payment type is Credit Card" do
+      let(:type) { "CreditCard" }
+
+      it "returns the translated payment type" do
+        expect(subject).to eq "Credit Card"
+      end
+    end
   end
 
   describe "#apple_pay?" do


### PR DESCRIPTION
Without this, the `#friendly_payment_type` method on sources will throw an I18n error.