### PR TITLE
Remove integer type declaration from cassettes

### DIFF
--- a/spec/fixtures/cassettes/admin/invalid_credit_card.yml
+++ b/spec/fixtures/cassettes/admin/invalid_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/admin/resubmit_credit_card.yml
+++ b/spec/fixtures/cassettes/admin/resubmit_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/admin/valid_credit_card.yml
+++ b/spec/fixtures/cassettes/admin/valid_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/braintree/generate_token.yml
+++ b/spec/fixtures/cassettes/braintree/generate_token.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/braintree/token.yml
+++ b/spec/fixtures/cassettes/braintree/token.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/checkout/invalid_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/invalid_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/resubmit_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/checkout/valid_credit_card.yml
+++ b/spec/fixtures/cassettes/checkout/valid_credit_card.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:

--- a/spec/fixtures/cassettes/gateway/cancel/refunds.yml
+++ b/spec/fixtures/cassettes/gateway/cancel/refunds.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">40</amount>
+          <amount>40</amount>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
           <options>
             <submit-for-settlement type="boolean">true</submit-for-settlement>

--- a/spec/fixtures/cassettes/gateway/cancel/void.yml
+++ b/spec/fixtures/cassettes/gateway/cancel/void.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">40</amount>
+          <amount>40</amount>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>

--- a/spec/fixtures/cassettes/gateway/capture.yml
+++ b/spec/fixtures/cassettes/gateway/capture.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">40</amount>
+          <amount>40</amount>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>

--- a/spec/fixtures/cassettes/gateway/credit.yml
+++ b/spec/fixtures/cassettes/gateway/credit.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">40</amount>
+          <amount>40</amount>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
           <options>
             <submit-for-settlement type="boolean">true</submit-for-settlement>

--- a/spec/fixtures/cassettes/gateway/void.yml
+++ b/spec/fixtures/cassettes/gateway/void.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <transaction>
-          <amount type="integer">40</amount>
+          <amount>40</amount>
           <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
           <type>sale</type>
         </transaction>

--- a/spec/fixtures/cassettes/paypal/checkout.yml
+++ b/spec/fixtures/cassettes/paypal/checkout.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:
@@ -91,7 +91,7 @@ http_interactions:
         dtZuTuK1Z08Z4Afcg0ymHdzN5o5cgS8d+P0kwB8M7vEsIYXBnTMPzmO093o+
         YvJAl0ezv4aYKnc44MHyIbG+3Xx9fg/4dPP1/RvC3wAAAP//AwBycSkcWAgA
         AA==
-    http_version: 
+    http_version:
   recorded_at: Mon, 17 Jul 2017 03:27:47 GMT
 - request:
     method: post
@@ -101,7 +101,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:
@@ -184,7 +184,7 @@ http_interactions:
         21m7OfHXnj2lgB9w9yIet3A36ztyCb604P8zB39EcI+nMck17ixy4Dxae6dj
         AyYHdHnS+3cQU2YWAzxYPMbG1/svl++AT/df3n8h/AIAAP//AwD+FzsrWAgA
         AA==
-    http_version: 
+    http_version:
   recorded_at: Mon, 17 Jul 2017 03:27:51 GMT
 - request:
     method: post
@@ -260,7 +260,7 @@ http_interactions:
         Ve1RvXKjVSfZWVAs12d/P9cOY0/b5LYwvHb+Jh9Mudc4/YIqi1crs2YpHaKR
         ++LeDf+2pDtYhYJwxR3v+HubSxDW+/xIeq3jf9+NTJX6/rx6WnDJu86NRaIN
         66c7FaZ0urX3mO1BYMygH9DEttv+ZLN/AAAA//8DACqgWnn1BAAA
-    http_version: 
+    http_version:
   recorded_at: Mon, 17 Jul 2017 03:28:14 GMT
 - request:
     method: post
@@ -379,6 +379,6 @@ http_interactions:
         ilZlkjimUDDLyNvNy4vSDIvj472tdZh8h/Jg9ruwbTHlMAmV9vuB+YRp09Fd
         /UWwU3QPcP05o6OX/jjSHTVGQc+fVQ0nz53VTjA6hTSEICSNr0Ix4GvRV3Av
         4USv/gcAAP//AwA1zwmgMRYAAA==
-    http_version: 
+    http_version:
   recorded_at: Mon, 17 Jul 2017 03:28:18 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/paypal/one_touch_checkout.yml
+++ b/spec/fixtures/cassettes/paypal/one_touch_checkout.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <client-token>
-          <version type="integer">2</version>
+          <version>2</version>
         </client-token>
     headers:
       Accept-Encoding:


### PR DESCRIPTION
Lots of older cassettes had `type="integer"` attributes in the xml
of the request body. Newer cassettes do not have this. This causes
build errors depending on which machine the specs run.

It is not 100% clear what's the cause of this.

Maybe the builder gem? - braintree depends on >=2.0.0 while 3.2.3 is the most recent version
Maybe the braintree gem? - 2.76.0 is the most recent version and was updated lately
Maybe libxml? - The version on the different machines may vary