### PR TITLE
Stop importing address from PayPal

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,18 +190,13 @@ A PayPal button can also be included on the cart view to enable express checkout
 render "spree/shared/paypal_cart_button"
 ```
 
-#### PayPal configuration
+#### PayPal
 
-If your store requires the [phone number into user addresses](https://github.com/solidusio/solidus/blob/859143f3f061de79cc1b385234599422b8ae8e21/core/app/models/spree/address.rb#L151-L153)
-you'll need to configure PayPal to return the phone back when it returns the
-address used by the user:
+##### Known limitations
 
-1. Log into your PayPal account
-2. Go to Profile -> My Selling Tools -> Website preferences
-3. Set Contact Telephone to `On (Required Field)` or `On (Optional Field)`
-
-Using the option `Off` will not make the address valid and will raise a
-validation error.
+It's not possible to let the user update the address via PayPal, because of
+storing formats incompatibilities between PayPal and Solidus; thus be sure that
+the PayPal client configuration has `shippingAddressEditable` set to `false`.
 
 ## Optional configuration
 

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -104,41 +104,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payl
       "email" : payload.details.email,
       "phone" : payload.details.phone,
       "nonce" : payload.nonce,
-      "payment_type" : payload.type,
-      "address_attributes" : this._addressParams(payload)
+      "payment_type" : payload.type
     }
-  };
-};
-
-/**
- * Builds the address parameters to submit to Solidus using the payload
- * returned by Braintree
- *
- * @param {object} payload - The payload returned by Braintree after tokenization
- */
-SolidusPaypalBraintree.PaypalButton.prototype._addressParams = function(payload) {
-  var first_name, last_name;
-  var payload_address = payload.details.shippingAddress || payload.details.billingAddress;
-  if (!payload_address) return {};
-
-  if (payload_address.recipientName) {
-    first_name = payload_address.recipientName.split(" ")[0];
-    last_name = payload_address.recipientName.split(" ")[1];
-  }
-
-  if (!first_name || !last_name) {
-    first_name = payload.details.firstName;
-    last_name = payload.details.lastName;
-  }
-
-  return {
-    "first_name" : first_name,
-    "last_name" : last_name,
-    "address_line_1" : payload_address.line1,
-    "address_line_2" : payload_address.line2,
-    "city" : payload_address.city,
-    "state_code" : payload_address.state,
-    "zip" : payload_address.postalCode,
-    "country_code" : payload_address.countryCode
   };
 };

--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -39,7 +39,7 @@ module SolidusPaypalBraintree
       if valid?
         order.email = user.try!(:email) || transaction.email
 
-        if address
+        if address && !source.paypal?
           order.shipping_address = order.billing_address = address
           # work around a bug in most solidus versions
           # about tax zone cachine between address changes


### PR DESCRIPTION
Closes #226. When PayPal sends the authorization response to the server, it format the address with a single field for the first name and the last name, `recipientName`. We can’t safely infer the first name and the last name from that field (see #226), so we have to skip the user address updating. The good news is that the user address updating in this case is redundant, since Solidus always requires the address to be set before the payment happens, and such address is sent to PayPal with the `shippingAddressEditable` configuration set to `false`, so the address is necessarily the same as the one stored anyway.