### PR TITLE
Rescue Braintree::NotFound errors in source display methods

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -64,6 +64,9 @@ module SolidusPaypalBraintree
     def braintree_payment_method
       return unless braintree_client && credit_card?
       @braintree_payment_method ||= braintree_client.payment_method.find(token)
+    rescue Braintree::NotFoundError, ArgumentError => e
+      Rails.logger.warn("#{e}: token unknown or missing for #{inspect}")
+      nil
     end
 
     def braintree_client

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -56,7 +56,7 @@ module SolidusPaypalBraintree
     end
 
     def display_number
-      "XXXX-XXXX-XXXX-#{last_digits}"
+      "XXXX-XXXX-XXXX-#{last_digits.to_s.rjust(4, 'X')}"
     end
 
     private

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -240,11 +240,21 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
     let(:payment_source) { described_class.new }
     subject { payment_source.display_number }
 
-    before do
-      allow(payment_source).to receive(:last_digits).and_return('1234')
+    context "when last_digits is a number" do
+      before do
+        allow(payment_source).to receive(:last_digits).and_return('1234')
+      end
+
+      it { is_expected.to eq 'XXXX-XXXX-XXXX-1234' }
     end
 
-    it { is_expected.to eq 'XXXX-XXXX-XXXX-1234' }
+    context "when last_digits is nil" do
+      before do
+        allow(payment_source).to receive(:last_digits).and_return(nil)
+      end
+
+      it { is_expected.to eq 'XXXX-XXXX-XXXX-XXXX' }
+    end
   end
 
   describe "#card_type" do

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -173,10 +173,10 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
 
   describe "#last_4", vcr: { cassette_name: "source/last4" } do
     let(:method) { new_gateway.tap(&:save!) }
-    let(:instance) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
+    let(:payment_source) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
     let(:braintree_client) { method.braintree }
 
-    subject { instance.last_4 }
+    subject { payment_source.last_4 }
 
     before do
       customer = braintree_client.customer.create
@@ -187,21 +187,21 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
       })
       expect(method.payment_method.token).to be
 
-      instance.update_attributes!(token: method.payment_method.token)
+      payment_source.update_attributes!(token: method.payment_method.token)
     end
 
     it "delegates to the braintree payment method" do
-      method = braintree_client.payment_method.find(instance.token)
+      method = braintree_client.payment_method.find(payment_source.token)
       expect(subject).to eql(method.last_4)
     end
   end
 
   describe "#display_number" do
-    let(:instance) { described_class.new }
-    subject { instance.display_number }
+    let(:payment_source) { described_class.new }
+    subject { payment_source.display_number }
 
     before do
-      allow(instance).to receive(:last_digits).and_return('1234')
+      allow(payment_source).to receive(:last_digits).and_return('1234')
     end
 
     it { is_expected.to eq 'XXXX-XXXX-XXXX-1234' }
@@ -209,10 +209,10 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
 
   describe "#card_type", vcr: { cassette_name: "source/card_type" } do
     let(:method) { new_gateway.tap(&:save!) }
-    let(:instance) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
+    let(:payment_source) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
     let(:braintree_client) { method.braintree }
 
-    subject { instance.card_type }
+    subject { payment_source.card_type }
 
     before do
       customer = braintree_client.customer.create
@@ -223,11 +223,11 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
       })
       expect(method.payment_method.token).to be
 
-      instance.update_attributes!(token: method.payment_method.token)
+      payment_source.update_attributes!(token: method.payment_method.token)
     end
 
     it "delegates to the braintree payment method" do
-      method = braintree_client.payment_method.find(instance.token)
+      method = braintree_client.payment_method.find(payment_source.token)
       expect(subject).to eql(method.card_type)
     end
   end

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -226,13 +226,13 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
     context 'when the source token is not known at Braintree' do
       include_context 'unknown source token'
 
-      it('should be nil', :pending) { is_expected.to be(nil) }
+      it { is_expected.to be(nil) }
     end
 
     context 'when the source token is nil' do
       include_context 'nil source token'
 
-      it('should be nil', :pending) { is_expected.to be(nil) }
+      it { is_expected.to be(nil) }
     end
   end
 
@@ -276,13 +276,13 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
     context 'when the source token is not known at Braintree' do
       include_context 'unknown source token'
 
-      it('should be nil', :pending) { is_expected.to be_nil }
+      it { is_expected.to be_nil }
     end
 
     context 'when the source token is nil' do
       include_context 'nil source token'
 
-      it('should be nil', :pending) { is_expected.to be_nil }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -171,28 +171,68 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
     end
   end
 
-  describe "#last_4", vcr: { cassette_name: "source/last4" } do
+  shared_context 'unknown source token' do
+    let(:braintree_payment_method) { double }
+
+    before do
+      allow(braintree_payment_method).to receive(:find) do
+        raise Braintree::NotFoundError
+      end
+      allow(payment_source).to receive(:braintree_client) do
+        double(payment_method: braintree_payment_method)
+      end
+    end
+  end
+
+  shared_context 'nil source token' do
+    let(:braintree_payment_method) { double }
+
+    before do
+      allow(braintree_payment_method).to receive(:find) do
+        raise ArgumentError
+      end
+      allow(payment_source).to receive(:braintree_client) do
+        double(payment_method: braintree_payment_method)
+      end
+    end
+  end
+
+  describe "#last_4" do
     let(:method) { new_gateway.tap(&:save!) }
     let(:payment_source) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
     let(:braintree_client) { method.braintree }
 
     subject { payment_source.last_4 }
 
-    before do
-      customer = braintree_client.customer.create
-      expect(customer.customer.id).to be
+    context 'when token is known at braintree', vcr: { cassette_name: "source/last4" } do
+      before do
+        customer = braintree_client.customer.create
+        expect(customer.customer.id).to be
 
-      method = braintree_client.payment_method.create({
-        payment_method_nonce: "fake-valid-country-of-issuance-usa-nonce", customer_id: customer.customer.id
-      })
-      expect(method.payment_method.token).to be
+        method = braintree_client.payment_method.create({
+          payment_method_nonce: "fake-valid-country-of-issuance-usa-nonce", customer_id: customer.customer.id
+        })
+        expect(method.payment_method.token).to be
 
-      payment_source.update_attributes!(token: method.payment_method.token)
+        payment_source.update_attributes!(token: method.payment_method.token)
+      end
+
+      it "delegates to the braintree payment method" do
+        method = braintree_client.payment_method.find(payment_source.token)
+        expect(subject).to eql(method.last_4)
+      end
     end
 
-    it "delegates to the braintree payment method" do
-      method = braintree_client.payment_method.find(payment_source.token)
-      expect(subject).to eql(method.last_4)
+    context 'when the source token is not known at Braintree' do
+      include_context 'unknown source token'
+
+      it('should be nil', :pending) { is_expected.to be(nil) }
+    end
+
+    context 'when the source token is nil' do
+      include_context 'nil source token'
+
+      it('should be nil', :pending) { is_expected.to be(nil) }
     end
   end
 
@@ -207,28 +247,42 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
     it { is_expected.to eq 'XXXX-XXXX-XXXX-1234' }
   end
 
-  describe "#card_type", vcr: { cassette_name: "source/card_type" } do
+  describe "#card_type" do
     let(:method) { new_gateway.tap(&:save!) }
     let(:payment_source) { described_class.create!(payment_type: "CreditCard", payment_method: method) }
     let(:braintree_client) { method.braintree }
 
     subject { payment_source.card_type }
 
-    before do
-      customer = braintree_client.customer.create
-      expect(customer.customer.id).to be
+    context "when the token is known at braintree", vcr: { cassette_name: "source/card_type" } do
+      before do
+        customer = braintree_client.customer.create
+        expect(customer.customer.id).to be
 
-      method = braintree_client.payment_method.create({
-        payment_method_nonce: "fake-valid-country-of-issuance-usa-nonce", customer_id: customer.customer.id
-      })
-      expect(method.payment_method.token).to be
+        method = braintree_client.payment_method.create({
+          payment_method_nonce: "fake-valid-country-of-issuance-usa-nonce", customer_id: customer.customer.id
+        })
+        expect(method.payment_method.token).to be
 
-      payment_source.update_attributes!(token: method.payment_method.token)
+        payment_source.update_attributes!(token: method.payment_method.token)
+      end
+
+      it "delegates to the braintree payment method" do
+        method = braintree_client.payment_method.find(payment_source.token)
+        expect(subject).to eql(method.card_type)
+      end
     end
 
-    it "delegates to the braintree payment method" do
-      method = braintree_client.payment_method.find(payment_source.token)
-      expect(subject).to eql(method.card_type)
+    context 'when the source token is not known at Braintree' do
+      include_context 'unknown source token'
+
+      it('should be nil', :pending) { is_expected.to be_nil }
+    end
+
+    context 'when the source token is nil' do
+      include_context 'nil source token'
+
+      it('should be nil', :pending) { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
Whenever we want to display a payment source during checkout or admin
payments screen it may happen that the token is not known at Braintree or
the token is nil.

In order to not blow up these pages we should rescue these errors instead.