### PR TITLE
Make use of data collector in JS configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Payment methods can accept preferences either directly entered in admin, or from
         public_key: ENV['BRAINTREE_PUBLIC_KEY'],
         private_key: ENV['BRAINTREE_PRIVATE_KEY'],
         paypal_flow: 'vault', # 'checkout' is accepted too
+        use_data_collector: true # Fingerprint the user's browser when using Paypal
       }
     )
   end
@@ -211,6 +212,13 @@ address used by the user:
 
 Using the option `Off` will not make the address valid and will raise a
 validation error.
+
+#### Disabling the data collector
+
+For fraud prevention, PayPal recommends using a data collector to collect device
+information, which we've included by default. You're able to turn off the PayPal
+data collector on the payment method preferences if you desire. If you use
+static preferences, add `use_data_collector: false` to your initializer.
 
 ## Optional configuration
 

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -32,7 +32,10 @@ SolidusPaypalBraintree.PaypalButton = function(element, paypalOptions, options) 
  * See {@link https://braintree.github.io/braintree-web/3.9.0/PayPal.html#tokenize}
  */
 SolidusPaypalBraintree.PaypalButton.prototype.initialize = function() {
-  this._client = new SolidusPaypalBraintree.createClient({useDataCollector: true, usePaypal: true});
+  this._client = new SolidusPaypalBraintree.createClient({
+      useDataCollector: this._paypalOptions.useDataCollector,
+      usePaypal: true
+  });
 
   return this._client.initialize().then(this.initializeCallback.bind(this));
 };

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -55,6 +55,9 @@ module SolidusPaypalBraintree
     # Example: { number: "Enter card number", cvv: "Enter CVV", expirationDate: "mm/yy" }
     preference(:placeholder_text, :hash, default: {})
 
+    # Wether to use the JS device data collector
+    preference(:use_data_collector, :boolean, default: true)
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -12,8 +12,8 @@ module SolidusPaypalBraintree
     NON_VOIDABLE_STATUS_ERROR_REGEXP = /can only be voided if status is authorized/.freeze
 
     TOKEN_GENERATION_DISABLED_MESSAGE = 'Token generation is disabled.' \
-      ' To re-enable set the `token_generation_enabled` preference on the' \
-      ' gateway to `true`.'
+                                        ' To re-enable set the `token_generation_enabled` preference on the' \
+                                        ' gateway to `true`.'
 
     ALLOWED_BRAINTREE_OPTIONS = [
       :device_data,

--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -11,6 +11,7 @@
     enableShippingAddress: true,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>',
     locale: '<%= paypal_button_preference(:paypal_button_locale, store: current_store) %>',
+    useDataCollector: <%= SolidusPaypalBraintree::Gateway.first.preferred_use_data_collector %>,
     style: {
       color: '<%= paypal_button_preference(:paypal_button_color, store: current_store) %>',
       shape: '<%= paypal_button_preference(:paypal_button_shape, store: current_store) %>',


### PR DESCRIPTION
Some stores do not want or need to do invasive fraud protection. For
these, it should be possible to turn data collection off without
overwriting partials.