### PR TITLE
Simplify Solidus Dependencies

### DIFF
--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -1,1 +1,3 @@
-Spree::Admin::PaymentsController.helper :braintree_admin
+if SolidusSupport.backend_available?
+  Spree::Admin::PaymentsController.helper :braintree_admin
+end

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency "solidus", ['>= 1.0', '< 3']
+  s.add_dependency "solidus_api", ['>= 1.0', '< 3']
+  s.add_dependency "solidus_core", ['>= 1.0', '< 3']
   s.add_dependency "solidus_support", '>= 0.1.3'
   s.add_dependency "braintree", '~> 2.65'
   s.add_dependency 'activemerchant', '~> 1.48'


### PR DESCRIPTION
This moves the solidus dependency imports to only directly import
solidus_core and solidus_api through the gemspec.