### PR TITLE
Protect against connection errors

### DIFF
--- a/app/models/solidus_paypal_braintree/avs_result.rb
+++ b/app/models/solidus_paypal_braintree/avs_result.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_merchant/billing/avs_result'
+
 module SolidusPaypalBraintree
   class AVSResult < ActiveMerchant::Billing::AVSResult
     # Mapping took from ActiveMerchant::Billing::BraintreeBlueGateway

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -150,7 +150,9 @@ module SolidusPaypalBraintree
     # @param response_code [String] the transaction id of the payment to void
     # @return [Response]
     def cancel(response_code)
-      transaction = braintree.transaction.find(response_code)
+      transaction = protected_request do
+        braintree.transaction.find(response_code)
+      end
       if VOIDABLE_STATUSES.include?(transaction.status)
         void(response_code, nil, {})
       else

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -1,9 +1,8 @@
 require 'braintree'
-require 'active_merchant/network_connection_retries'
 
 module SolidusPaypalBraintree
   class Gateway < ::Spree::PaymentMethod
-    include ActiveMerchant::NetworkConnectionRetries
+    include RequestProtection
 
     TOKEN_GENERATION_DISABLED_MESSAGE = 'Token generation is disabled.' \
       ' To re-enable set the `token_generation_enabled` preference on the' \
@@ -333,17 +332,6 @@ module SolidusPaypalBraintree
       end
 
       params
-    end
-
-    def protected_request
-      raise ArgumentError unless block_given?
-      options = {
-        connection_exceptions: {
-          Braintree::BraintreeError => 'Error while connecting to Braintree gateway'
-        },
-        logger: Rails.logger
-      }
-      retry_exceptions(options) { yield }
     end
   end
 end

--- a/app/models/solidus_paypal_braintree/response.rb
+++ b/app/models/solidus_paypal_braintree/response.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_merchant/billing/response'
 require_relative 'avs_result'
 
 # Response object that all actions on the gateway should return

--- a/lib/solidus_paypal_braintree.rb
+++ b/lib/solidus_paypal_braintree.rb
@@ -2,6 +2,7 @@ require 'solidus_core'
 require 'solidus_support'
 require 'solidus_paypal_braintree/engine'
 require 'solidus_paypal_braintree/country_mapper'
+require 'solidus_paypal_braintree/request_protection'
 
 module SolidusPaypalBraintree
   def self.table_name_prefix

--- a/lib/solidus_paypal_braintree/request_protection.rb
+++ b/lib/solidus_paypal_braintree/request_protection.rb
@@ -1,0 +1,18 @@
+require 'active_merchant/network_connection_retries'
+
+module SolidusPaypalBraintree
+  module RequestProtection
+    include ActiveMerchant::NetworkConnectionRetries
+
+    def protected_request
+      raise ArgumentError unless block_given?
+      options = {
+        connection_exceptions: {
+          Braintree::BraintreeError => 'Error while connecting to Braintree gateway'
+        },
+        logger: Rails.logger
+      }
+      retry_exceptions(options) { yield }
+    end
+  end
+end

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus", ['>= 1.0', '< 3']
   s.add_dependency "solidus_support"
   s.add_dependency "braintree", '~> 2.65'
+  s.add_dependency 'activemerchant', '~> 1.48'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'

--- a/spec/fixtures/cassettes/gateway/authorized_transaction.yml
+++ b/spec/fixtures/cassettes/gateway/authorized_transaction.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount type="integer">40</amount>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.78.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 19 Oct 2017 11:26:16 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"2ebfd223c948ff960edeeee7263b4c73"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 984e6228-6e6c-4db4-aac8-90236a3e6c59
+      X-Runtime:
+      - '0.376285'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIANiL6FkAA+RXUW/jNgx+v18R5F11nBV3vcJ1N2AYsA3by12H7V4K2WJi
+        XWVJk+Q02a8fZdmOXctp9zIM2JtNfqJIiiI/ZffHWqwOYCxX8m6dXm3WK5Cl
+        Ylzu79YPn38gN+v7/F3mDJWWlg5R+bvVKuMs3x/haVvTNEvwx8uso66xOW1c
+        pQz/C1iWdCKvdScNuaUCsqT99LKyMQZ3OxFuFcFNIX/49H2WzMUeTGvVSJdf
+        b642myzp/ryiBlNWVDpCy9ILCfpjHdSFEi5LYtrW26YgEd1KcnG3dqaBdRKs
+        U7Rl3gRVhiEyoigNUAeMULfysd+tGf46XsM6327SDyTdkPTj5zS93b6/Td9/
+        wQwMC9r1jWb/bP15QZdn6xRG4H/aw3vpIQp33FhHJK0hohR0WVeqWlN5imig
+        plxE5M9QWO5itnSlZEy+o8dZUpNxVFnBhcCa/ZcjtM4AYE0wZsDaWAqODiTz
+        J7EIEaqkgruYeQN7vHCxPCm8WSLcjY/X6eZDloxFvdtYp+a0HFVQ+xWECl3R
+        7ZtQ37yGkg0eCi/nBzY6Iwxt10gWuyyDxnbFTo2hp4kS8zlqSDEjmhrHMR0W
+        nBNQA17Y6YqY8XPnes38yGxBXVlFMRXX+n9ZkhcK5D9Ti+PT6foj2XEQzHa1
+        cLAEjFGGYI60khaiobW4UehTdP4LDqqLgN7E9NRegH4MVi5i2jAOh/n+c6GH
+        7nE8PNMTar5CqHKcOHZ+sJk2qsTdMA/97aAtvLX0x89ffvodh/FF0NTK1JV0
+        s5ksnzsa0Tms4Pw7jZqD5xhLiDa1jHHvCSZ/DpvFelC89Ae0w4PHFVg7BZh5
+        RhrPBHCXMO4XUI4eSeAoURUcodb9NC+UEkDlOt9RYT0/GgA9e8AoSEkN60rc
+        qSeI3cGCS+RH6fbmxjdbOe4j13l6c4NcrfvprgqaJC0b+41birUy/PetQnMT
+        jrJW0lV5us2SmXCGPQE1SEy2mwm4lXb7dpOb+EbTcsqHT+d5fpaevayUaJMd
+        bx+8pnsgjRF55Zy2t0lCLbZoe1UYyqW/Nl29X2HfTDQ9+c79WAPWKnsUaq+S
+        A8Z/peX+HuSBGyU94M5SyQp1RII72O96nQFNkUf+qnz5he+gqYAKV6HHSGXl
+        k1TPMktGsgBiUHB31offTtUYPDiswX0jPIMboV5qhkHgqSnOujN0JOv8pSej
+        xAjRC7r0WdtgK8RRJp/OmIl02lrVjngtlSXkfru5tM+TYk3ZUu7z1mdZADWS
+        /9lAd49QjJnn2IlnV8pfUJC1IpY9LVycQd8RxOnF6R4opOJYZ+Y0IQDD8GwR
+        gIa6E/G3DYk2Kmr9RvI94AcLF19GLWLpcRMyZJHkDqX8bf+28cWMVN/2vN67
+        OqItVmGjgpxqji7N5SHg5GXEg6TLUmh5gsZpUFPY0nC9SJNG+qFFtRyQaBzL
+        ihFkIsTnM9rMJkh0y7goFl1+sY/v+wRbfITjMW7beo3qIFhRfZ9aaDdLrxRs
+        EHPfpkaRP/nXLca1UMKDPrR+fHJKmFvFMz/4WbUDWJoyflv1TMJpzrSYhqIx
+        NlBYBg4farZvQRNV/GxG/De+/RQze9C/EQ5HnwBsvSbuhn8LYKUia4sZbMoy
+        Qm/xRBZi95HrxsGlp0EYZZR9xVnl18ew3XwhXCJja8Lbw8/U0I4efTvKkiXQ
+        lPOMkjKlRmPaswh63VZLlF6zNbApV2H7IXgVfY0Cur5T0+xOGk3+7m8AAAD/
+        /wMAEprd410SAAA=
+    http_version: 
+  recorded_at: Thu, 19 Oct 2017 11:26:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/gateway/settled_transaction.yml
+++ b/spec/fixtures/cassettes/gateway/settled_transaction.yml
@@ -1,0 +1,193 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount type="integer">40</amount>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <options>
+            <submit-for-settlement type="boolean">true</submit-for-settlement>
+          </options>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.78.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 19 Oct 2017 11:26:19 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"4555997a9b8deb66d72c88a3a4fd33a6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - '07854723-1694-4d43-86d1-f6b4c365561a'
+      X-Runtime:
+      - '0.433041'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIANuL6FkAA+RYTW/jNhC951cEvjOy3GDjDRSlRYuiPbSX3RRFLwElji1u
+        KFLlh2P313coUbIUUUl6aLFAb9bM43BmOJx5dHZ/rMXlAbThSt6t0qv16hJk
+        qRiX+7vVw+cfyXZ1n19kVlNpaGkRlV9cXmac5dvjzYfi+rrIEvzwMmOpdSY3
+        rqi5tcAed0o/GrBWQA3SZkkAeKw9NZAbKiBL2p9eVjqtce8T4UYRdAHyh08/
+        ZMlc7MG0Vk7a/Hp9tV5nSfjyihp0WVFpCS1LLyTonbFQF0qgCzFt67srSER3
+        Kbm4W1ntYJV01ina0u+CKs0QGVGUGiimh1B76WO/WzH8tLyGVb5ZpzckXZP0
+        4+c0vd18uE0//oEZGBa0613D/tn684KQZ2MVRuA/2qN86SEKd1wbSyStIaIU
+        dFlXqrqh8hTRQE25iMifoTDcxmw1lZIx+Y4eZ0lNxlFlBRcCK/g/jtBYDYA1
+        wZgGY2IpOFqQzJ/EIkSokgpuY+Y17PH6xfKk8GaJ7m58vE7XN1kyFvVuY53q
+        03JUndqvIFQ0Fd28C/XNWyjp8FB4OT+w0RlhaDsnWeyyDBoTip1qTU8TJeZz
+        1J5iRhqqLcd0nJvRixUx49TZSmn+19vmR2YLassqiql40/wvS/KVAvlqanF8
+        OqE/kh0HwUyohYMhoLXSBHPUKGkgGlqLG4U+Ree/4KB6FdCbmJ7aC9DPnZVX
+        MW0Yh8N8/7nQQ/c4Hp7pCTVfoKtynDhmfrBZo1WJu2Ee+ttBW3hrafPT99vf
+        cRi/CppambqSrteT5XNHIzqLFZx/16DmACy6ukW0qWWMe08w+XPYLNaD4qU/
+        oB0ePK7A2ilAzzPiPBPAXbpxv4Cy9Eg6jhJVwRHqpp/mhVICqFzlOyqM50cD
+        oGcPGAUpqWahxK16gtgdLLhEfpRutlvfbOW4j1zn6XabZkn4CFcFTZKWjf3G
+        DcVaGb77VtFw3R1lraSt8nSTJTPhDHsCqpGYbNYTcCsN+4bJTXyjaRnmw6fz
+        PD9Lz15WSrTJjrcPXtM9EKdFXlnbmNskoQZbtLkqNOXSX5tQ71fYN5OGnnzn
+        fqwBa5U9CrVXyQHjv2rk/h7kgWslPeDOUMkKdUS6O9gPvU5DQ5FH/qp8+XW/
+        O00FVNgKPUYqK5+kepZZMpJ1IAYFt2d99xlUTuPBYQ3unfAMboR6qRkGgaem
+        OOvO0JEs+EtPWokRoheE9BnjsBXiKJNPZ8xEOm2take8lsoScr/dXNrnSTFX
+        tpT7vPVZ1oGc5H86CPcIxZh5jp14dqX8BQVZK2LY08LFGfSBIE4vTniukIpj
+        nenThAAMw7NFABoKJ+JvGxJtVNTNO8n3gB8shGfQmV+MX0YtYulx02XIIMkd
+        Svnb/m3jixmpvul5vXd1RFuMwkYFOW04ujSXdwEn84j/5SS857H4daVkkITC
+        6aaAoHFm6ApTat4sMseRfujaLS0mDTIVxQiSM+KzG+3vEyS6pW0Uiy6/2MeP
+        QoJTL0J7GTftFY7qoLOi+ta90IGXHm7YM+e+TY0ipfQPfoxr4VYP+m4a4itc
+        wtwqnvnBj+8dwNLg9duqZ9Kd5kyLaSicNh2rZ2Dx7Wr6rjxRxc9m9CSIbz/F
+        zP7jeCccjj4BOI103A3/PMJKRSIbM+jKMsL48UQWYveRN87Ca6+lbrpT9gXH
+        t18fw4aRS7hEEuu655inGV2HfvQdOkuWQFMaOErKlC2OmeAi6G1bLXd8y9ZA
+        MG2F7YfgVfQ1Cuj6Tk2zO2k0+cXfAAAA//8DAGMRB+t+EwAA
+    http_version: 
+  recorded_at: Thu, 19 Oct 2017 11:26:19 GMT
+- request:
+    method: put
+    uri: https://api.sandbox.braintreegateway.com/merchants/7rdg92j7bm7fk5h3/transactions/8x76b44b/settle
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.78.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic bXdqa2t4d2NwMzJja2huZjphOTI5OGY0M2IzMGM2OTlkYjMwNzJjYzRhMDBmN2Y0OQ==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Oct 2017 11:26:21 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 3v249hqtptsg744y
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"05ff77bb071e5180a5a08b4bb6f693d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0ab8baae-536e-4152-9bff-e1dc74806b40
+      X-Runtime:
+      - '0.809610'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAN2L6FkAA+RYS2/jNhC+51cYvjOy3CBxAkVp0aJoD+1lN4uiF4MSxxYT
+        iVRIyrH76zsU9YyoxHvYomhv1szHIWc4j4+OHo5FvjiA0lyK+2V4uVouQKSS
+        cbG/Xz5+/plslg/xRWQUFZqmBlHxxWIRcRZvjjfXydVVEgX4YWXaUFPpWIMx
+        ObAoaL6typxKiDXNIQrqn1aWVkrhVifCtSS4I8SPn36KgqnYgmkhK2Hiq9Xl
+        ahUFzZdVFKDSjApDaJpaIcHDaANFInMTBT5tfdQqIR7dQvD8fmlUBcvAWado
+        S50FlYoh0qNIFVADjFCzsL7fLxl+Gl7AMl6vwhsSrkh4+zkM79bXd+HtnxiB
+        bkG9virZ2evXIa7vFzRx1kaiB/ajvrm3J0ThjittiKAFeJQ5ndelsiipOHk0
+        UFCee+SvkGhufLbKTAqffEePk6AGQ6+ihOc5Juw/7KE2CgBzgjEFWvtCcDQg
+        mL2JWUguU5pz4zOvYI/V5ouTxMrKXW3cXoWrmygYitpjY56q07xXTm1XEJqX
+        GV2fhfruI5So8FJ4Or2wwR2ha7tKMF+xdBrdJDtVip5GSoznoBv5jJRUGY7h
+        cJ2oACzY8QqfcVqZTCr+18fmB2YTatLMNpW+Erdt99m+qPXL9c3TBjuhZ0Vt
+        KeNl+b9M3HfS6F+TscPbaboo2XHImW4y5qAJKCUVwRiVUmjwulbjBq6P0fFv
+        OM7eBbQmxrf2BvSrs/IupnbjcJjuPxVa6B6HyCs9oeYJXC3gXNLTi41KJVPc
+        DePQ1hCt4bWl9S8/bv7Akf0uaGxlfJRwtRotnx7UozOYwfEPJWoOlonMIerQ
+        MsbtSTD4U9jE14Pkqb2gHV48rsDcSUBNI1JZvoC7OFIwgzL0SByT8argCEXZ
+        zvxEyhyoWMY7mmvLojpAyzHQC5JSxZoUN/IZfDWYcIEsKlxvNrYli2EfuYrD
+        zSaMguajKRU0SWrO9oVrirnSfbetouTKXWUhhcnicB0FE+EEewKqsGmuVyNw
+        LW32beY7sY2mpp2Pn/qp30v7U2Yyr4Ptbx+8oHsglcrjzJhS3wUB1diW9WWi
+        KBe2bJp8v8S+GZT0ZLv1tgDMVbbN5V4GB/T/shT7BxAHrqSwgHtNBUvkETlw
+        Z7/pdQpKim3+d2nTz/12mgxobjI8MRJe8Szkq4iCgcyBGCTc9Hr32agqhReH
+        ObivcsvzBqi3mm4QWAKLE7GHDmTNeelJyXyAaAVN+LSusBXi+BLPPWYkHbdW
+        uSNWS0UKsd1uKm3jJFmV1sS837qXOVAl+EsFTR2hGCPPsRNPSsoWKIhCEs2e
+        Zwqn0zc0clw4zRuGZBzzTJ1GNKEbnjUC0FBzI7bakI6joijPpPgdvrPQPJZ6
+        FjJ8P9WIuSeQi5BGKtyl8vctB7HJjA8C3bJ/e9QBudESGxXEtOR4pKncORxM
+        Pf7GQcDXWcENJvB2J9W2J0//6ZDUT7f5kEwf1edFYFoifoe/xttO0pSJm3k5
+        9bPlKtGp4uUsmx7ouxlVPxVIibxMMoJUlNjAeafZCInHUsaLxSO/2ccOfoIz
+        3vMUYFzXDcurA2dFtoNqZt7MPWZxQkzPNjaKBNr+CYJ+zfSwTu9mf0aFgKlV
+        vPyDJSs7gDmaYbeVr8Td5kSLYUgqpd27hYHB97xuZ9BI5b+bwaPHv/0YM/nf
+        50w4HG0AcPYq/zHskxEzFWm7z2CVpp73Dd7IjO/W87Iy8N4L0nEZyp6QrNj1
+        PmxDMAgXSNkr90S1pMrNo62dR1EwBxqT3kFQxtx4yHtnQR/bqpnyR7Y6Om0y
+        bLYES9HmKODRd3Ic3VGjiS/+BgAA//8DAD0PldqBFAAA
+    http_version: 
+  recorded_at: Thu, 19 Oct 2017 11:26:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -350,8 +350,8 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       end
 
       context "when the transaction is not found", vcr: { cassette_name: 'gateway/cancel/missing' } do
-        it 'raises an error', aggregate_failures: true do
-          expect{ cancel }.to raise_error Braintree::NotFoundError
+        it 'raises an error' do
+          expect{ cancel }.to raise_error ActiveMerchant::ConnectionError
         end
       end
     end

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
     end
 
     shared_examples "sources_by_order" do
-      let(:order) { FactoryGirl.create :order, user: user, state: "complete", completed_at: DateTime.current }
+      let(:order) { FactoryGirl.create :order, user: user, state: "complete", completed_at: Time.current }
       let(:gateway) { new_gateway.tap(&:save!) }
 
       let(:other_payment_method) { FactoryGirl.create(:payment_method) }
@@ -463,7 +463,7 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
 
     describe "#sources_by_order" do
       let(:gateway) { new_gateway.tap(&:save!) }
-      let(:order) { FactoryGirl.create :order, user: user, state: "complete", completed_at: DateTime.current }
+      let(:order) { FactoryGirl.create :order, user: user, state: "complete", completed_at: Time.current }
 
       subject { gateway.sources_by_order(order) }
 

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
         end
 
         it 'raises ActiveMerchant::ConnectionError' do
-          pending 'Show that we are not protected against various connection errors'
           expect { subject }.to raise_error ActiveMerchant::ConnectionError
         end
       end

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       end
     end
 
+    shared_examples "protects against connection errors" do
+      context 'when a timeout error happens' do
+        before do
+          expect_any_instance_of(Braintree::TransactionGateway).to receive(gateway_action) do
+            raise Braintree::BraintreeError
+          end
+        end
+
+        it 'raises ActiveMerchant::ConnectionError' do
+          pending 'Show that we are not protected against various connection errors'
+          expect { subject }.to raise_error ActiveMerchant::ConnectionError
+        end
+      end
+    end
+
     let(:authorized_id) do
       braintree.transaction.sale(
         amount: 40,
@@ -146,19 +161,29 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       it { is_expected.to eq "paypal_braintree" }
     end
 
-    describe '#purchase', vcr: { cassette_name: 'gateway/purchase' } do
+    describe '#purchase' do
       subject(:purchase) { gateway.purchase(1000, source, gateway_options) }
 
-      include_examples "successful response"
+      context 'successful purchase', vcr: { cassette_name: 'gateway/purchase' } do
+        include_examples "successful response"
 
-      it 'submits the transaction for settlement', aggregate_failures: true do
-        expect(purchase.message).to eq 'submitted_for_settlement'
-        expect(purchase.authorization).to be_present
+        it 'submits the transaction for settlement', aggregate_failures: true do
+          expect(purchase.message).to eq 'submitted_for_settlement'
+          expect(purchase.authorization).to be_present
+        end
+      end
+
+      include_examples "protects against connection errors" do
+        let(:gateway_action) { :sale }
       end
     end
 
     describe "#authorize" do
       subject(:authorize) { gateway.authorize(1000, source, gateway_options) }
+
+      include_examples "protects against connection errors" do
+        let(:gateway_action) { :sale }
+      end
 
       context 'successful authorization', vcr: { cassette_name: 'gateway/authorize' } do
         include_examples "successful response"
@@ -244,33 +269,57 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       end
     end
 
-    describe "#capture", vcr: { cassette_name: 'gateway/capture' } do
+    describe "#capture" do
       subject(:capture) { gateway.capture(1000, authorized_id, {}) }
 
-      include_examples "successful response"
+      context 'successful capture', vcr: { cassette_name: 'gateway/capture' } do
+        include_examples "successful response"
 
-      it 'submits the transaction for settlement' do
-        expect(capture.message).to eq "submitted_for_settlement"
+        it 'submits the transaction for settlement' do
+          expect(capture.message).to eq "submitted_for_settlement"
+        end
+      end
+
+      context 'with authorized transaction', vcr: { cassette_name: 'gateway/authorized_transaction' } do
+        include_examples "protects against connection errors" do
+          let(:gateway_action) { :submit_for_settlement }
+        end
       end
     end
 
-    describe "#credit", vcr: { cassette_name: 'gateway/credit' } do
+    describe "#credit" do
       subject(:credit) { gateway.credit(2000, source, settled_id, {}) }
 
-      include_examples "successful response"
+      context 'successful credit', vcr: { cassette_name: 'gateway/credit' } do
+        include_examples "successful response"
 
-      it 'credits the transaction' do
-        expect(credit.message).to eq 'submitted_for_settlement'
+        it 'credits the transaction' do
+          expect(credit.message).to eq 'submitted_for_settlement'
+        end
+      end
+
+      context 'with settled transaction', vcr: { cassette_name: 'gateway/settled_transaction' } do
+        include_examples "protects against connection errors" do
+          let(:gateway_action) { :refund }
+        end
       end
     end
 
-    describe "#void", vcr: { cassette_name: 'gateway/void' } do
+    describe "#void" do
       subject(:void) { gateway.void(authorized_id, source, {}) }
 
-      include_examples "successful response"
+      context 'successful void', vcr: { cassette_name: 'gateway/void' } do
+        include_examples "successful response"
 
-      it 'voids the transaction' do
-        expect(void.message).to eq 'voided'
+        it 'voids the transaction' do
+          expect(void.message).to eq 'voided'
+        end
+      end
+
+      context 'with authorized transaction', vcr: { cassette_name: 'gateway/authorized_transaction' } do
+        include_examples "protects against connection errors" do
+          let(:gateway_action) { :void }
+        end
       end
     end
 


### PR DESCRIPTION
Neither the `braintree` gem nor we handle various connection errors Rubys `net/http` library raises. Solidus expects [1] that payment method implementations raise an `ActiveMerchant::ConnectionError` if one of the several errors [2] happen and handles the payment accordingly. Without that protection we leave payments in processing state whenever a connection error happens.

This uses the activemerchant/network_connection_retries module to prtoect us against these errors and with that ensure that we always have a `ActiveMerchant::ConnectionError` that Solidus knows how to handle correctly.

[1] https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment/processing.rb#L198-L202
[2] https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/network_connection_retries.rb#L4-L12