### PR TITLE
Update to Braintree 3.4.0

### DIFF
--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'activemerchant', '~> 1.48'
-  s.add_dependency 'braintree', '~> 2.65'
+  s.add_dependency 'braintree', '~> 3.4'
   s.add_dependency 'solidus_api', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', ['>= 0.8.1', '< 1']


### PR DESCRIPTION
This updates the Braintree gem from v2.65 to v3.4. Among other benefits, this gives better insight into payment and refund declines by adding a processor response code in the API response object.

See https://www.braintreepayments.com/blog/refund-authorizations-api-updates-and-sandbox-testing/