### PR TITLE
Add existing payments partial

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -81,7 +81,7 @@ module SolidusPaypalBraintree
     private
 
     def braintree_payment_method
-      return unless braintree_client && credit_card?
+      return unless braintree_client
       @braintree_payment_method ||= protected_request do
         braintree_client.payment_method.find(token)
       end

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -17,7 +17,7 @@ module SolidusPaypalBraintree
     scope(:with_payment_profile, -> { joins(:customer) })
     scope(:credit_card, -> { where(payment_type: CREDIT_CARD) })
 
-    delegate :last_4, :card_type, :expiration_month, :expiration_year,
+    delegate :last_4, :card_type, :expiration_month, :expiration_year, :email,
       to: :braintree_payment_method, allow_nil: true
 
     # Aliases to match Spree::CreditCard's interface
@@ -75,7 +75,11 @@ module SolidusPaypalBraintree
     end
 
     def display_number
-      "XXXX-XXXX-XXXX-#{last_digits.to_s.rjust(4, 'X')}"
+      if paypal?
+        email
+      else
+        "XXXX-XXXX-XXXX-#{last_digits.to_s.rjust(4, 'X')}"
+      end
     end
 
     private

--- a/app/views/spree/checkout/existing_payment/_paypal_braintree.html.erb
+++ b/app/views/spree/checkout/existing_payment/_paypal_braintree.html.erb
@@ -1,0 +1,10 @@
+<tr id="<%= dom_id(wallet_payment_source, 'spree')%>" class="<%= cycle('even', 'odd') %>">
+  <td>
+    <%= radio_button_tag "order[wallet_payment_source_id]",
+                          wallet_payment_source.id,
+                          default,
+                          class: "existing-cc-radio" %>
+  </td>
+  <td><%= wallet_payment_source.payment_source.friendly_payment_type %></td>
+  <td><%= wallet_payment_source.payment_source.display_number %></td>
+</tr>

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -263,7 +263,8 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
   end
 
   describe "#display_number" do
-    let(:payment_source) { described_class.new }
+    let(:type) { nil }
+    let(:payment_source) { described_class.new(payment_type: type) }
     subject { payment_source.display_number }
 
     context "when last_digits is a number" do
@@ -280,6 +281,16 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
       end
 
       it { is_expected.to eq 'XXXX-XXXX-XXXX-XXXX' }
+    end
+
+    context "when is a PayPal source" do
+      let(:type) { "PayPalAccount" }
+
+      before do
+        allow(payment_source).to receive(:email).and_return('user@example.com')
+      end
+
+      it { is_expected.to eq 'user@example.com' }
     end
   end
 


### PR DESCRIPTION
This fixes #135.
It's similar to #165 but a bit more generic and simple: i think displaying the CC last digits is enough.

This should also work for Apply Pay but i did not test it. 

This is what i get on vanilla Solidus:
<img width="451" alt="screen shot 2018-07-06 at 18 16 56" src="https://user-images.githubusercontent.com/557414/42389379-d26759ae-8148-11e8-8d11-50e4623536fa.png">
