### PR TITLE
Fix test gems versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,11 @@ source 'https://rubygems.org'
 branch = ENV.fetch("SOLIDUS_BRANCH", "master")
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-if branch == 'master' || branch >= "v2.3"
-  gem "rails-controller-testing", group: :test
-  gem 'rails', '~> 5.1.0' # HACK: broken bundler dependency resolution
-elsif branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
-  gem 'rails', '~> 5.0.3' # HACK: broken bundler dependency resolution
+gem 'rails-controller-testing'
+if branch < "v2.5"
+  gem 'factory_bot', '4.10.0'
 else
-  gem "rails", '~> 4.2.0' # HACK: broken bundler dependency resolution
-  gem "rails_test_params_backport", group: :test
+  gem 'factory_bot', '> 4.10.0'
 end
 
 # Provides basic authentication functionality for testing parts of your engine


### PR DESCRIPTION
Removes gems we do not need anymore as we do not test Solidus < 2.2 any more and use `factory_bot` versions that work with Solidus branches.