### PR TITLE
Fix ambiguous behavior in generate_token method

### DIFF
--- a/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
+++ b/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
@@ -7,7 +7,7 @@ module SolidusPaypalBraintree
     before_action :load_gateway
 
     def create
-      render json: { client_token: @gateway.generate_token, payment_method_id: @gateway.id }
+      render json: { client_token: generate_token, payment_method_id: @gateway.id }
     end
 
     private
@@ -24,6 +24,13 @@ module SolidusPaypalBraintree
           end
         @gateway = ::SolidusPaypalBraintree::Gateway.where(active: true).merge(store_payment_methods_scope).first!
       end
+    end
+
+    def generate_token
+      @gateway.generate_token
+    rescue ::SolidusPaypalBraintree::Gateway::TokenGenerationDisabledError => error
+      Rails.logger.error error
+      nil
     end
   end
 end

--- a/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
+++ b/app/controllers/solidus_paypal_braintree/client_tokens_controller.rb
@@ -7,7 +7,12 @@ module SolidusPaypalBraintree
     before_action :load_gateway
 
     def create
-      render json: { client_token: generate_token, payment_method_id: @gateway.id }
+      token = @gateway.generate_token
+      if token
+        render json: { client_token: token, payment_method_id: @gateway.id }
+      else
+        render json: { error: Gateway::TOKEN_GENERATION_DISABLED_MESSAGE }, status: :unprocessable_entity
+      end
     end
 
     private
@@ -28,8 +33,8 @@ module SolidusPaypalBraintree
 
     def generate_token
       @gateway.generate_token
-    rescue ::SolidusPaypalBraintree::Gateway::TokenGenerationDisabledError => error
-      Rails.logger.error error
+    rescue ::SolidusPaypalBraintree::Gateway::TokenGenerationDisabledError => e
+      Rails.logger.error e
       nil
     end
   end

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -686,7 +686,7 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
         gateway
       end
 
-      it { is_expected.to match(/Token generation is disabled/) }
+      it { expect { subject }.to raise_error SolidusPaypalBraintree::Gateway::TokenGenerationDisabledError }
     end
   end
 end


### PR DESCRIPTION
The `SolidusPaypalBraintree::Gateway#generate_token` method is ambiguous
on success and failure. Both results will return a string. To be more
explicit, this method should raise an error which can be handled by the
app.

Closes https://github.com/solidusio/solidus_paypal_braintree/issues/208