### PR TITLE
Respect vault/checkout configuration on cart paypal button

### DIFF
--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -4,7 +4,7 @@
 
 <script>
   var paypalOptions = {
-    flow: 'vault',
+    flow: '<%= SolidusPaypalBraintree::Gateway.first.preferred_paypal_flow %>',
     enableShippingAddress: true,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>'
   }


### PR DESCRIPTION
We have a configuration for the preferred payment flow, however it is
only recognised in the checkout paypal payment button, and not in the
cart paypal button. This commit adds that recognition.