### PR TITLE
Make http open and read timeouts configurable

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -35,6 +35,8 @@ module SolidusPaypalBraintree
     preference(:merchant_id, :string, default: nil)
     preference(:public_key,  :string, default: nil)
     preference(:private_key, :string, default: nil)
+    preference(:http_open_timeout, :integer, default: 60)
+    preference(:http_read_timeout, :integer, default: 60)
     preference(:merchant_currency_map, :hash, default: {})
     preference(:paypal_payee_email_map, :hash, default: {})
 
@@ -60,6 +62,8 @@ module SolidusPaypalBraintree
         merchant_id: preferred_merchant_id,
         public_key: preferred_public_key,
         private_key: preferred_private_key,
+        http_open_timeout: preferred_http_open_timeout,
+        http_read_timeout: preferred_http_read_timeout,
         logger: logger
       }
     end

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -163,6 +163,20 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       it { is_expected.to eq "paypal_braintree" }
     end
 
+    describe '#gateway_options' do
+      subject(:gateway_options) { gateway.gateway_options }
+
+      it 'includes http_open_timeout' do
+        is_expected.to have_key(:http_open_timeout)
+        expect(gateway_options[:http_open_timeout]).to eq(60)
+      end
+
+      it 'includes http_read_timeout' do
+        is_expected.to have_key(:http_read_timeout)
+        expect(gateway_options[:http_read_timeout]).to eq(60)
+      end
+    end
+
     describe '#purchase' do
       subject(:purchase) { gateway.purchase(1000, source, gateway_options) }
 


### PR DESCRIPTION
The default timeout of 60 seconds is way too long for real life scenarios. Ideally we would drop the open timeout to 1 second and the read timeout below the heroku timeout of 30 seconds.

I left the default values for now, to not impact any existing stores.