### PR TITLE
Remove Transaction#phone validation

### DIFF
--- a/app/models/solidus_paypal_braintree/transaction.rb
+++ b/app/models/solidus_paypal_braintree/transaction.rb
@@ -9,7 +9,6 @@ module SolidusPaypalBraintree
     validates :nonce, presence: true
     validates :payment_method, presence: true
     validates :payment_type, presence: true
-    validates :phone, presence: true
     validates :email, presence: true
 
     validate do

--- a/spec/models/solidus_paypal_braintree/transaction_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_spec.rb
@@ -8,7 +8,6 @@ describe SolidusPaypalBraintree::Transaction do
         nonce: 'abcde-fghjkl-lmnop',
         payment_method: SolidusPaypalBraintree::Gateway.new,
         payment_type: 'ApplePayCard',
-        phone: "555-1234",
         email: "test@example.com"
       }
     end
@@ -48,11 +47,6 @@ describe SolidusPaypalBraintree::Transaction do
 
     context 'no payment_type' do
       let(:valid_attributes) { super().except(:payment_type) }
-      it { is_expected.to be false }
-    end
-
-    context 'no phone' do
-      let(:valid_attributes) { super().except(:phone) }
       it { is_expected.to be false }
     end
 


### PR DESCRIPTION
There are situations where we may have addresses without a phone number, so i think this validation should not be enforced here.
This was introduced in https://github.com/solidusio/solidus_paypal_braintree/pull/16.

Examples:
- When using the Paypal express button from the cart we receive an address without the phone field from Paypal. 
(If there's an optional setting to enable the phone number on the Paypal side i haven't found it).
- On Solidus the `Address#phone` validation can be switched off.