### PR TITLE
Fix shipping contact name for ApplePay

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The following is a relatively bare-bones implementation to enable Apple Pay on t
       amount: "<%= current_order.total %>",
       shippingContact: {
         emailAddress: '<%= current_order.email %>',
-        familyName: '<%= address.firstname %>',
-        givenName: '<%= address.lastname %>',
+        givenName: '<%= address.firstname %>',
+        familyName: '<%= address.lastname %>',
         phoneNumber: '<%= address.phone %>',
         addressLines: ['<%= address.address1 %>','<%= address.address2 %>'],
         locality: '<%= address.city %>',

--- a/app/views/spree/shared/_apple_pay_button.html.erb
+++ b/app/views/spree/shared/_apple_pay_button.html.erb
@@ -11,8 +11,8 @@
     amount: "<%= current_order.total %>",
     shippingContact: {
       emailAddress: '<%= current_order.email %>',
-      familyName: '<%= address.firstname %>',
-      givenName: '<%= address.lastname %>',
+      givenName: '<%= address.firstname %>',
+      familyName: '<%= address.lastname %>',
       phoneNumber: '<%= address.phone %>',
       addressLines: ['<%= address.address1 %>','<%= address.address2 %>'],
       locality: '<%= address.city %>',


### PR DESCRIPTION
The firstname was assigned to `familyName` and lastname to `givenName`.

This change them to:
- `givenName` => `firstname`
- `familyName` => `lastname`

Refs:
- https://github.com/solidusio/solidus_paypal_braintree/blob/c19a733b044671a3f7be427d8d697d00e70780a0/app/assets/javascripts/solidus_paypal_braintree/apple_pay_button.js#L166-L167
- https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypayment/1916097-shippingcontact
