### PR TITLE
Use latest Bundler while building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
   directories:
     - travis_phantomjs
 before_install:
-  - "gem install bundler -v 1.14.6"
-  - "bundler -v"
   - "phantomjs --version"
   - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
   - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"


### PR DESCRIPTION
Do not use outdated Bundler version. After the buggy 1.15 release series latest Bundler (1.16) works again.