### PR TITLE
Updated solidus_support gem version

### DIFF
--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -43,11 +43,11 @@ module SolidusPaypalBraintree
 
       # We support Solidus v1.2, which requires some different markup in the
       # source form partial. This will take precedence over lib/views/backend.
-      paths["app/views"] << "lib/views/backend_v1.2" if SolidusSupport.solidus_gem_version < Gem::Version.new('1.3')
+      paths["app/views"] << "lib/views/backend_v1.2" if Spree.solidus_gem_version < Gem::Version.new('1.3')
 
       # Solidus v2.4 introduced preference field partials but does not ship a hash field type.
       # This is solved in Solidus v2.5.
-      if SolidusSupport.solidus_gem_version <= Gem::Version.new('2.5.0')
+      if Spree.solidus_gem_version <= Gem::Version.new('2.5.0')
         paths["app/views"] << "lib/views/backend_v2.4"
       end
 

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'braintree', '~> 2.65'
   s.add_dependency 'solidus_api', ['>= 2.0.0', '< 3']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '~> 0.5.0'
 
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
- Updated solidus_support gem version to 0.5.0.

- Updated Engine.rb with latest gem API to **Spree.solidus_gem_version** from **SolidusSupport.solidus_gem_version**, which has been deprecated.

