### PR TITLE
Allow user to specify style and placeholder_text of hosted_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ default configuration that gets created by overriding the private
 ### Hosted Fields Styling
 You can style the Braintree credit card fields by using the `credit_card_fields_style` preference on the payment method. The `credit_card_fields_style` will be passed to the `style` key when initializing the credit card fields. You can find more information about styling hosted fields can be found [here.](https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3)
 
+You can also use the `placeholder_text` preference on the payment method to set the placeholder text you'd like to use for each of the hosted fields. You'll pass the field name in as the key, and the placeholder text you'd like to use as the value. For example:
+```ruby
+  { number: "Enter card number", cvv: "Enter CVV", expirationDate: "mm/yy" }
+```
+
 ### 3D Secure
 
 This gem supports [3D Secure 2](https://developers.braintreepayments.com/guides/3d-secure/overview),

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ has each payment type disabled. It also adds a `before_create` callback to
 default configuration that gets created by overriding the private
 `build_default_configuration` method on `Spree::Store`.
 
+### Hosted Fields Styling
+You can style the Braintree credit card fields by using the `credit_card_fields_style` preference on the payment method. The `credit_card_fields_style` will be passed to the `style` key when initializing the credit card fields. You can find more information about styling hosted fields can be found [here.](https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3)
+
 ### 3D Secure
 
 This gem supports [3D Secure 2](https://developers.braintreepayments.com/guides/3d-secure/overview),

--- a/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
@@ -34,7 +34,9 @@ SolidusPaypalBraintree.HostedForm.prototype._createHostedFields = function () {
       expirationDate: {
         selector: "#card_expiry" + this.paymentMethodId
       }
-    }
+    },
+
+    styles: credit_card_fields_style
   };
 
   return SolidusPaypalBraintree.PromiseShim.convertBraintreePromise(braintree.hostedFields.create, [opts]);

--- a/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/hosted_form.js
@@ -24,15 +24,18 @@ SolidusPaypalBraintree.HostedForm.prototype._createHostedFields = function () {
 
     fields: {
       number: {
-        selector: "#card_number" + this.paymentMethodId
+        selector: "#card_number" + this.paymentMethodId,
+        placeholder: placeholder_text["number"]
       },
 
       cvv: {
-        selector: "#card_code" + this.paymentMethodId
+        selector: "#card_code" + this.paymentMethodId,
+        placeholder: placeholder_text["cvv"]
       },
 
       expirationDate: {
-        selector: "#card_expiry" + this.paymentMethodId
+        selector: "#card_expiry" + this.paymentMethodId,
+        placeholder: placeholder_text["expirationDate"]
       }
     },
 

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -51,6 +51,10 @@ module SolidusPaypalBraintree
     # See https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3
     preference(:credit_card_fields_style, :hash, default: {})
 
+    # A hash that gets its keys passed to the associated braintree field placeholder tag.
+    # Example: { number: "Enter card number", cvv: "Enter CVV", expirationDate: "mm/yy" }
+    preference(:placeholder_text, :hash, default: {})
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -47,6 +47,10 @@ module SolidusPaypalBraintree
     # Which checkout flow to use (vault/checkout)
     preference(:paypal_flow, :string, default: 'vault')
 
+    # A hash that gets passed to the `style` key when initializing the credit card fields.
+    # See https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3
+    preference(:credit_card_fields_style, :hash, default: {})
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -1,19 +1,19 @@
-<% prefix = "payment_source[#{id}]" %>
+<% prefix = "payment_source[#{payment_method.id}]" %>
 
 <div class="hosted-fields">
   <div class="field" data-hook="card_number">
-    <%= label_tag "card_number#{id}", Spree::CreditCard.human_attribute_name(:number), class: "required" %>
-    <div class="input" id="card_number<%= id %>"></div>
+    <%= label_tag "card_number#{payment_method.id}", Spree::CreditCard.human_attribute_name(:number), class: "required" %>
+    <div class="input" id="card_number<%= payment_method.id %>"></div>
   </div>
 
   <div class="field" data-hook="card_expiration">
-    <%= label_tag "card_expiry#{id}", Spree::CreditCard.human_attribute_name(:expiration), class: "required" %>
-    <div class="input" id="card_expiry<%= id %>"></div>
+    <%= label_tag "card_expiry#{payment_method.id}", Spree::CreditCard.human_attribute_name(:expiration), class: "required" %>
+    <div class="input" id="card_expiry<%= payment_method.id %>"></div>
   </div>
 
   <div class="field" data-hook="card_code">
-    <%= label_tag "card_code#{id}", Spree::CreditCard.human_attribute_name(:card_code), class: "required" %>
-    <div class="input" id="card_code<%= id %>"></div>
+    <%= label_tag "card_code#{payment_method.id}", Spree::CreditCard.human_attribute_name(:card_code), class: "required" %>
+    <div class="input" id="card_code<%= payment_method.id %>"></div>
 
     <a href="/content/cvv" class="info cvvLink" target="_blank">
       (<%= I18n.t("spree.what_is_this") %>)

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -1,3 +1,11 @@
+<% if defined?(id) && !defined?(payment_method) %>
+  <% payment_method = Spree::PaymentMethod.find(id) %>
+  <% Spree::Deprecation.warn(
+    "passing id to _braintree_hosted_fields.html.erb is deprecated. Please pass the payment_method directly.",
+    caller
+  ) %>
+<% end %>
+
 <% prefix = "payment_source[#{payment_method.id}]" %>
 
 <div class="hosted-fields">
@@ -31,4 +39,5 @@
     var threeDSecureOptions = <%= raw braintree_3ds_options_for(current_order).to_json %>;
   <% end -%>
   var credit_card_fields_style = <%= raw payment_method.preferred_credit_card_fields_style.to_json %>
+  var placeholder_text = <%= raw payment_method.preferred_placeholder_text.to_json %>
 </script>

--- a/app/views/spree/shared/_braintree_hosted_fields.html.erb
+++ b/app/views/spree/shared/_braintree_hosted_fields.html.erb
@@ -25,8 +25,10 @@
   <input type="hidden" id="payment_method_nonce" name="<%= prefix %>[nonce]">
 </div>
 
-<% if current_store.braintree_configuration.three_d_secure? %>
-  <script>
-    var threeDSecureOptions = <%=raw braintree_3ds_options_for(current_order).to_json %>;
-  </script>
-<% end -%>
+
+<script>
+  <% if current_store.braintree_configuration.three_d_secure? %>
+    var threeDSecureOptions = <%= raw braintree_3ds_options_for(current_order).to_json %>;
+  <% end -%>
+  var credit_card_fields_style = <%= raw payment_method.preferred_credit_card_fields_style.to_json %>
+</script>

--- a/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -11,6 +11,6 @@
   </div>
 
   <div id="card_form<%= id %>" data-hook style="display: none;">
-    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id } %>
+    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { payment_method: payment_method } %>
   </div>
 </fieldset>

--- a/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
+++ b/lib/views/backend_v1.2/spree/admin/payments/source_forms/_paypal_braintree.html.erb
@@ -11,6 +11,6 @@
   </div>
 
   <div id="card_form<%= id %>" data-hook style="display: none;">
-    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { id: id } %>
+    <%= render partial: "spree/shared/braintree_hosted_fields", locals: { payment_method: payment_method } %>
   </div>
 </fieldset>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb
@@ -8,7 +8,7 @@
 
 <% if current_store.braintree_configuration.credit_card? %>
   <fieldset class="braintree-hosted-fields" data-braintree-hosted-fields data-id="<%= id %>">
-    <%= render "spree/shared/braintree_hosted_fields", id: id %>
+    <%= render "spree/shared/braintree_hosted_fields", payment_method: payment_method %>
   </fieldset>
 <% end %>
 

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -17,7 +17,10 @@ shared_context "with frontend checkout setup" do
         three_d_secure: three_d_secure_enabled
       )
 
-      braintree.update(preferred_credit_card_fields_style: { input: { 'font-size': '30px' } })
+      braintree.update(
+        preferred_credit_card_fields_style: { input: { 'font-size': '30px' } },
+        preferred_placeholder_text: { number: "Enter Your Card Number" }
+      )
     end
 
     order = if SolidusSupport.solidus_gem_version >= Gem::Version.new('2.6.0')
@@ -59,6 +62,12 @@ describe 'entering credit card details', type: :feature, js: true do
     it "credit card field style variable is set" do
       within_frame("braintree-hosted-field-number") do
         expect(find("#credit-card-number").style("font-size")).to eq({ "font-size" => "30px" })
+      end
+    end
+
+    it "sets the placeholder text correctly" do
+      within_frame("braintree-hosted-field-number") do
+        expect(find("#credit-card-number")['placeholder']).to eq("Enter Your Card Number")
       end
     end
   end

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -16,6 +16,8 @@ shared_context "with frontend checkout setup" do
         credit_card: true,
         three_d_secure: three_d_secure_enabled
       )
+
+      braintree.update(preferred_credit_card_fields_style: { input: { 'font-size': '30px' } })
     end
 
     order = if SolidusSupport.solidus_gem_version >= Gem::Version.new('2.6.0')
@@ -52,6 +54,12 @@ describe 'entering credit card details', type: :feature, js: true do
       expect(page).to have_selector("#payment_method_#{braintree.id}", visible: :visible)
       expect(page).to have_selector("iframe#braintree-hosted-field-number")
       expect(page).to have_selector("iframe[type='number']")
+    end
+
+    it "credit card field style variable is set" do
+      within_frame("braintree-hosted-field-number") do
+        expect(find("#credit-card-number").style("font-size")).to eq({ "font-size" => "30px" })
+      end
     end
   end
 


### PR DESCRIPTION
Adds the `credit_card_fields_style` and `placeholder_text` preferences to the payment_method, allowing the user full control over the look & feel of their hosted fields. 

closes #121 