### PR TITLE
Update braintree client libs to v3.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The following is a relatively bare-bones implementation to enable Apple Pay on t
 
 ```html
 <% if current_store.braintree_configuration.apple_pay? %>
-  <script src="https://js.braintreegateway.com/web/3.14.0/js/apple-pay.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.22.1/js/apple-pay.min.js"></script>
 
   <button id="apple-pay-button" class="apple-pay-button"></button>
 

--- a/app/assets/javascripts/spree/backend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/backend/solidus_paypal_braintree.js
@@ -68,8 +68,8 @@ $(function() {
   if (!$paymentForm.length || !$hostedFields.length) { return; }
 
   $.when(
-    $.getScript("https://js.braintreegateway.com/web/3.9.0/js/client.min.js"),
-    $.getScript("https://js.braintreegateway.com/web/3.9.0/js/hosted-fields.min.js")
+    $.getScript("https://js.braintreegateway.com/web/3.22.1/js/client.min.js"),
+    $.getScript("https://js.braintreegateway.com/web/3.22.1/js/hosted-fields.min.js")
   ).done(function() {
     $hostedFields.each(function() {
       var $this = $(this),

--- a/app/assets/javascripts/spree/frontend/paypal_button.js
+++ b/app/assets/javascripts/spree/frontend/paypal_button.js
@@ -3,9 +3,9 @@
 $(document).ready(function() {
   if (document.getElementById("empty-cart")) {
     $.when(
-      $.getScript("https://js.braintreegateway.com/web/3.14.0/js/client.min.js"),
-      $.getScript("https://js.braintreegateway.com/web/3.14.0/js/paypal.min.js"),
-      $.getScript("https://js.braintreegateway.com/web/3.14.0/js/data-collector.min.js")
+      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/client.min.js"),
+      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/paypal.min.js"),
+      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/data-collector.min.js")
     ).done(function() {
       $('<script/>').attr({
         'data-merchant' : "braintree",

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -2,19 +2,19 @@
 <% id = payment_method.id %>
 
 <% content_for :head do %>
-  <script src="https://js.braintreegateway.com/web/3.14.0/js/client.min.js"></script>
-  <script src="https://js.braintreegateway.com/web/3.14.0/js/data-collector.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.22.1/js/client.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.22.1/js/data-collector.min.js"></script>
 
   <% if current_store.braintree_configuration.paypal? %>
-    <script src="https://js.braintreegateway.com/web/3.14.0/js/paypal.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.22.1/js/paypal.min.js"></script>
   <% end %>
 
   <% if current_store.braintree_configuration.credit_card? %>
-    <script src="https://js.braintreegateway.com/web/3.14.0/js/hosted-fields.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.22.1/js/hosted-fields.min.js"></script>
   <% end %>
 
   <% if current_store.braintree_configuration.apple_pay? %>
-    <script src="https://js.braintreegateway.com/web/3.14.0/js/apple-pay.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.22.1/js/apple-pay.min.js"></script>
   <% end %>
 
   <%= javascript_include_tag "solidus_paypal_braintree/checkout" %>


### PR DESCRIPTION
We use rather outdated (and even inconsistent) versions of Braintree JS libs.