### PR TITLE
Rename Gateway#method_type to Gateway#partial_name

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -32,10 +32,11 @@ module SolidusPaypalBraintree
     preference(:merchant_currency_map, :hash, default: {})
     preference(:paypal_payee_email_map, :hash, default: {})
 
-    def method_type
+    def partial_name
       "paypal_braintree"
     end
-
+    alias_method :method_type, :partial_name
+    
     def payment_source_class
       Source
     end


### PR DESCRIPTION
This catches up with a recent change to solidus_core made by @tvdeyen
https://github.com/solidusio/solidus/commit/a6f92e6496628190dfae81752e4e534bbf4b173e