### PR TITLE
Make Paypal button style configurable

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -36,7 +36,7 @@ SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
 
   paypal.Button.render({
     env: this._environment,
-
+    style: this._paypalOptions.buttonStyle,
     payment: function () {
       return this._client.getPaypalInstance().createPayment(this._paypalOptions);
     }.bind(this),

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -41,6 +41,11 @@ module SolidusPaypalBraintree
     # Which checkout flow to use (vault/checkout)
     preference(:paypal_flow, :string, default: 'vault')
 
+    # How to style your paypal button(s)
+    # A hash that gets passed to the `style` key when initializing the button.
+    # See https://developer.paypal.com/docs/checkout/integration-features/customize-button
+    preference(:paypal_button_style, :hash, default: {})
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -4,6 +4,7 @@
 
 <script>
   var paypalOptions = {
+    buttonStyle: <%== SolidusPaypalBraintree::Gateway.first.preferred_paypal_button_style.to_json %>,
     flow: 'vault',
     enableShippingAddress: true,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>'

--- a/app/views/spree/shared/_paypal_checkout_button.html.erb
+++ b/app/views/spree/shared/_paypal_checkout_button.html.erb
@@ -21,6 +21,7 @@
     enableShippingAddress: true,
     shippingAddressOverride: address,
     shippingAddressEditable: false,
+    buttonStyle: <%== SolidusPaypalBraintree::Gateway.first.preferred_paypal_button_style.to_json %>,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>'
   }
 

--- a/spec/support/gateway_helpers.rb
+++ b/spec/support/gateway_helpers.rb
@@ -12,6 +12,9 @@ module SolidusPaypalBraintree::GatewayHelpers
         },
         paypal_payee_email_map: {
           'EUR' => ENV.fetch('BRAINTREE_PAYPAL_PAYEE_EMAIL', 'paypal+europe@example.com')
+        },
+        paypal_button_style: {
+          color: 'black'
         }
       }
     }.merge(opts))


### PR DESCRIPTION
This allows developers to configure how their paypal button is styled.
See
https://developer.paypal.com/docs/checkout/integration-features/customize-button/
for the available options.