### PR TITLE
Fix deprecated solidus_gem_version reference in spec

### DIFF
--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -18,7 +18,7 @@ shared_context "with frontend checkout setup" do
       )
     end
 
-    order = if SolidusSupport.solidus_gem_version >= Gem::Version.new('2.6.0')
+    order = if Spree.solidus_gem_version >= Gem::Version.new('2.6.0')
               Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
             else
               OrderWalkthrough.up_to(:delivery)


### PR DESCRIPTION
SolidusSupport.solidus_gem_version is deprecated and will be removed in solidus_support 1.0