### PR TITLE
Use State Abbreviation in Checkout Helper

### DIFF
--- a/app/helpers/solidus_paypal_braintree/braintree_checkout_helper.rb
+++ b/app/helpers/solidus_paypal_braintree/braintree_checkout_helper.rb
@@ -19,7 +19,7 @@ module SolidusPaypalBraintree
           streetAddress: bill_address.address1,
           extendedAddress: bill_address.address2,
           locality: bill_address.city,
-          region: bill_address.state&.name,
+          region: bill_address.state&.abbr,
           postalCode: bill_address.zipcode,
           countryCodeAlpha2: bill_address.country&.iso,
         },
@@ -31,7 +31,7 @@ module SolidusPaypalBraintree
             streedAddress: ship_address.address1,
             extendedAddress: ship_address.address2,
             locality: ship_address.city,
-            region: ship_address.state&.name,
+            region: ship_address.state&.abbr,
             postalCode: ship_address.zipcode,
             countryCodeAlpha2: ship_address.country&.iso,
           }


### PR DESCRIPTION
Braintree states on their website that "any string up to 50 characters
is valid". This is not true, according to

https://stackoverflow.com/questions/65701058/sudden-failure-requests-on-braintree-sandbox-api-billing-state-format-is-inval

So apparently Braintree ACTUALLY wants a two-letter abbreviation.
We've tested this manually...