### PR TITLE
Remove AddBraintreeConfigurationToStores migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SolidusPaypalBraintree::Gateway.new(
 ```
 
 ### Configure payment types
-Your payment method can accept payments in three ways: through Paypal, through ApplePay, or with credit card details entered directly by the customer. By default all are disabled for all your site's stores.
+Your payment method can accept payments in three ways: through Paypal, through ApplePay, or with credit card details entered directly by the customer. By default all are disabled for all your site's stores. Before proceeding to checkout, ensure you've created a Braintree configuration for your store:
 
 1. Visit /solidus_paypal_braintree/configurations/list
 

--- a/db/migrate/20161125172005_add_braintree_configuration_to_stores.rb
+++ b/db/migrate/20161125172005_add_braintree_configuration_to_stores.rb
@@ -1,9 +1,7 @@
 class AddBraintreeConfigurationToStores < SolidusSupport::Migration[4.2]
-  def up
-    Spree::Store.all.each(&:create_braintree_configuration)
-  end
-
-  def down
-    SolidusPaypalBraintree::Configuration.joins(:store).destroy_all
-  end
+# The content of this migration has been removed because store's Braintree
+# configuration doesn't already have paypal_button_preferences fields, so
+# their validations will break this migration.
+#
+# Ref here for more info https://github.com/solidusio/solidus_paypal_braintree/pull/249
 end

--- a/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
+++ b/lib/controllers/backend/solidus_paypal_braintree/configurations_controller.rb
@@ -5,7 +5,7 @@ module SolidusPaypalBraintree
     def list
       authorize! :list, SolidusPaypalBraintree::Configuration
 
-      @configurations = ::Spree::Store.all.map(&:braintree_configuration)
+      @configurations = ::Spree::Store.all.map { |s| s.braintree_configuration || s.create_braintree_configuration }
     end
 
     def update


### PR DESCRIPTION
because store's braintree configuration doesn't already have
paypal_button_preferences fields and validations here will break migration

Should fix https://github.com/solidusio/solidus_paypal_braintree/issues/244 , while failing tests should be fixed in #253 .