### PR TITLE
Add a partial for the hash preference field

### DIFF
--- a/lib/solidus_paypal_braintree.rb
+++ b/lib/solidus_paypal_braintree.rb
@@ -1,5 +1,4 @@
 require 'solidus_core'
-require 'solidus_support'
 require 'solidus_paypal_braintree/engine'
 require 'solidus_paypal_braintree/country_mapper'
 require 'solidus_paypal_braintree/request_protection'

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -42,6 +42,12 @@ module SolidusPaypalBraintree
       # source form partial. This will take precedence over lib/views/backend.
       paths["app/views"] << "lib/views/backend_v1.2" if SolidusSupport.solidus_gem_version < Gem::Version.new('1.3')
 
+      # Solidus v2.4 introduced preference field partials but does not ship a hash field type.
+      # This is solved in Solidus v2.5.
+      if SolidusSupport.solidus_gem_version <= Gem::Version.new('2.5.0')
+        paths["app/views"] << "lib/views/backend_v2.4"
+      end
+
       paths["app/views"] << "lib/views/backend"
     end
   end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -1,3 +1,5 @@
+require 'solidus_support'
+
 module SolidusPaypalBraintree
   class Engine < Rails::Engine
     isolate_namespace SolidusPaypalBraintree
@@ -21,15 +23,7 @@ module SolidusPaypalBraintree
 
     config.to_prepare(&method(:activate).to_proc)
 
-    def self.frontend_available?
-      defined?(Spree::Frontend::Engine) == "constant"
-    end
-
-    def self.backend_available?
-      defined?(Spree::Backend::Engine) == "constant"
-    end
-
-    if frontend_available?
+    if SolidusSupport.frontend_available?
       config.assets.precompile += [
         'solidus_paypal_braintree/checkout.js',
         'solidus_paypal_braintree/frontend.js',
@@ -40,13 +34,13 @@ module SolidusPaypalBraintree
       paths["app/views"] << "lib/views/frontend"
     end
 
-    if backend_available?
+    if SolidusSupport.backend_available?
       config.assets.precompile += ["spree/backend/solidus_paypal_braintree.js"]
       paths["app/controllers"] << "lib/controllers/backend"
 
       # We support Solidus v1.2, which requires some different markup in the
       # source form partial. This will take precedence over lib/views/backend.
-      paths["app/views"] << "lib/views/backend_v1.2" if Gem::Version.new(Spree.solidus_version) < Gem::Version.new('1.3')
+      paths["app/views"] << "lib/views/backend_v1.2" if SolidusSupport.solidus_gem_version < Gem::Version.new('1.3')
 
       paths["app/views"] << "lib/views/backend"
     end

--- a/lib/views/backend_v2.4/spree/admin/shared/preference_fields/_hash.html.erb
+++ b/lib/views/backend_v2.4/spree/admin/shared/preference_fields/_hash.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'input_hash fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.text_area attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= text_area_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/spec/features/backend/configuration_spec.rb
+++ b/spec/features/backend/configuration_spec.rb
@@ -1,11 +1,23 @@
 require 'spec_helper'
 
-RSpec.describe "viewing the configuration interface", js: true do
+RSpec.describe "viewing the configuration interface" do
   stub_authorization!
 
   # Regression to ensure this page still renders on old versions of solidus
   scenario "should not raise any errors due to unavailable route helpers" do
     visit "/solidus_paypal_braintree/configurations/list"
     expect(page).to have_content("Braintree Configurations")
+  end
+
+  # Regression to ensure this page renders on Solidus 2.4
+  scenario 'should not raise any errors due to unavailable preference field partial' do
+    Rails.application.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
+    Spree::PaymentMethod.create!(
+      type: 'SolidusPaypalBraintree::Gateway',
+      name: 'Braintree Payments'
+    )
+    visit '/admin/payment_methods'
+    page.find('a[title="Edit"]').click
+    expect(page).to have_field 'Name', with: 'Braintree Payments'
   end
 end


### PR DESCRIPTION
We store two settings inside a hash preference field. Solidus 2.4
is missing this partial. As will hopefully be fixed with Solidus 2.5
we load our own partial if we are using Solidus 2.4

Closes #132 