### PR TITLE
Disable PayPal messaging when vault flow is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The checkout view
 [initializes the PayPal button](/lib/views/frontend/spree/checkout/payment/_paypal_braintree.html.erb)
 using the
 [Vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
-which allows the source to be reused. If you want, you can use [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3)
+which allows the source to be reused. Please note that PayPal messaging is disabled with vault flow. If you want, you can use [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3)
 instead, which doesn't allow you to reuse sources but allows your customers to pay with their PayPal
 balance and with PayPal financing options ([see setup instructions](#create-a-new-payment-method)).
 
@@ -190,7 +190,7 @@ render "spree/shared/paypal_cart_button"
 
 ### PayPal Financing Messaging
 
-PayPal offers an [on-site messaging component](https://www.paypal.com/us/webapps/mpp/on-site-messaging) to notify the customer that there are financing options available. By default, this component is used in both the cart and checkout partials.
+PayPal offers an [on-site messaging component](https://www.paypal.com/us/webapps/mpp/on-site-messaging) to notify the customer that there are financing options available. This component is included in both the cart and checkout partials, but is disabled by default. To enable this option, you'll need to use the `checkout` flow, and set the `paypal button messaging` option to `true` in your Braintree configuration.
 
 You can also include this view partial to implement this messaging component anywhere - for instance, on the product page:
 ```ruby

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -44,7 +44,7 @@ SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
     currency: this._paypalOptions.currency,
     commit: true,
     vault: this._paypalOptions.flow == "vault",
-    components: this.style['messaging'] == "true" ? "buttons,messages" : "buttons",
+    components: this.style['messaging'] == "true" && this._paypalOptions.flow != "vault" ? "buttons,messages" : "buttons",
     intent: this._paypalOptions.flow == "vault" ? "tokenize" : "authorize"
   }).then(() => {
     var create_method = this._paypalOptions.flow == "vault" ? "createBillingAgreement" : "createOrder"

--- a/app/models/solidus_paypal_braintree/configuration.rb
+++ b/app/models/solidus_paypal_braintree/configuration.rb
@@ -8,7 +8,7 @@ module SolidusPaypalBraintree
       label: { availables: %w[checkout credit pay buynow paypal installment], default: 'checkout' },
       tagline: { availables: %w[true false], default: 'false' },
       layout: { availables: %w[horizontal vertical], default: 'horizontal' },
-      messaging: { availables: %w[true false], default: 'true' }
+      messaging: { availables: %w[true false], default: 'false' }
     }.freeze
 
     belongs_to :store, class_name: 'Spree::Store'


### PR DESCRIPTION
PayPal doesn't want you to use the messaging component when vault flow
is being used. This disables the default messaging component when vault
flow is on, and defaults the component to disabled (since the extensions
defaults to vault flow: true)