### PR TITLE
Remove Deface

### DIFF
--- a/app/overrides/admin_navigation_menu.rb
+++ b/app/overrides/admin_navigation_menu.rb
@@ -1,6 +1,0 @@
-Deface::Override.new(
-  virtual_path: "spree/admin/shared/_settings_sub_menu",
-  name: "solidus_paypal_braintree_admin_navigation_configuration",
-  insert_bottom: "[data-hook='admin_settings_sub_tabs']",
-  partial: "solidus_paypal_braintree/configurations/admin_tab"
-)

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -48,6 +48,17 @@ module SolidusPaypalBraintree
       end
 
       paths["app/views"] << "lib/views/backend"
+
+      initializer "solidus_paypal_braintree_admin_menu_item", after: "register_solidus_paypal_braintree_gateway" do |app|
+        Spree::Backend::Config.configure do |config|
+          config.menu_items << config.class::MenuItem.new(
+            [:braintree],
+            'cc-paypal',
+            url: '/solidus_paypal_braintree/configurations/list',
+            condition: -> { can?(:list, SolidusPaypalBraintree::Configuration) }
+          )
+        end
+      end
     end
   end
 end

--- a/lib/views/backend/solidus_paypal_braintree/configurations/_admin_tab.html.erb
+++ b/lib/views/backend/solidus_paypal_braintree/configurations/_admin_tab.html.erb
@@ -1,3 +1,0 @@
-<%= tab :braintree, match_path: /braintree\/configurations/,
-  url: solidus_paypal_braintree.list_configurations_path
-%>


### PR DESCRIPTION
Solidus no longer uses Deface, and the implicit dependency on it in this
plugin broke our Solidus app. We decided to remove the use of Deface
rather than make it a dependency, following Solidus' lead.