### PR TITLE
Make nonce-only payment sources non-reusable

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -67,7 +67,7 @@ module SolidusPaypalBraintree
     end
 
     def reusable?
-      true
+      token.present?
     end
 
     def credit_card?

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -332,4 +332,20 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#reusable?' do
+    let(:payment_source) { described_class.new(token: token, nonce: nonce) }
+    let(:nonce) { 'nonce67890' }
+    subject { payment_source.reusable? }
+
+    context 'when source token is present' do
+      let(:token) { 'token12345' }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when source token is nil' do
+      let(:token) { nil }
+      it { is_expected.to be_falsy }
+    end
+  end
 end


### PR DESCRIPTION
Solidus tries to present reusable payment sources to customers from
their wallet. Subscriptions can cause a non-reusable payment source to
be added to the user's wallet. We need to prevent that source from being
made available to users, since the nonce will almost certainly fail.

Fixes https://github.com/solidusio/solidus_paypal_braintree/issues/203