### PR TITLE
Allow null address Paypal payload

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -119,6 +119,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payl
 SolidusPaypalBraintree.PaypalButton.prototype._addressParams = function(payload) {
   var first_name, last_name;
   var payload_address = payload.details.shippingAddress || payload.details.billingAddress;
+  if (!payload_address) return {};
 
   if (payload_address.recipientName) {
     first_name = payload_address.recipientName.split(" ")[0];


### PR DESCRIPTION
This is needed to use `enableShippingAddress: false` without errors.