### PR TITLE
Add PayPal messaging component to cart button partial

### DIFF
--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -1,6 +1,7 @@
 <%= render "spree/shared/paypal_braintree_head_scripts" %>
 
 <div id="paypal-button"></div>
+<div data-pp-message data-pp-placement="payment" data-pp-amount="<%= current_order.total %>"></div>
 
 <script>
   var paypalOptions = {


### PR DESCRIPTION
With the component:
<img width="791" alt="Screen Shot 2020-10-29 at 7 40 08 AM" src="https://user-images.githubusercontent.com/5720486/97574994-0eeda980-19ba-11eb-9a59-12869a9f317a.png">

Without the component:
<img width="878" alt="Screen Shot 2020-10-29 at 7 40 31 AM" src="https://user-images.githubusercontent.com/5720486/97575001-1319c700-19ba-11eb-8159-7754b376d106.png">
