### PR TITLE
Add PayPal button customizable style also for cart page

### DIFF
--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -6,7 +6,15 @@
   var paypalOptions = {
     flow: 'vault',
     enableShippingAddress: true,
-    environment: '<%= Rails.env.production? ? "production" : "sandbox" %>'
+    environment: '<%= Rails.env.production? ? "production" : "sandbox" %>',
+    locale: '<%= paypal_button_preference(:paypal_button_locale, store: current_store) %>',
+    style: {
+      color: '<%= paypal_button_preference(:paypal_button_color, store: current_store) %>',
+      size: '<%= paypal_button_preference(:paypal_button_size, store: current_store) %>',
+      shape: '<%= paypal_button_preference(:paypal_button_shape, store: current_store) %>',
+      label: '<%= paypal_button_preference(:paypal_button_label, store: current_store) %>',
+      tagline: '<%= paypal_button_preference(:paypal_button_tagline, store: current_store) %>'
+    }
   }
   var options = {
     restart_checkout: true

--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -4,4 +4,5 @@ end
 
 if SolidusSupport.frontend_available?
   Spree::CheckoutController.helper :braintree_checkout
+  Spree::OrdersController.helper :braintree_checkout
 end


### PR DESCRIPTION
This complete #229 since #236 was incomplete: adds PayPal button customizable parameters only for checkout/payment step. This PR adds the same feature also for cart page.

Also add an ad-hoc example at cart page feature spec.