### PR TITLE
Add ability to style braintree credit card fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ has each payment type disabled. It also adds a `before_create` callback to
 default configuration that gets created by overriding the private
 `build_default_configuration` method on `Spree::Store`.
 
+### Hosted Fields Styling
+You can style the Braintree credit card fields by using the `credit_card_fields_style` preference on the payment method. The `credit_card_fields_style` will be passed to the `style` key when initializing the credit card fields. You can find more information about styling hosted fields can be found [here.](https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3)
+
 ### 3D Secure
 
 This gem supports [3D Secure 2](https://developers.braintreepayments.com/guides/3d-secure/overview),

--- a/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
@@ -34,7 +34,9 @@ SolidusPaypalBraintree.HostedForm.prototype._createHostedFields = function () {
       expirationDate: {
         selector: "#card_expiry" + this.paymentMethodId
       }
-    }
+    },
+
+    styles: credit_card_fields_style
   };
 
   return SolidusPaypalBraintree.PromiseShim.convertBraintreePromise(braintree.hostedFields.create, [opts]);

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -47,6 +47,10 @@ module SolidusPaypalBraintree
     # Which checkout flow to use (vault/checkout)
     preference(:paypal_flow, :string, default: 'vault')
 
+    # A hash that gets passed to the `style` key when initializing the credit card fields.
+    # See https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3
+    preference(:credit_card_fields_style, :hash, default: {})
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -25,8 +25,10 @@
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
 </div>
 
-<% if current_store.braintree_configuration.three_d_secure? %>
+
   <script>
-    var threeDSecureOptions = <%=raw braintree_3ds_options_for(current_order).to_json %>;
+    <% if current_store.braintree_configuration.three_d_secure? %>
+      var threeDSecureOptions = <%=raw braintree_3ds_options_for(current_order).to_json %>;
+    <% end -%>
+    var credit_card_fields_style = <%= raw credit_card_fields_style.to_json %>
   </script>
-<% end -%>

--- a/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -11,6 +11,6 @@
   </div>
 
   <div id="card_form<%= id %>" data-hook style="display: none;">
-    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id } %>
+    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id, credit_card_fields_style: payment_method.preferred_credit_card_fields_style } %>
   </div>
 </fieldset>

--- a/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -11,6 +11,6 @@
   </div>
 
   <div id="card_form<%= id %>" data-hook style="display: none;">
-    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id } %>
+    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id, credit_card_fields_style: payment_method.preferred_credit_card_fields_style } %>
   </div>
 </fieldset>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -8,7 +8,7 @@
 
 <% if current_store.braintree_configuration.credit_card? %>
   <fieldset class="braintree-hosted-fields" data-braintree-hosted-fields data-id="<%= id %>">
-    <%= render "spree/shared/braintree_hosted_fields", id: id %>
+    <%= render "spree/shared/braintree_hosted_fields", id: id, credit_card_fields_style: payment_method.preferred_credit_card_fields_style %>
   </fieldset>
 <% end %>
 

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -16,6 +16,8 @@ shared_context "with frontend checkout setup" do
         credit_card: true,
         three_d_secure: three_d_secure_enabled
       )
+
+      braintree.update(preferred_credit_card_fields_style: { input: { 'font-size': '30px' } })
     end
 
     order = if SolidusSupport.solidus_gem_version >= Gem::Version.new('2.6.0')
@@ -52,6 +54,12 @@ describe 'entering credit card details', type: :feature, js: true do
       expect(page).to have_selector("#payment_method_#{braintree.id}", visible: :visible)
       expect(page).to have_selector("iframe#braintree-hosted-field-number")
       expect(page).to have_selector("iframe[type='number']")
+    end
+
+    it "credit card field style variable is set" do
+      within_frame("braintree-hosted-field-number") do
+        expect(find("#credit-card-number").style("font-size")).to eq({ "font-size" => "30px" })
+      end
     end
   end
 


### PR DESCRIPTION
Using the `credit_card_fields_style` preference, you're able to pass
style attributes to the hosted fields. This allows you to pass any
arbitrary CSS to the Braintree fields, such as font size or color.

Handles the style portion of #121 