### PR TITLE
Add fields to match Spree::CreditCard's interface

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -17,8 +17,15 @@ module SolidusPaypalBraintree
     scope(:with_payment_profile, -> { joins(:customer) })
     scope(:credit_card, -> { where(payment_type: CREDIT_CARD) })
 
-    delegate :last_4, :card_type, to: :braintree_payment_method, allow_nil: true
+    delegate :last_4, :card_type, :expiration_month, :expiration_year,
+      to: :braintree_payment_method, allow_nil: true
+
+    # Aliases to match Spree::CreditCard's interface
     alias_method :last_digits, :last_4
+    alias_method :month, :expiration_month
+    alias_method :year, :expiration_year
+    alias_method :cc_type, :card_type
+
 
     # we are not currenctly supporting an "imported" flag
     def imported


### PR DESCRIPTION
These fields will help make SolidusPaypalBraintree::Source be a little easier to interchange with Spree::CreditCard.