### PR TITLE
Set sandbox mode if environment is sandbox

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -41,6 +41,7 @@ SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
   this._paymentMethodId = this._client.paymentMethodId;
 
   this._client.getPaypalInstance().loadPayPalSDK({
+    "client-id": this._environment === "sandbox" ? "sb" : null,
     currency: this._paypalOptions.currency,
     commit: true,
     vault: this._paypalOptions.flow == "vault",


### PR DESCRIPTION
Currently if environment is passed in the options, it is set to a
prototype field and then promptly ignored and never used. This
configures the paypal client instance to use sandbox mode (through
loading with `client-id=sb` [as per the docs][1]) if the caller has
specified the environment to be "sandbox."

[1]: https://developer.paypal.com/docs/checkout/reference/customize-sdk/#client-id