### PR TITLE
Include Persistable Module in SolidusPayPalBraintree::Configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ Layout/FirstHashElementIndentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+# We have a lot of these, and they're part of this gem's API.
+# The cop would want to rename e.g. `:last_4` to `:last4`.
+Naming/VariableNumber:
+  Enabled: false
+
 # We use this extensively, the alternatives are not viable or desirable.
 RSpec/AnyInstance:
   Enabled: false

--- a/app/models/solidus_paypal_braintree/configuration.rb
+++ b/app/models/solidus_paypal_braintree/configuration.rb
@@ -2,6 +2,9 @@
 
 module SolidusPaypalBraintree
   class Configuration < ::Spree::Base
+    if Spree.solidus_gem_version >= Gem::Version.new('2.11.8')
+      include Spree::Preferences::Persistable
+    end
     PAYPAL_BUTTON_PREFERENCES = {
       color: { availables: %w[gold blue silver white black], default: 'white' },
       shape: { availables: %w[pill rect], default: 'rect' },


### PR DESCRIPTION
This stops us from getting a deprecation warning on Solidus 2.11, and from outright failing to build on 3.0.