### PR TITLE
Update transaction_address to support name attribute

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -125,23 +125,18 @@ SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payl
  * @param {object} payload - The payload returned by Braintree after tokenization
  */
 SolidusPaypalBraintree.PaypalButton.prototype._addressParams = function(payload) {
-  var first_name, last_name;
+  var name;
   var payload_address = payload.details.shippingAddress || payload.details.billingAddress;
   if (!payload_address) return {};
 
   if (payload_address.recipientName) {
-    first_name = payload_address.recipientName.split(" ")[0];
-    last_name = payload_address.recipientName.split(" ")[1];
-  }
-
-  if (!first_name || !last_name) {
-    first_name = payload.details.firstName;
-    last_name = payload.details.lastName;
+    name = payload_address.recipientName
+  } else {
+    name = payload.details.firstName + " " + payload.details.lastName;
   }
 
   return {
-    "first_name" : first_name,
-    "last_name" : last_name,
+    "name" : name,
     "address_line_1" : payload_address.line1,
     "address_line_2" : payload_address.line2,
     "city" : payload_address.city,

--- a/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
+++ b/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
@@ -10,8 +10,8 @@ module SolidusPaypalBraintree
       :phone,
       :email,
       { address_attributes: [
-        :country_code, :country_name, :last_name, :first_name,
-        :city, :zip, :state_code, :address_line_1, :address_line_2
+        :country_code, :country_name, :name, :city, :zip, :state_code,
+        :address_line_1, :address_line_2, :first_name, :last_name
       ] }
     ].freeze
 

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
           phone: "1112223333",
           email: "batman@example.com",
           address_attributes: {
-            first_name: "Wade",
-            last_name: "Wilson",
+            name: "Wade Wilson",
             address_line_1: "123 Fake Street",
             city: "Seattle",
             zip: "98101",

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -31,8 +31,7 @@ describe SolidusPaypalBraintree::TransactionImport do
     context "with invalid address" do
       let(:transaction_address) do
         SolidusPaypalBraintree::TransactionAddress.new(
-          first_name: "Bruce",
-          last_name: "Wayne",
+          name: "Bruce Wayne",
           address_line_1: "42 Spruce Lane",
           city: "Gotham",
           state_code: "WA",
@@ -187,8 +186,7 @@ describe SolidusPaypalBraintree::TransactionImport do
         let(:transaction_address) do
           SolidusPaypalBraintree::TransactionAddress.new(
             country_code: 'US',
-            last_name: 'Venture',
-            first_name: 'Thaddeus',
+            name: 'Thaddeus Venture',
             city: 'New York',
             state_code: 'NY',
             address_line_1: '350 5th Ave',
@@ -247,8 +245,7 @@ describe SolidusPaypalBraintree::TransactionImport do
       let(:transaction_address) do
         SolidusPaypalBraintree::TransactionAddress.new(
           country_code: 'US',
-          last_name: 'Venture',
-          first_name: 'Thaddeus',
+          name: 'Thaddeus Venture',
           city: 'New York',
           state_code: 'NY',
           address_line_1: '350 5th Ave'

--- a/spec/models/solidus_paypal_braintree/transaction_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_spec.rb
@@ -15,8 +15,7 @@ describe SolidusPaypalBraintree::Transaction do
     let(:valid_address_attributes) do
       {
         address_attributes: {
-          first_name: "Bruce",
-          last_name: "Wayne",
+          name: "Bruce Wayne",
           address_line_1: "42 Spruce Lane",
           city: "Gotham",
           zip: "98201",


### PR DESCRIPTION
Solidus is moving away from using first_name and last_name, in favor of
just "name". This updates the paypal JS to send a name to
transaction_addess, rather than splitting it on the spot.
transaction_address is responsible for either:

* Splitting the name, if the user is on Solidus 2.10 or below
-or-
* Passing the name directly to the address, if the user is on Solidus
2.11 or higher - where the name parameter is supported.

Also deprecates using first_name and last_name in transaction_address,
in case someone has overridden `paypal_button`

Fixes #226 