### PR TITLE
Fix LoadError on failed payments

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -203,7 +203,7 @@ module SolidusPaypalBraintree
       return if source.token.present? || source.customer.present? || source.nonce.nil?
 
       result = braintree.customer.create(customer_profile_params(payment))
-      fail Spree::Core::GatewayError, result.message unless result.success?
+      fail ::Spree::Core::GatewayError, result.message unless result.success?
 
       customer = result.customer
 


### PR DESCRIPTION
We're getting the following error in production:

vendor/bundle/ruby/2.6.0/bundler/gems/solidus_paypal_braintree-091a6f94203a/app/models/solidus_paypal_braintree/gateway.rb:210:in `create_profile': uninitialized constant SolidusPaypalBraintree::Spree::Core (NameError)

I believe adding the root namespace `::` would fix those.