### PR TITLE
Express Checkout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Payment methods can accept preferences either directly entered in admin, or from
         environment: Rails.env.production? ? 'production' : 'sandbox',
         merchant_id: ENV['BRAINTREE_MERCHANT_ID'],
         public_key: ENV['BRAINTREE_PUBLIC_KEY'],
-        private_key: ENV['BRAINTREE_PRIVATE_KEY']
+        private_key: ENV['BRAINTREE_PRIVATE_KEY'],
+        paypal_flow: 'vault', # 'checkout' is accepted too
       }
     )
   end
@@ -155,8 +156,10 @@ store's configuration.
 The checkout view
 [initializes the PayPal button](/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb)
 using the
-[vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
-which allows the source to be reused.
+[Vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
+which allows the source to be reused. If you want, you can use [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3)
+instead, which doesn't allow you to reuse sources but allows your customers to pay with their PayPal
+balance (see setup instructions).
 
 If you are creating your own checkout view or would like to customize the
 [options that get passed to tokenize](https://braintree.github.io/braintree-web/3.6.3/PayPal.html#tokenize)

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -264,6 +264,12 @@ module SolidusPaypalBraintree
 
     private
 
+    # Whether to store this payment method in the PayPal Vault. This only works when the checkout
+    # flow is "vault", so make sure to call +super+ if you override it.
+    def store_in_vault
+      preferred_paypal_flow == 'vault'
+    end
+
     def logger
       Braintree::Configuration.logger.clone.tap do |logger|
         logger.level = Rails.logger.level
@@ -295,7 +301,7 @@ module SolidusPaypalBraintree
       end
 
       params[:channel] = "Solidus"
-      params[:options] = { store_in_vault_on_success: (preferred_paypal_flow == 'vault') }
+      params[:options] = { store_in_vault_on_success: store_in_vault }
 
       if submit_for_settlement
         params[:options][:submit_for_settlement] = true
@@ -366,7 +372,7 @@ module SolidusPaypalBraintree
     def customer_profile_params(payment)
       params = {}
 
-      if preferred_paypal_flow == 'vault' && payment.source.try(:nonce)
+      if store_in_vault && payment.source.try(:nonce)
         params[:payment_method_nonce] = payment.source.nonce
       end
 

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -38,6 +38,9 @@ module SolidusPaypalBraintree
     preference(:merchant_currency_map, :hash, default: {})
     preference(:paypal_payee_email_map, :hash, default: {})
 
+    # Which checkout flow to use (vault/checkout)
+    preference(:paypal_flow, :string, default: 'vault')
+
     def partial_name
       "paypal_braintree"
     end
@@ -292,7 +295,7 @@ module SolidusPaypalBraintree
       end
 
       params[:channel] = "Solidus"
-      params[:options] = { store_in_vault_on_success: true }
+      params[:options] = { store_in_vault_on_success: (preferred_paypal_flow == 'vault') }
 
       if submit_for_settlement
         params[:options][:submit_for_settlement] = true
@@ -363,7 +366,7 @@ module SolidusPaypalBraintree
     def customer_profile_params(payment)
       params = {}
 
-      if payment.source.try(:nonce)
+      if preferred_paypal_flow == 'vault' && payment.source.try(:nonce)
         params[:payment_method_nonce] = payment.source.nonce
       end
 

--- a/app/views/spree/shared/_paypal_checkout_button.html.erb
+++ b/app/views/spree/shared/_paypal_checkout_button.html.erb
@@ -15,7 +15,9 @@
   }
 
   var paypalOptions = {
-    flow: 'vault',
+    flow: '<%= SolidusPaypalBraintree::Gateway.first.preferred_paypal_flow %>',
+    amount: '<%= current_order.total %>',
+    currency: '<%= current_order.currency %>',
     enableShippingAddress: true,
     shippingAddressOverride: address,
     shippingAddressEditable: false,


### PR DESCRIPTION
Allows users to choose between Vault and Express Checkout via a gateway-level preference.