### PR TITLE
Solidus passes a Spree::Payment object not the payment response code

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -174,6 +174,9 @@ module SolidusPaypalBraintree
     # @param response_code [String] the transaction id of the payment to void
     # @return [Response|FalseClass]
     def try_void(response_code)
+      # If response_code is an instance of Spree::Payment
+      response_code = response_code.response_code if response_code.respond_to?(:response_code)
+
       transaction = braintree.transaction.find(response_code)
       if transaction.status.in? SolidusPaypalBraintree::Gateway::VOIDABLE_STATUSES
         # Sometimes Braintree returns a voidable status although it is not voidable anymore.


### PR DESCRIPTION
`Spree::Payment::Cancellation.cancel` passes an instance of `Spree::Payment` to `SolidusPaypalBraintree::Gateway.try_void` and not the string text code. 

      # Cancels a payment
      #
      # Tries to void the payment by asking the payment method to try a void,
      # if that fails create a refund about the allowed credit amount instead.
      #
      # @param payment [Spree::Payment] - the payment that should be canceled
      #
      def cancel(payment)
        # For payment methods already implemeting `try_void`
        if try_void_available?(payment.payment_method)
          if response = payment.payment_method.try_void(payment)
            payment.send(:handle_void_response, response)
          else
            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
          end
        else
          # For payment methods not yet implemeting `try_void`
          deprecated_behavior(payment)
        end
      end