### PR TITLE
Extension maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ rvm:
   - 2.5
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -16,7 +16,7 @@
     <div class="input" id="card_code<%= id %>"></div>
 
     <a href="/content/cvv" class="info cvvLink" target="_blank">
-      (<%= Spree.t(:what_is_this) %>)
+      (<%= I18n.t("spree.what_is_this") %>)
     </a>
   </div>
 

--- a/lib/solidus_paypal_braintree/factories.rb
+++ b/lib/solidus_paypal_braintree/factories.rb
@@ -12,7 +12,7 @@ FactoryBot.modify do
   # As we match the body in our VCR settings VCR can not match the request anymore and therefore cannot replay existing cassettes.
   #
   factory :address do
-    zipcode '21088-0255'
-    lastname "Doe"
+    zipcode { '21088-0255' }
+    lastname { 'Doe' }
   end
 end

--- a/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -6,7 +6,7 @@
       <% previous_cards.each do |card| %>
         <label><%= radio_button_tag :card, card.id, card == previous_cards.first %> <%= card.display_number %><br /></label>
       <% end %>
-      <label><%= radio_button_tag :card, "new", false, { id: "card_new#{id}" } %> <%= Spree.t(:use_new_cc) %></label>
+      <label><%= radio_button_tag :card, "new", false, { id: "card_new#{id}" } %> <%= I18n.t("spree.use_new_cc") %></label>
     <% end %>
   </div>
 

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
@@ -4,10 +4,10 @@
   <div class="row">
     <div class="alpha six columns">
       <dl>
-        <dt><%= Spree.t(:identifier) %>:</dt>
+        <dt><%= I18n.t("spree.identifier") %>:</dt>
         <dd><%= payment.number %></dd>
 
-        <dt><%= Spree.t(:response_code) %>:</dt>
+        <dt><%= I18n.t("spree.response_code") %>:</dt>
         <dd><%= braintree_transaction_link(payment) %></dd>
 
         <% if payment.source.token.present? %>

--- a/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -6,7 +6,7 @@
       <% previous_cards.each do |card| %>
         <label><%= radio_button_tag :card, card.id, card == previous_cards.first %> <%= card.display_number %><br /></label>
       <% end %>
-      <label><%= radio_button_tag :card, "new", false, { id: "card_new#{id}" } %> <%= Spree.t(:use_new_cc) %></label>
+      <label><%= radio_button_tag :card, "new", false, { id: "card_new#{id}" } %> <%= I18n.t("spree.use_new_cc") %></label>
     <% end %>
   </div>
 

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.53.0'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'vcr'
 end

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -10,7 +10,7 @@ shared_context "checkout setup" do
     create(:store, payment_methods: [gateway, braintree]).tap do |store|
       store.braintree_configuration.update!(credit_card: true)
     end
-    order = OrderWalkthrough.up_to(:delivery)
+    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
     user = create(:user)
     order.user = user

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -10,7 +10,12 @@ shared_context "checkout setup" do
     create(:store, payment_methods: [gateway, braintree]).tap do |store|
       store.braintree_configuration.update!(credit_card: true)
     end
-    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
+
+    if SolidusSupport.solidus_gem_version >= Gem::Version.new('2.6.0')
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
+    else
+      order = OrderWalkthrough.up_to(:delivery)
+    end
 
     user = create(:user)
     order.user = user

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -190,7 +190,7 @@ describe SolidusPaypalBraintree::TransactionImport do
             # new address is NY
             ny_zone = Spree::Zone.create name: 'nyc tax'
             ny_zone.members << Spree::ZoneMember.new(zoneable: new_york)
-            create :tax_rate, tax_category: original_tax_rate.tax_category, zone: ny_zone, amount: 0.1
+            create :tax_rate, tax_categories: [original_tax_rate.tax_categories.first], zone: ny_zone, amount: 0.1
           end
 
           it 'includes the lower tax in the payment' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,8 @@ require 'solidus_paypal_braintree/factories'
 
 ApplicationController.prepend_view_path "spec/fixtures/views"
 
+FactoryBot.use_parent_strategy = false
+
 VCR.configure do |c|
   c.cassette_library_dir = "spec/fixtures/cassettes"
   c.hook_into :webmock


### PR DESCRIPTION
This PR will introduce the following changes to get a green Travis build once again:

* Update Travis build matrix (see commit's description for details)
* Use dynamic attributes on factories
* Set `FactoryBot.use_parent_strategy` to `false` (see commit's description for details)
* Lock SQLite3 to version 1.3 (see commit's description for details)
* Fix deprecation warnings