### PR TITLE
Show transaction link

### DIFF
--- a/app/helpers/braintree_admin_helper.rb
+++ b/app/helpers/braintree_admin_helper.rb
@@ -1,0 +1,18 @@
+module BraintreeAdminHelper
+  # Returns a link to the Braintree web UI for the given Braintree payment
+  def braintree_transaction_link(payment)
+    environment = payment.payment_method.preferred_environment == 'sandbox' ? 'sandbox' : 'www'
+    merchant_id = payment.payment_method.preferred_merchant_id
+    response_code = payment.response_code
+
+    return unless response_code.present?
+    return response_code unless merchant_id.present?
+
+    link_to(
+      response_code,
+      "https://#{environment}.braintreegateway.com/merchants/#{merchant_id}/transactions/#{response_code}",
+      title: 'Show payment on Braintree',
+      target: '_blank'
+    )
+  end
+end

--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -1,0 +1,1 @@
+Spree::Admin::PaymentsController.helper :braintree_admin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  activerecord:
+    models:
+      solidus_paypal_braintree/gateway: Braintree
   spree:
     admin:
       tab:
@@ -12,6 +15,7 @@ en:
     public_key: Public key
     token_generation_enabled: Token generation enabled?
   solidus_paypal_braintree:
+    braintree: Braintree
     nonce: Nonce
     token: Token
     payment_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
     nonce: Nonce
     token: Token
     payment_type:
+      label: Payment Type
       apple_pay_card: Apple Pay
       credit_card: Credit Card
       pay_pal_account: PayPal

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
@@ -7,6 +7,9 @@
         <dt><%= Spree.t(:identifier) %>:</dt>
         <dd><%= payment.number %></dd>
 
+        <dt><%= Spree.t(:response_code) %>:</dt>
+        <dd><%= braintree_transaction_link(payment) %></dd>
+
         <% if payment.source.token.present? %>
           <dt><%= t('solidus_paypal_braintree.token') %>:</dt>
           <dd><%= payment.source.token %></dd>
@@ -14,9 +17,6 @@
           <dt><%= t('solidus_paypal_braintree.nonce') %>:</dt>
           <dd><%= payment.source.nonce %></dd>
         <% end %>
-
-        <dt><%= Spree.t(:response_code) %>:</dt>
-        <dd><%= payment.response_code %></dd>
       </dl>
     </div>
   </div>

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
@@ -1,4 +1,6 @@
 <fieldset data-hook="credit_card">
+  <legend align="center"><%= SolidusPaypalBraintree::Gateway.model_name.human %></legend>
+
   <div class="row">
     <div class="alpha six columns">
       <dl>

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
@@ -17,6 +17,17 @@
           <dt><%= t('solidus_paypal_braintree.nonce') %>:</dt>
           <dd><%= payment.source.nonce %></dd>
         <% end %>
+
+        <dt><%= t('solidus_paypal_braintree.payment_type.label') %>:</dt>
+        <dd><%= payment.source.friendly_payment_type %></dd>
+
+        <% if payment.source.credit_card? %>
+          <dt><%= Spree::CreditCard.human_attribute_name(:card_type) %>:</dt>
+          <dd><%= payment.source.card_type %></dd>
+
+          <dt><%= Spree::CreditCard.human_attribute_name(:last_digits) %>:</dt>
+          <dd><%= payment.source.last_digits %></dd>
+        <% end %>
       </dl>
     </div>
   </div>

--- a/spec/helpers/braintree_admin_helper_spec.rb
+++ b/spec/helpers/braintree_admin_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe BraintreeAdminHelper do
+  describe '#braintree_transaction_link' do
+    let(:payment_method) { create_gateway }
+    let(:payment) do
+      double(Spree::Payment, payment_method: payment_method, response_code: 'abcde')
+    end
+
+    subject { helper.braintree_transaction_link(payment) }
+
+    it 'should generate a link to Braintree admin' do
+      expect(subject).to eq "<a title=\"Show payment on Braintree\" target=\"_blank\" href=\"https://sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/abcde\">abcde</a>"
+    end
+  end
+end


### PR DESCRIPTION
When we click through to a payment in admin, include a link to the Braintree admin page for the payment. 

This is based on https://github.com/solidusio/solidus_braintree/commit/68abb9683bf38a546ae703df7433a4e8233b9c81 by @ericsaupe