### PR TITLE
Add API payment source view for Braintree payments

### DIFF
--- a/app/views/spree/api/source_views/_paypal_braintree.json.jbuilder
+++ b/app/views/spree/api/source_views/_paypal_braintree.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.call(payment_source, :id, :token, :created_at)


### PR DESCRIPTION
The solidus_paypal_braintree does not provide an API view for their
payment sources, which causes errors in the admin panel and when
using the API.

See https://github.com/solidusio/solidus_paypal_braintree/issues/167.