### PR TITLE
Use remote transaction status for admin actions

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -25,6 +25,10 @@ module SolidusPaypalBraintree
       Braintree::Transaction::Status::Settled
     ].freeze
 
+    CAPTURABLE_STATUSES = [
+      Braintree::Transaction::Status::Authorized
+    ].freeze
+
     # This is useful in feature tests to avoid rate limited requests from
     # Braintree
     preference(:client_sdk_enabled, :boolean, default: true)

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -20,6 +20,11 @@ module SolidusPaypalBraintree
       Braintree::Transaction::Status::Authorized
     ].freeze
 
+    REFUNDABLE_STATUSES = [
+      Braintree::Transaction::Status::Settling,
+      Braintree::Transaction::Status::Settled
+    ].freeze
+
     # This is useful in feature tests to avoid rate limited requests from
     # Braintree
     preference(:client_sdk_enabled, :boolean, default: true)

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -34,13 +34,8 @@ module SolidusPaypalBraintree
     end
 
     def can_void?(payment)
-      return false unless payment.response_code
-      transaction = protected_request do
-        braintree_client.transaction.find(payment.response_code)
-      end
-      Gateway::VOIDABLE_STATUSES.include?(transaction.status)
-    rescue ActiveMerchant::ConnectionError
-      false
+      return false unless payment && braintree_transaction(payment)
+      Gateway::VOIDABLE_STATUSES.include?(braintree_transaction(payment).status)
     end
 
     def can_credit?(payment)
@@ -77,6 +72,17 @@ module SolidusPaypalBraintree
       return unless braintree_client && credit_card?
       @braintree_payment_method ||= protected_request do
         braintree_client.payment_method.find(token)
+      end
+    rescue ActiveMerchant::ConnectionError, ArgumentError => e
+      Rails.logger.warn("#{e}: token unknown or missing for #{inspect}")
+      nil
+    end
+
+    def braintree_transaction(payment)
+      response_code = payment.response_code
+      return unless braintree_client && response_code
+      @braintree_transaction ||= protected_request do
+        braintree_client.transaction.find(response_code)
       end
     rescue ActiveMerchant::ConnectionError, ArgumentError => e
       Rails.logger.warn("#{e}: token unknown or missing for #{inspect}")

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -30,7 +30,8 @@ module SolidusPaypalBraintree
     end
 
     def can_capture?(payment)
-      payment.pending? || payment.checkout?
+      return false unless payment && braintree_transaction(payment)
+      Gateway::CAPTURABLE_STATUSES.include?(braintree_transaction(payment).status)
     end
 
     def can_void?(payment)

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -39,7 +39,8 @@ module SolidusPaypalBraintree
     end
 
     def can_credit?(payment)
-      payment.completed? && payment.credit_allowed > 0
+      return false unless payment && braintree_transaction(payment)
+      Gateway::REFUNDABLE_STATUSES.include?(braintree_transaction(payment).status)
     end
 
     def friendly_payment_type

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -71,7 +71,7 @@ module SolidusPaypalBraintree
     private
 
     def braintree_payment_method
-      return unless braintree_client && credit_card?
+      return unless braintree_client
       @braintree_payment_method ||= protected_request do
         braintree_client.payment_method.find(token)
       end


### PR DESCRIPTION
Solidus usually uses the payment state for deciding if a certain admin action (capture, credit, void) is possible for a payment. Do to the async nature of the web this might get out of sync and leads to payments in a non-actionable state for admins. By asking the Braintree gateway for the current transaction status we know if a certain action is possible or not.

I also sneaked in a change that makes it possible for other payment types (besides credit cards) to access the payment method from the gateway. It doesn't make sense to not allow to read the data for other payment types (PayPal, ApplePay) which we support.