### PR TITLE
Fix error display

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/constants.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/constants.js
@@ -60,3 +60,14 @@ SolidusPaypalBraintree = {
     return new (Function.prototype.bind.apply(klass, [null].concat(normalizedArgs)));
   }
 };
+
+BraintreeError = {
+  DEFAULT: "Something bad happened!",
+
+  getErrorFromSlug: function(slug) {
+    error = BraintreeError.DEFAULT
+    if (slug in BraintreeError)
+      error = BraintreeError[slug]
+    return error
+  }
+}

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -70,7 +70,22 @@ SolidusPaypalBraintree.PaypalButton.prototype._tokenizeCallback = function(token
       window.location.href = response.redirectUrl;
     },
     error: function(xhr) {
-      console.error("Error submitting transaction");
+      var errorText = BraintreeError.DEFAULT;
+
+      if (xhr.responseJSON && xhr.responseJSON.errors) {
+        var errors = [];
+        $.each(xhr.responseJSON.errors, function(key, values) {
+          $.each(values, function(index, value) {
+            errors.push(key + " " + value)
+          });
+        });
+
+        if (errors.length > 0)
+          errorText = errors.join(", ");
+      }
+
+      console.error("Error submitting transaction: " + errorText);
+      SolidusPaypalBraintree.showError(errorText);
     },
   });
 };

--- a/app/views/spree/shared/_braintree_errors.html.erb
+++ b/app/views/spree/shared/_braintree_errors.html.erb
@@ -1,19 +1,10 @@
 <script type="text/javascript">
-  BraintreeError = {
-    HOSTED_FIELDS_FIELDS_EMPTY: "<%= I18n.t('solidus_paypal_braintree.errors.empty_fields')%>",
-    HOSTED_FIELDS_FIELDS_INVALID: "<%= I18n.t('solidus_paypal_braintree.errors.invalid_fields')%>",
-    HOSTED_FIELDS_FAILED_TOKENIZATION: "<%= I18n.t('solidus_paypal_braintree.errors.invalid_card')%>",
-    HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR: "<%= I18n.t('solidus_paypal_braintree.errors.network_error')%>",
-    HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME: "<%= I18n.t('solidus_paypal_braintree.errors.duplicate_iframe')%>",
-    HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE: "<%= I18n.t('solidus_paypal_braintree.errors.fail_on_duplicate')%>",
-    HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED: "<%= I18n.t('solidus_paypal_braintree.errors.cvv_verification_failed')%>",
-
-    getErrorFromSlug: function(slug) {
-      // Default error message
-      error = "<%= I18n.t('solidus_paypal_braintree.errors.default_error')%>"
-      if (slug in BraintreeError)
-        error = BraintreeError[slug]
-      return error
-    }
-  }
+  BraintreeError.DEFAULT = "<%= I18n.t('solidus_paypal_braintree.errors.default_error')%>"
+  BraintreeError.HOSTED_FIELDS_FIELDS_EMPTY = "<%= I18n.t('solidus_paypal_braintree.errors.empty_fields')%>"
+  BraintreeError.HOSTED_FIELDS_FIELDS_INVALID = "<%= I18n.t('solidus_paypal_braintree.errors.invalid_fields')%>"
+  BraintreeError.HOSTED_FIELDS_FAILED_TOKENIZATION = "<%= I18n.t('solidus_paypal_braintree.errors.invalid_card')%>"
+  BraintreeError.HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR = "<%= I18n.t('solidus_paypal_braintree.errors.network_error')%>"
+  BraintreeError.HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME = "<%= I18n.t('solidus_paypal_braintree.errors.duplicate_iframe')%>"
+  BraintreeError.HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE = "<%= I18n.t('solidus_paypal_braintree.errors.fail_on_duplicate')%>"
+  BraintreeError.HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED = "<%= I18n.t('solidus_paypal_braintree.errors.cvv_verification_failed')%>"
 </script>

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -1,7 +1,5 @@
 <% prefix = "payment_source[#{id}]" %>
 
-<%= render partial: "spree/shared/braintree_errors" %>
-
 <div class="hosted-fields">
   <div class="field" data-hook="card_number">
     <%= label_tag "card_number#{id}", Spree::CreditCard.human_attribute_name(:number), class: "required" %>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -15,3 +15,5 @@
 <% if current_store.braintree_configuration.apple_pay? %>
   <%= render "spree/shared/apple_pay_button" %>
 <% end %>
+
+<%= render "spree/shared/braintree_errors" %>

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency "braintree", '~> 2.65'
   s.add_dependency 'activemerchant', '~> 1.48'
 
-  s.add_development_dependency 'capybara', '~> 2.18'
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'poltergeist'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,25 +35,6 @@ require 'solidus_paypal_braintree/factories'
 
 ApplicationController.prepend_view_path "spec/fixtures/views"
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
-
-Capybara.register_driver(:headless_chrome) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome \
-    chromeOptions: { args: %w[headless disable-gpu window-size=1600,1024] }
-  capybara_options = {
-    browser: :chrome,
-    desired_capabilities: capabilities
-  }
-
-  Capybara::Selenium::Driver.new(app, capybara_options)
-end
-
-Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
-
 VCR.configure do |c|
   c.cassette_library_dir = "spec/fixtures/cassettes"
   c.hook_into :webmock
@@ -78,6 +59,7 @@ RSpec.configure do |config|
   config.include SolidusPaypalBraintree::GatewayHelpers
 
   config.before(:each, type: :feature, js: true) do |ex|
-    Capybara.current_driver = ex.metadata[:driver] || :headless_chrome
+    Capybara.current_driver = ex.metadata[:driver] || :selenium_chrome_headless
+    page.driver.browser.manage.window.resize_to(1600, 1024)
   end
 end


### PR DESCRIPTION
We currently don't display transaction errors on the checkout. This behaviour is very confusing for the user.
Even if the user may not be able to fix the error by itself, we should make clear that something bad happened.

This is the result: 
<img width="484" alt="screen shot 2018-07-06 at 16 06 55" src="https://user-images.githubusercontent.com/557414/42383136-a3276704-8136-11e8-9409-e7f5b6155708.png">
