### PR TITLE
Check for rails-ujs object when re-enabling button

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/checkout.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/checkout.js
@@ -15,9 +15,16 @@ $(function() {
      * https://github.com/rails/jquery-rails/blob/master/vendor/assets/javascripts/jquery_ujs.js#L517
      * The only way we can re-enable it is by delaying longer than that timeout
      * or stopping propagation so their submit handler doesn't run. */
-    if ($.rails) {
+    if ($.rails && typeof $.rails.enableFormElement !== 'undefined') {
       setTimeout(function () {
         $.rails.enableFormElement($submitButton);
+        $submitButton.attr("disabled", false).removeClass("disabled").addClass("primary");
+      }, 100);
+    } else if (typeof Rails !== 'undefined' && typeof Rails.enableElement !== 'undefined') {
+      /* Indicates that we have rails-ujs instead of jquery-ujs. Rails-ujs was added to rails
+       * core in Rails 5.1.0 */
+      setTimeout(function () {
+        Rails.enableElement($submitButton[0]);
         $submitButton.attr("disabled", false).removeClass("disabled").addClass("primary");
       }, 100);
     } else {


### PR DESCRIPTION
When using this gem in a project with Rails 5.2.0, I noticed that the "Save and Continue" button to submit credit card information using the Braintree hosted fields was disabled.

I tracked the issue to a call to $.rails.enableFormElement. This method likely exists for people that are using older versions of Rails and jquery-ujs. However, at Rails 5.1.0, jquery-ujs was "adapted" into the rails core as rails-ujs. rails-ujs has a slightly different way of enabling elements.

I added a check to make sure that if $.rails exists, it has the appropriate method. If not, a further check is performed to determine if Rails (the rails-ujs object) exists. If so, it uses a different way to enable the submit button.

Let me know if you see anything I can improve.
Thanks,
Jeff
