### PR TITLE
Only add state if available in Paypal Checkout Button View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ pkg
 *.swp
 spec/dummy
 spec/examples.txt
+.bundle/
+.env

--- a/app/models/solidus_paypal_braintree/address.rb
+++ b/app/models/solidus_paypal_braintree/address.rb
@@ -15,7 +15,7 @@ module SolidusPaypalBraintree
         recipientName: spree_address.full_name
       }
 
-      if Spree::Config.address_requires_state && spree_address.country.states_required
+      if ::Spree::Config.address_requires_state && spree_address.country.states_required
         address_hash[:state] = spree_address.state.name
       end
       address_hash.to_json

--- a/app/models/solidus_paypal_braintree/address.rb
+++ b/app/models/solidus_paypal_braintree/address.rb
@@ -1,0 +1,28 @@
+module SolidusPaypalBraintree
+  class Address
+    def initialize(spree_address)
+      @spree_address = spree_address
+    end
+
+    def to_json
+      address_hash = {
+        line1: spree_address.address1,
+        line2: spree_address.address2,
+        city: spree_address.city,
+        postalCode: spree_address.zipcode,
+        countryCode: spree_address.country.iso,
+        phone: spree_address.phone,
+        recipientName: spree_address.full_name
+      }
+
+      if Spree::Config.address_requires_state && spree_address.country.states_required
+        address_hash[:state] = spree_address.state.name
+      end
+      address_hash.to_json
+    end
+
+    private
+
+    attr_reader :spree_address
+  end
+end

--- a/app/models/solidus_paypal_braintree/address.rb
+++ b/app/models/solidus_paypal_braintree/address.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module SolidusPaypalBraintree
   class Address
     def initialize(spree_address)
       @spree_address = spree_address
     end
 
-    def to_json
+    def to_json(*_args)
       address_hash = {
         line1: spree_address.address1,
         line2: spree_address.address2,

--- a/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
+++ b/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
@@ -1,18 +1,7 @@
-<% address = current_order.ship_address %>
-
 <div id="paypal-button"></div>
 
 <script>
-  var address = {
-    line1: '<%= address.address1 %>',
-    line2: '<%= address.address2 %>',
-    city: '<%= address.city %>',
-    state: '<%= address.state.name %>',
-    postalCode: '<%= address.zipcode %>',
-    countryCode: '<%= address.country.iso %>',
-    phone: '<%= address.phone %>',
-    recipientName: '<%= "#{address.firstname} #{address.lastname}" %>'
-  }
+  var address = <%= SolidusPaypalBraintree::Address.new(current_order.ship_address).to_json %>
 
   var paypalOptions = {
     flow: '<%= SolidusPaypalBraintree::Gateway.first.preferred_paypal_flow %>',

--- a/spec/models/solidus_paypal_braintree/address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/address_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SolidusPaypalBraintree::Address do
 
     context 'with states turned off globally' do
       before do
-        allow(Spree::Config).to receive(:address_requires_state) { false }
+        allow(::Spree::Config).to receive(:address_requires_state) { false }
       end
 
       context 'with a country that requires states' do

--- a/spec/models/solidus_paypal_braintree/address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/address_spec.rb
@@ -2,13 +2,16 @@ require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::Address do
   describe '#to_json' do
-    let!(:germany) { create(:country, iso: 'DE', states_required: false) }
-    let!(:usa) { create(:country, iso: 'US', states_required: true) }
+    subject(:address_json) { JSON.parse(described_class.new(spree_address).to_json) }
+
     let(:german_address) { create(:address, country_iso: 'DE', state: nil) } # Does not require states
     let(:us_address) { create(:address, country_iso: 'US') } # Requires states
     let(:spree_address) { us_address }
 
-    subject(:address_json) { JSON.parse(described_class.new(spree_address).to_json) }
+    before do
+      create(:country, iso: 'DE', states_required: false)
+      create(:country, iso: 'US', states_required: true)
+    end
 
     it 'has all the required keys' do
       expect(address_json.keys).to contain_exactly(
@@ -31,7 +34,7 @@ RSpec.describe SolidusPaypalBraintree::Address do
 
     context 'with states turned off globally' do
       before do
-        allow(::Spree::Config).to receive(:address_requires_state) { false }
+        allow(::Spree::Config).to receive(:address_requires_state).and_return(false)
       end
 
       context 'with a country that requires states' do

--- a/spec/models/solidus_paypal_braintree/address_spec.rb
+++ b/spec/models/solidus_paypal_braintree/address_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalBraintree::Address do
+  describe '#to_json' do
+    let!(:germany) { create(:country, iso: 'DE', states_required: false) }
+    let!(:usa) { create(:country, iso: 'US', states_required: true) }
+    let(:german_address) { create(:address, country_iso: 'DE', state: nil) } # Does not require states
+    let(:us_address) { create(:address, country_iso: 'US') } # Requires states
+    let(:spree_address) { us_address }
+
+    subject(:address_json) { JSON.parse(described_class.new(spree_address).to_json) }
+
+    it 'has all the required keys' do
+      expect(address_json.keys).to contain_exactly(
+        'line1',
+        'line2',
+        'city',
+        'postalCode',
+        'countryCode',
+        'recipientName',
+        'state',
+        'phone'
+      )
+    end
+
+    context 'with a country that does not require state' do
+      let(:spree_address) { german_address }
+
+      it { is_expected.not_to have_key('state') }
+    end
+
+    context 'with states turned off globally' do
+      before do
+        allow(Spree::Config).to receive(:address_requires_state) { false }
+      end
+
+      context 'with a country that requires states' do
+        it { is_expected.not_to have_key('state') }
+      end
+
+      context 'with a country that does not require state' do
+        let(:spree_address) { german_address }
+
+        it { is_expected.not_to have_key('state') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This refactors some logic out of the paypal checkout button view and only adds a state name to the address hash there if the state is configured and necessary.

Fixes #182 
Supersedes #196 and #231 

