### PR TITLE
Make Paypal button bg transparent on hover

### DIFF
--- a/app/assets/stylesheets/spree/frontend/solidus_paypal_braintree.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_paypal_braintree.css
@@ -10,3 +10,7 @@ the installer will append this file to the app vendored assets here: 'vendor/ass
   height: 30px;
   padding: 5px 10px;
 }
+
+.paypal-button-widget .paypal-button:hover {
+  background: transparent;
+}


### PR DESCRIPTION
![paypal button hover](https://user-images.githubusercontent.com/342659/27523870-5ecb331c-5a84-11e7-9b2e-b73bd7d831ec.png)

Default Solidus CSS was giving the Paypal button a black background on hover. This makes it transparent.