### PR TITLE
Fix translation key

### DIFF
--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -54,6 +54,7 @@ module SolidusPaypalBraintree
           config.menu_items << config.class::MenuItem.new(
             [:braintree],
             'cc-paypal',
+            label: 'braintree',
             url: '/solidus_paypal_braintree/configurations/list',
             condition: -> { can?(:list, SolidusPaypalBraintree::Configuration) }
           )


### PR DESCRIPTION
Avoids scenarios where the translation is built like `spree.admin.tab.Braintree`, with the label this doesn't affect it