### PR TITLE
Move Braintree initializer into to_prepare block

### DIFF
--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -1,8 +1,10 @@
-if SolidusSupport.backend_available?
-  Spree::Admin::PaymentsController.helper :braintree_admin
-end
+Rails.application.config.to_prepare do
+  if SolidusSupport.backend_available?
+    Spree::Admin::PaymentsController.helper :braintree_admin
+  end
 
-if SolidusSupport.frontend_available?
-  Spree::CheckoutController.helper :braintree_checkout
-  Spree::OrdersController.helper :braintree_checkout
+  if SolidusSupport.frontend_available?
+    Spree::CheckoutController.helper :braintree_checkout
+    Spree::OrdersController.helper :braintree_checkout
+  end
 end


### PR DESCRIPTION
This fixes a probably load order error that can occur when Rails controller caching is disabled in development mode.

This error can be reproduced by running Solidus, Alchemy, and this extension together in development mode with `perform_caching = false` in the development.rb environment file. Attempting to either (1) start checkout or (2) view the details of a previously placed order will result in this error.

Turning on caching resolves the problem. Turning it off causes the problem to occur again.

I'm not 100% sure what's going on, but it seems to involve the braintree.rb initializer. If I comment out the following lines, the error goes away:

```ruby
Spree::CheckoutController.helper :braintree_checkout
Spree::OrdersController.helper :braintree_checkout
```

Placing the entire initializer into a `config.to_prepare` block also resolves the problem, and seems like the right thing to do given that most other Solidus extensions use `to_prepend` blocks when adding helpers into controllers.

![Screen Shot 2020-07-21 at 11 12 25 AM](https://user-images.githubusercontent.com/3756/88072512-1d1e6500-cb43-11ea-8979-7c1f9902a2cd.png)