### PR TITLE
Fix value conversion method

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -292,11 +292,15 @@ module SolidusPaypalBraintree
       JSON.parse(preference_string.gsub("=>", ":"))
     end
 
-    def convert_preference_value(value, type)
+    def convert_preference_value(value, type, preference_encryptor = nil)
       if type == :hash && value.is_a?(String)
         value = to_hash(value)
       end
-      super
+      if method(__method__).super_method.arity == 3
+        super
+      else
+        super(value, type)
+      end
     end
 
     def transaction_options(source, options, submit_for_settlement = false)


### PR DESCRIPTION
In Solidus, this method has changed from having two parameters to
having three. This updates the method here to match, so we avoid
any too_many_parameter errors. Most noticably, this was affecting
our test suite.

See: https://github.com/solidusio/solidus/commit/e05da68179b45a68d762dfcc7c1ba6618d00d234