### PR TITLE
Restart checkout when cart Paypal button is used

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -4,9 +4,10 @@
  * @constructor
  * @param {object} element - The DOM element of your PayPal button
  */
-SolidusPaypalBraintree.PaypalButton = function(element, paypalOptions) {
+SolidusPaypalBraintree.PaypalButton = function(element, paypalOptions, options) {
   this._element = element;
   this._paypalOptions = paypalOptions || {};
+  this._options = options || {};
   this._client = null;
 
   if(!this._element) {
@@ -74,6 +75,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._tokenizeCallback = function(token
 SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payload) {
   return {
     "payment_method_id" : this._paymentMethodId,
+    "options": this._options,
     "transaction" : {
       "email" : payload.details.email,
       "phone" : payload.details.phone,

--- a/app/assets/javascripts/spree/frontend/paypal_button.js
+++ b/app/assets/javascripts/spree/frontend/paypal_button.js
@@ -1,5 +1,6 @@
 //= require solidus_paypal_braintree/paypal_button
 
+// This is the PayPal button on the cart page
 $(document).ready(function() {
   if (document.getElementById("empty-cart")) {
     $.when(
@@ -22,7 +23,14 @@ $(document).ready(function() {
           flow: 'vault',
           enableShippingAddress: true
         }
-        var button = new SolidusPaypalBraintree.createPaypalButton(document.querySelector("#paypal-button"), paypalOptions);
+        var options = {
+          restart_checkout: true
+        }
+        var button = new SolidusPaypalBraintree.createPaypalButton(
+          document.querySelector("#paypal-button"),
+          paypalOptions,
+          options
+        );
         return button.initialize();
       }).
       insertAfter("#content").

--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -35,7 +35,7 @@ module SolidusPaypalBraintree
       order.user
     end
 
-    def import!(end_state)
+    def import!(end_state, restart_checkout: false)
       if valid?
         order.email = user.try!(:email) || transaction.email
 
@@ -51,6 +51,7 @@ module SolidusPaypalBraintree
           amount: order.total
 
         order.save!
+        order.restart_checkout_flow if restart_checkout
         advance_order(payment, end_state)
       else
         raise InvalidImportError,

--- a/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
+++ b/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
@@ -15,10 +15,11 @@ class SolidusPaypalBraintree::TransactionsController < Spree::StoreController
   def create
     transaction = SolidusPaypalBraintree::Transaction.new transaction_params
     import = SolidusPaypalBraintree::TransactionImport.new(current_order, transaction)
+    restart_checkout = params[:options] && params[:options][:restart_checkout] == "true"
 
     respond_to do |format|
       if import.valid?
-        import.import!(import_state)
+        import.import!(import_state, restart_checkout: restart_checkout)
 
         format.html { redirect_to redirect_url(import) }
         format.json { render json: { redirectUrl: redirect_url(import) } }

--- a/spec/features/frontend/paypal_checkout_spec.rb
+++ b/spec/features/frontend/paypal_checkout_spec.rb
@@ -23,6 +23,7 @@ describe "Checkout", type: :feature, js: true do
 
     it "should check out successfully using one touch" do
       pend_if_paypal_slow do
+        expect_any_instance_of(Spree::Order).to receive(:restart_checkout_flow)
         move_through_paypal_popup
         expect(page).to have_content("Shipments")
         click_on "Place Order"
@@ -48,6 +49,7 @@ describe "Checkout", type: :feature, js: true do
       expect(page).to have_content("SHIPPING METHOD")
       click_button("Save and Continue")
       pend_if_paypal_slow do
+        expect_any_instance_of(Spree::Order).to_not receive(:restart_checkout_flow)
         move_through_paypal_popup
         expect(page).to have_content("Shipments")
         click_on "Place Order"

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -196,5 +196,23 @@ describe SolidusPaypalBraintree::TransactionImport do
         )
       end
     end
+
+    context "checkout flow", vcr: { cassette_name: 'transaction/import/valid' } do
+      it "is not restarted by default" do
+        expect(order).to_not receive(:restart_checkout_flow)
+        subject
+      end
+
+      context "with restart_checkout: true" do
+        subject do
+          described_class.new(order, transaction).import!(end_state, restart_checkout: true)
+        end
+
+        it "is restarted" do
+          expect(order).to receive(:restart_checkout_flow)
+          subject
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The problem:
We have two different Paypal flows here: the express checkout from the cart (address comes from Paypal) and the normal Solidus checkout (address comes from Solidus).

If an user starts the express checkout, and then comes back to the cart (from the confirm page) and restarts it with a different address, we currently don't recalculate all the address-dependent order stuff, thus we can end up with wrong taxes and shipping methods.

This is a quick solution for that: the cart button sends a special param to the Solidus controller that restarts the checkout flow.
The normal checkout flow is unaltered.

Comments or better solutions are welcome :)