### PR TITLE
[WIP] Use PayPal Checkout.js

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/client.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/client.js
@@ -168,7 +168,7 @@ SolidusPaypalBraintree.Client.prototype._createDataCollector = function() {
 };
 
 SolidusPaypalBraintree.Client.prototype._createPaypal = function() {
-  return SolidusPaypalBraintree.PromiseShim.convertBraintreePromise(braintree.paypal.create, [{
+  return SolidusPaypalBraintree.PromiseShim.convertBraintreePromise(braintree.paypalCheckout.create, [{
     client: this._braintreeInstance
   }]).then(function (paypalInstance) {
     this._paypalInstance = paypalInstance;

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -8,11 +8,13 @@ SolidusPaypalBraintree.PaypalButton = function(element, paypalOptions) {
   this._element = element;
   this._paypalOptions = paypalOptions || {};
   this._client = null;
+  this._environment = this._paypalOptions.environment || 'sandbox';
+  delete this._paypalOptions.environment;
 
   if(!this._element) {
     throw new Error("Element for the paypal button must be present on the page");
   }
-}
+};
 
 /**
  * Creates the PayPal session using the provided options and enables the button
@@ -31,10 +33,17 @@ SolidusPaypalBraintree.PaypalButton.prototype.initialize = function() {
 SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
   this._paymentMethodId = this._client.paymentMethodId;
 
-  this._element.removeAttribute('disabled');
-  this._element.addEventListener('click', function(event) {
-    this._client.getPaypalInstance().tokenize(this._paypalOptions, this._tokenizeCallback.bind(this));
-  }.bind(this), false);
+  paypal.Button.render({
+    env: this._environment,
+
+    payment: function () {
+      return this._client.getPaypalInstance().createPayment(this._paypalOptions);
+    }.bind(this),
+
+    onAuthorize: function (data, actions) {
+      return this._client.getPaypalInstance().tokenizePayment(data, this._tokenizeCallback.bind(this));
+    }.bind(this)
+  }, this._element);
 };
 
 /**
@@ -60,7 +69,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._tokenizeCallback = function(token
       window.location.href = response.redirectUrl;
     },
     error: function(xhr) {
-      console.error("Error submitting transaction")
+      console.error("Error submitting transaction");
     },
   });
 };
@@ -81,7 +90,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payl
       "payment_type" : payload.type,
       "address_attributes" : this._addressParams(payload)
     }
-  }
+  };
 };
 
 /**

--- a/app/assets/javascripts/spree/backend/solidus_paypal_braintree.js
+++ b/app/assets/javascripts/spree/backend/solidus_paypal_braintree.js
@@ -68,8 +68,8 @@ $(function() {
   if (!$paymentForm.length || !$hostedFields.length) { return; }
 
   $.when(
-    $.getScript("https://js.braintreegateway.com/web/3.22.1/js/client.min.js"),
-    $.getScript("https://js.braintreegateway.com/web/3.22.1/js/hosted-fields.min.js")
+    $.getScript("https://js.braintreegateway.com/web/3.31.0/js/client.min.js"),
+    $.getScript("https://js.braintreegateway.com/web/3.31.0/js/hosted-fields.min.js")
   ).done(function() {
     $hostedFields.each(function() {
       var $this = $(this),

--- a/app/assets/javascripts/spree/frontend/paypal_button.js
+++ b/app/assets/javascripts/spree/frontend/paypal_button.js
@@ -4,29 +4,23 @@ $(document).ready(function() {
   if (document.getElementById("empty-cart")) {
     $.when(
       $.getScript("https://js.braintreegateway.com/web/3.31.0/js/client.min.js"),
-      $.getScript("https://js.braintreegateway.com/web/3.31.0/js/paypal.min.js"),
+      $.getScript("https://js.braintreegateway.com/web/3.31.0/js/paypal-checkout.min.js"),
       $.getScript("https://js.braintreegateway.com/web/3.31.0/js/data-collector.min.js")
     ).done(function() {
+      $("#content").append('<div id="paypal-button"/>');
       $('<script/>').attr({
-        'data-merchant' : "braintree",
-        'data-id' : "paypal-button",
-        'data-button' : "checkout",
-        'data-color' : "blue",
-        'data-size' : "medium",
-        'data-shape' : "pill",
-        'data-button_type' : "button",
-        'data-button_disabled' : "true"
+        'data-version-4' : "true"
       }).
       load(function() {
         var paypalOptions = {
           flow: 'vault',
           enableShippingAddress: true
-        }
+        };
         var button = new SolidusPaypalBraintree.createPaypalButton(document.querySelector("#paypal-button"), paypalOptions);
         return button.initialize();
       }).
       insertAfter("#content").
-      attr('src', 'https://www.paypalobjects.com/api/button.js?')
+      attr('src', 'https://www.paypalobjects.com/api/checkout.js');
     });
   }
 });

--- a/app/assets/javascripts/spree/frontend/paypal_button.js
+++ b/app/assets/javascripts/spree/frontend/paypal_button.js
@@ -3,9 +3,9 @@
 $(document).ready(function() {
   if (document.getElementById("empty-cart")) {
     $.when(
-      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/client.min.js"),
-      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/paypal.min.js"),
-      $.getScript("https://js.braintreegateway.com/web/3.22.1/js/data-collector.min.js")
+      $.getScript("https://js.braintreegateway.com/web/3.31.0/js/client.min.js"),
+      $.getScript("https://js.braintreegateway.com/web/3.31.0/js/paypal.min.js"),
+      $.getScript("https://js.braintreegateway.com/web/3.31.0/js/data-collector.min.js")
     ).done(function() {
       $('<script/>').attr({
         'data-merchant' : "braintree",

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -2,19 +2,19 @@
 <% id = payment_method.id %>
 
 <% content_for :head do %>
-  <script src="https://js.braintreegateway.com/web/3.22.1/js/client.min.js"></script>
-  <script src="https://js.braintreegateway.com/web/3.22.1/js/data-collector.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.31.0/js/client.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.31.0/js/data-collector.min.js"></script>
 
   <% if current_store.braintree_configuration.paypal? %>
-    <script src="https://js.braintreegateway.com/web/3.22.1/js/paypal.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.31.0/js/paypal.min.js"></script>
   <% end %>
 
   <% if current_store.braintree_configuration.credit_card? %>
-    <script src="https://js.braintreegateway.com/web/3.22.1/js/hosted-fields.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.31.0/js/hosted-fields.min.js"></script>
   <% end %>
 
   <% if current_store.braintree_configuration.apple_pay? %>
-    <script src="https://js.braintreegateway.com/web/3.22.1/js/apple-pay.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.31.0/js/apple-pay.min.js"></script>
   <% end %>
 
   <%= javascript_include_tag "solidus_paypal_braintree/checkout" %>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -6,7 +6,7 @@
   <script src="https://js.braintreegateway.com/web/3.31.0/js/data-collector.min.js"></script>
 
   <% if current_store.braintree_configuration.paypal? %>
-    <script src="https://js.braintreegateway.com/web/3.31.0/js/paypal.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.31.0/js/paypal-checkout.min.js"></script>
   <% end %>
 
   <% if current_store.braintree_configuration.credit_card? %>
@@ -21,16 +21,8 @@
 <% end %>
 
 <% if current_store.braintree_configuration.paypal? %>
-  <script src="https://www.paypalobjects.com/api/button.js?"
-          data-merchant="braintree"
-          data-id="paypal-button"
-          data-button="checkout"
-          data-color="blue"
-          data-size="medium"
-          data-shape="pill"
-          data-button_type="button"
-          data-button_disabled="true"
-          ></script>
+  <div id="paypal-button"></div>
+  <script src="https://www.paypalobjects.com/api/checkout.js" data-version-4></script>
 
   <script>
     var address = {
@@ -48,7 +40,9 @@
       flow: 'vault',
       enableShippingAddress: true,
       shippingAddressOverride: address,
-      shippingAddressEditable: false
+      shippingAddressEditable: false,
+      shippingAddressEditable: false,
+      environment: '<%= Rails.env.production? ? "production" : "sandbox" %>'
     }
 
     var button = new SolidusPaypalBraintree.createPaypalButton(document.querySelector("#paypal-button"), paypalOptions);

--- a/spec/features/frontend/paypal_checkout_spec.rb
+++ b/spec/features/frontend/paypal_checkout_spec.rb
@@ -38,7 +38,6 @@ describe "Checkout", type: :feature, js: true do
     end
 
     it "should check out successfully through regular checkout" do
-      expect(page).to have_button("paypal-button")
       click_button("Checkout")
       fill_in("order_email", with: "stembolt_buyer@stembolttest.com")
       click_button("Continue")
@@ -65,9 +64,9 @@ describe "Checkout", type: :feature, js: true do
   # this greatly increases the test time, so it is left out since CI runs
   # these with poltergeist.
   def move_through_paypal_popup
-    expect(page).to have_button("paypal-button")
+    expect(page).to have_css('#paypal-button .paypal-button')
     popup = page.window_opened_by do
-      click_button("paypal-button")
+      find('#paypal-button .paypal-button').click
     end
     page.switch_to_window(popup)
 


### PR DESCRIPTION
# Work in progress

Closes #157 

## Todo

- [x] Update Braintree client libs to 3.31.0
- [x] Use `paypal-checkout.js` instead of deprecated `paypal.js`
- [ ] Refactor the PayPal cart button into a partial, so that we can pass the `Rails.env`
- [ ] Fix specs (maybe move to chromedriver for feature specs? #161)