### PR TITLE
Use messaging partial on payment buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ You can also include this view partial to implement this messaging component any
 render "spree/shared/paypal_messaging, options: {total: @product.price, placement: "product", currency: 'USD'}"
 ```
 
+If you're using this partial on a page where the PayPal SDK isn't already initialized, you'll also need to include this somewhere on the page:
+```ruby
+  <%= render "spree/shared/paypal_braintree_head_scripts" %>
+
+  <script>
+    var message = new SolidusPaypalBraintree.createPaypalMessaging(
+      {
+        currency: "<%= options[:currency] %>"
+      }
+    )
+
+    message.initialize();
+  </script>
+  ```
+
 While we provide the messaging component on the payment buttons for cart and checkout, you're expected to move these to where they make the most sense for your frontend. PayPal recommends keeping the messaging directly below wherever the order or product total is located.
 
 #### PayPal configuration

--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -1,7 +1,9 @@
 <%= render "spree/shared/paypal_braintree_head_scripts" %>
 
 <div id="paypal-button"></div>
-<div data-pp-message data-pp-placement="payment" data-pp-amount="<%= current_order.total %>"></div>
+<%= render "spree/shared/paypal_messaging", options: {
+  total: current_order.total,
+  placement: "payment" } %>
 
 <script>
   var paypalOptions = {

--- a/app/views/spree/shared/_paypal_messaging.html.erb
+++ b/app/views/spree/shared/_paypal_messaging.html.erb
@@ -1,13 +1,1 @@
-<%= render "spree/shared/paypal_braintree_head_scripts" %>
-
 <div data-pp-message data-pp-placement="<%= options[:placement] %>" data-pp-amount="<%= options[:total] %>"></div>
-
-<script>
-  var message = new SolidusPaypalBraintree.createPaypalMessaging(
-    {
-      currency: "<%= options[:currency] %>"
-    }
-  )
-
-  message.initialize();
-</script>

--- a/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
+++ b/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
@@ -1,5 +1,7 @@
 <div id="paypal-button"></div>
-<div data-pp-message data-pp-placement="payment" data-pp-amount="<%= @order.total %>"></div>
+<%= render "spree/shared/paypal_messaging", options: {
+  total: current_order.total,
+  placement: "payment" } %>
 
 <script>
   var address = <%= sanitize SolidusPaypalBraintree::Address.new(current_order.ship_address).to_json %>


### PR DESCRIPTION
Uses the existing messaging partial on the cart & checkout payment
buttons, and passes the total & placement along. Also adds a
`skip_initialization` option to the partial, because we don't want to
initialize the messaging component twice, and PayPal _really_ doesn't
like loading in their SDK twice, even if for two different components.