### PR TITLE
Skip building default config on config presence

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -6,6 +6,6 @@ Spree::Store.class_eval do
   private
 
   def build_default_configuration
-    build_braintree_configuration
+    build_braintree_configuration unless braintree_configuration
   end
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Spree::Store do
+  describe 'before_create :build_default_configuration' do
+    context 'when a braintree_configuration record already exists' do
+      it 'does not overwrite it' do
+        store = build(:store)
+        custom_braintree_configuration = store.build_braintree_configuration
+        store.save!
+        expect(store.braintree_configuration).to be custom_braintree_configuration
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #224. On default Braintree configuration building we need to check whether a configuration already exists, so the prevent the overwrite of such configuration.