### PR TITLE
Rescue Braintree void errors and refund instead

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -159,6 +159,25 @@ module SolidusPaypalBraintree
       end
     end
 
+    # Will void the payment depending on its state or return false
+    #
+    # Used by Solidus >= 2.4 instead of +cancel+
+    #
+    # If the transaction has not yet been settled, we can void the transaction.
+    # Otherwise, we return false so Solidus creates a refund instead.
+    #
+    # @api public
+    # @param response_code [String] the transaction id of the payment to void
+    # @return [Response|FalseClass]
+    def try_void(response_code)
+      transaction = braintree.transaction.find(response_code)
+      if transaction.status.in? SolidusPaypalBraintree::Gateway::VOIDABLE_STATUSES
+        void(response_code, nil, {})
+      else
+        false
+      end
+    end
+
     # Creates a new customer profile in Braintree
     #
     # @api public

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -17,6 +17,7 @@ module SolidusPaypalBraintree
 
     VOIDABLE_STATUSES = [
       Braintree::Transaction::Status::SubmittedForSettlement,
+      Braintree::Transaction::Status::SettlementPending,
       Braintree::Transaction::Status::Authorized
     ].freeze
 

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -356,6 +356,42 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       end
     end
 
+    describe '#try_void' do
+      subject { gateway.try_void(source.token) }
+
+      let(:transaction_request) do
+        class_double('Braintree::Transaction',
+          find: transaction_response)
+      end
+
+      before do
+        client = instance_double('Braintree::Gateway')
+        expect(client).to receive(:transaction) { transaction_request }
+        expect(gateway).to receive(:braintree) { client }
+      end
+
+      context 'for voidable payment' do
+        let(:transaction_response) do
+          instance_double('Braintree::Transaction',
+            status: Braintree::Transaction::Status::Authorized)
+        end
+
+        it 'voids the payment' do
+          expect(gateway).to receive(:void)
+          subject
+        end
+      end
+
+      context 'for non-voidable payment' do
+        let(:transaction_response) do
+          instance_double('Braintree::Transaction',
+            status: Braintree::Transaction::Status::Settled)
+        end
+
+        it { is_expected.to be(false) }
+      end
+    end
+
     describe "#create_profile" do
       let(:payment) do
         build(:payment, {

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -382,6 +382,18 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
         end
       end
 
+      context 'for voidable paypal payment' do
+        let(:transaction_response) do
+          instance_double('Braintree::Transaction',
+            status: Braintree::Transaction::Status::SettlementPending)
+        end
+
+        it 'voids the payment' do
+          expect(gateway).to receive(:void)
+          subject
+        end
+      end
+
       context 'for non-voidable payment' do
         let(:transaction_response) do
           instance_double('Braintree::Transaction',

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -380,6 +380,32 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
           expect(gateway).to receive(:void)
           subject
         end
+
+        context 'with error response mentioning an unvoidable transaction' do
+          before do
+            expect(gateway).to receive(:void) do
+              raise ActiveMerchant::ConnectionError.new(
+                'Transaction can only be voided if status is authorized',
+                double
+              )
+            end
+          end
+
+          it { is_expected.to be(false) }
+        end
+
+        context 'with other error response' do
+          before do
+            expect(gateway).to receive(:void) do
+              raise ActiveMerchant::ConnectionError.new(
+                'Server unreachable',
+                double
+              )
+            end
+          end
+
+          it { expect { subject }.to raise_error ActiveMerchant::ConnectionError }
+        end
       end
 
       context 'for voidable paypal payment' do


### PR DESCRIPTION
Sometimes Braintree returns a voidable transaction status although it is not voidable anymore.

According to them there is a hidden state called `settling` that is not returned by the API for a transaction status request.

When we then void we get back an error from the API that leaves the transaction in an unvoided and not-refunded state.

This is solved by catching the error and let Solidus create a refund instead.