### PR TITLE
Recalculate payment total when order total decreases

### DIFF
--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -82,10 +82,10 @@ module SolidusPaypalBraintree
 
     def update_payment_total(payment)
       payment_total = order.payments.where(state: %w[checkout pending]).sum(:amount)
-      remaining_total = order.outstanding_balance - payment_total
+      payment_difference = order.outstanding_balance - payment_total
 
-      if remaining_total > 0
-        payment.update!(amount: payment.amount + remaining_total)
+      if payment_difference != 0
+        payment.update!(amount: payment.amount + payment_difference)
       end
     end
   end

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -179,6 +179,31 @@ describe SolidusPaypalBraintree::TransactionImport do
             expect(order.payments.first.amount).to eq 16
           end
         end
+
+        context 'with a less expensive tax category' do
+          before do
+            original_zone = Spree::Zone.create name: 'first address tax'
+            original_zone.members << Spree::ZoneMember.new(zoneable: address.state)
+            original_tax_rate = create :tax_rate, zone: original_zone, amount: 0.2
+
+            # new address is NY
+            ny_zone = Spree::Zone.create name: 'nyc tax'
+            ny_zone.members << Spree::ZoneMember.new(zoneable: new_york)
+            create :tax_rate, tax_category: original_tax_rate.tax_category, zone: ny_zone, amount: 0.1
+          end
+
+          it 'includes the lower tax in the payment' do
+            # so shipments and shipment cost is calculated before transaction import
+            order.next!; order.next!
+            # precondition
+            expect(order.additional_tax_total).to eq 2
+            expect(order.total).to eq 17
+
+            subject
+            expect(order.additional_tax_total).to eq 1
+            expect(order.payments.first.amount).to eq 16
+          end
+        end
       end
     end
 


### PR DESCRIPTION
- Apple Pay does not send street address until the last step. If street
  is a factor in the tax calculation you will have a discrepency after
  the payment is made. The payment amount wasn't decreased when
  the order total was lower