### PR TITLE
Set Braintree log level as a gateway preference

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -53,7 +53,7 @@ module SolidusPaypalBraintree
         merchant_id: preferred_merchant_id,
         public_key: preferred_public_key,
         private_key: preferred_private_key,
-        logger: Braintree::Configuration.logger.clone
+        logger: logger
       }
     end
 
@@ -230,6 +230,12 @@ module SolidusPaypalBraintree
     end
 
     private
+
+    def logger
+      Braintree::Configuration.logger.clone.tap do |logger|
+        logger.level = Rails.logger.level
+      end
+    end
 
     def dollars(cents)
       Money.new(cents).dollars


### PR DESCRIPTION
The `braintree` gem provides a default logger that logs at the INFO level, which clutters logs a bit.

This provides a gateway preference for log level, and sets the default a notch higher to WARN.