### PR TITLE
Fix Spree::Core lookup in gateway

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -207,7 +207,7 @@ module SolidusPaypalBraintree
       return if source.token.present? || source.customer.present? || source.nonce.nil?
 
       result = braintree.customer.create(customer_profile_params(payment))
-      fail Spree::Core::GatewayError, result.message unless result.success?
+      fail ::Spree::Core::GatewayError, result.message unless result.success?
 
       customer = result.customer
 


### PR DESCRIPTION
Gateway assumes that Spree::Core lives at
SolidusPaypalBraintree::Spree::Core. Adding leading colons forces the
lookup to happen from the toplevel namespace, which grabs the correct
class.

Fixes #254