### PR TITLE
Fix undefined local variable or method `id' error

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <% if current_store.braintree_configuration.apple_pay? %>
-  <%= render "spree/shared/apple_pay_button" %>
+  <%= render "spree/shared/apple_pay_button", id: id %>
 <% end %>
 
 <%= render "spree/shared/braintree_errors" %>


### PR DESCRIPTION
Closes #222. It adds an `id` local variable to `spree/shared/apple_pay_button` partial rendering in order to give such partial access to the payment method id.