### PR TITLE
Display Paypal setup errors on console

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/client.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/client.js
@@ -173,7 +173,9 @@ SolidusPaypalBraintree.Client.prototype._createPaypal = function() {
   }]).then(function (paypalInstance) {
     this._paypalInstance = paypalInstance;
     return paypalInstance;
-  }.bind(this));
+  }.bind(this), function(error) {
+    console.error(error.name + ':', error.message);
+  });
 };
 
 SolidusPaypalBraintree.Client.prototype._createApplepay = function() {


### PR DESCRIPTION
This was useful for me to understand why the Paypal button was missing:

<img width="755" alt="screen shot 2018-12-18 at 14 12 01" src="https://user-images.githubusercontent.com/557414/50156356-f052fd80-02ce-11e9-8e38-071168c0b1d3.png">
