### PR TITLE
Update TransactionAddress#state_code validation

### DIFF
--- a/app/models/solidus_paypal_braintree/transaction_address.rb
+++ b/app/models/solidus_paypal_braintree/transaction_address.rb
@@ -10,14 +10,14 @@ module SolidusPaypalBraintree
       :city, :zip, :state_code, :address_line_1, :address_line_2
 
     validates :first_name, :last_name, :address_line_1, :city, :zip,
-      :state_code, :country_code, presence: true
+      :country_code, presence: true
 
     before_validation do
       self.country_code = country_code.presence || "us"
     end
 
     validates :spree_country, presence: true
-    validates :spree_state, presence: true, if: :should_match_state_model?
+    validates :state_code, :spree_state, presence: true, if: :should_match_state_model?
 
     def initialize(attributes = {})
       country_name = attributes.delete(:country_name) || ""
@@ -57,10 +57,9 @@ module SolidusPaypalBraintree
       address
     end
 
-    # Check to see if this address should match to a state
-    #   model in the database.
+    # Check to see if this address should match to a state model in the database
     def should_match_state_model?
-      spree_country.present? && spree_country.states.any?
+      spree_country.try!(:states_required?)
     end
   end
 end

--- a/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_address_spec.rb
@@ -18,9 +18,8 @@ describe SolidusPaypalBraintree::TransactionAddress do
       }
     end
 
-    before do
-      create :country, iso: 'US'
-    end
+    let!(:country) { create :country, iso: 'US', states_required: true }
+    let!(:state) { create :state, abbr: 'WA', country: country }
 
     it { is_expected.to be true }
 
@@ -58,6 +57,12 @@ describe SolidusPaypalBraintree::TransactionAddress do
     context "no state_code" do
       let(:valid_attributes) { super().except(:state_code) }
       it { is_expected.to be false }
+
+      context "when country does not requires states" do
+        let!(:country) { create :country, iso: 'US', states_required: false }
+
+        it { is_expected.to be true }
+      end
     end
 
     context "no country_code" do
@@ -155,18 +160,18 @@ describe SolidusPaypalBraintree::TransactionAddress do
   describe '#should_match_state_model' do
     subject { described_class.new(country_code: 'US').should_match_state_model? }
 
-    it { is_expected.to be false }
+    it { is_expected.to be_falsey }
 
-    context 'country exists' do
-      let!(:us) { create :country, iso: 'US' }
+    context 'country does not require states' do
+      before { create :country, iso: 'US', states_required: false }
 
       it { is_expected.to be false }
+    end
 
-      context 'country has states' do
-        let!(:state) { create :state, country: us }
+    context 'country requires states' do
+      before { create :country, iso: 'US', states_required: true }
 
-        it { is_expected.to be true }
-      end
+      it { is_expected.to be true }
     end
   end
 


### PR DESCRIPTION
Only validates this field if the country requires states, because this is not always true.

Example:
On an express checkout from the cart button with a german address, the state field is not present on the Paypal form and the payload we receive, because it's not required.
(On Solidus the Germany country has `states_required: true`, and this is wrong.)

This also uses `Address#states_required?` for the check instead of checking objects presence, i think this is more correct.