### PR TITLE
Add Venmo as a PayPal funding option for checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,4 +283,14 @@ Simply add this require statement to your spec_helper:
 require 'solidus_paypal_braintree/factories'
 ```
 
+Development
+-------
+
+### Mocking your buyer country
+PayPal looks at the buyer's IP geolocation to determine what funding sources should be available to them. Because for example, Venmo is currently only available to US buyers. Because of this, you may want to pretend that you are from US so you can check if Venmo is correctly integrated for these customers. To do this, set the payment method's preference of `force_buyer_country` to "US". See more information about preferences above.
+
+This preference has no effect on production.
+
+## License
+
 Copyright (c) 2016-2020 Stembolt and others contributors, released under the New BSD License

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ using the
 [Vault flow](https://developers.braintreepayments.com/guides/paypal/overview/javascript/v3),
 which allows the source to be reused. Please note that PayPal messaging is disabled with vault flow. If you want, you can use [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3)
 instead, which doesn't allow you to reuse sources but allows your customers to pay with their PayPal
-balance and with PayPal financing options ([see setup instructions](#create-a-new-payment-method)).
+balance and with PayPal financing options ([see setup instructions](#create-a-new-payment-method)). More information about other [financing options below](#paypal-financing-options).
 
 If you are creating your own checkout view or would like to customize the
 [options that get passed to tokenize](https://braintree.github.io/braintree-web/3.6.3/PayPal.html#tokenize)
@@ -188,6 +188,26 @@ A PayPal button can also be included on the cart view to enable express checkout
 ```ruby
 render "spree/shared/paypal_cart_button"
 ```
+
+### PayPal financing options
+When using 'checkout' `paypal flow` and not 'vault'. Your customers can have different finance such as
+- paylater
+- Venmo
+
+#### Venmo
+Venmo is currently available to US merchants and buyers. There are also other [prequisites](https://developer.paypal.com/docs/business/checkout/pay-with-venmo/#eligibility).
+
+To enable Venmo be sure to have it enabled in your [Braintree account](https://developer.paypal.com/braintree/articles/guides/payment-methods/venmo#setup)
+
+By default, the extension and Braintree will try to render a Venmo button to buyers when prequisites are met and you have enabled it in your Braintree account).
+
+Set the SolidusPaypalBraintree `PaymentMethod` `enable_venmo_funding` preference to:
+- `enabled`, available as a PayPal funding option (if other prequisites are met); or
+- `disabled` (default).
+
+Note, Venmo is currently only available as a financing option on the checkout page; Venmo currently does not support shipping callbacks so it cannot be on the cart page.
+
+[_As Venmo is only available in the US, you may want to mock your location for testing_](#mocking-your-buyer-country)
 
 ### PayPal Financing Messaging
 

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -21,6 +21,11 @@ SolidusPaypalBraintree.PaypalButton = function(element, paypalOptions, options) 
   this._buyerCountry = this._paypalOptions.buyerCountry;
   delete paypalOptions['buyerCountry'];
 
+  this._enabledFunding = [];
+
+  if (paypalOptions['venmoFunding']) this._enabledFunding.push('venmo');
+  delete paypalOptions['venmoFunding'];
+
   if(!this._element) {
     throw new Error("Element for the paypal button must be present on the page");
   }
@@ -57,6 +62,9 @@ SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
 
   if (this._environment === "sandbox" && this._buyerCountry) {
     args["buyer-country"] = this._buyerCountry
+  }
+  if (this._enabledFunding.length !== 0) {
+    args["enable-funding"] = this._enabledFunding.join(',');
   }
 
   this._client.getPaypalInstance().loadPayPalSDK(args).then(() => {

--- a/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/paypal_button.js
@@ -72,6 +72,7 @@ SolidusPaypalBraintree.PaypalButton.prototype.initializeCallback = function() {
 
     var render_config = {
       style: this.style,
+      onClick: (data) => { SolidusPaypalBraintree.fundingSource = data.fundingSource },
       [create_method]: function () {
         return this._client.getPaypalInstance().createPayment(this._paypalOptions);
       }.bind(this),
@@ -142,6 +143,7 @@ SolidusPaypalBraintree.PaypalButton.prototype._transactionParams = function(payl
       "phone" : payload.details.phone,
       "nonce" : payload.nonce,
       "payment_type" : payload.type,
+      "paypal_funding_source": SolidusPaypalBraintree.fundingSource,
       "address_attributes" : this._addressParams(payload)
     }
   };

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -58,6 +58,10 @@ module SolidusPaypalBraintree
     # Wether to use the JS device data collector
     preference(:use_data_collector, :boolean, default: true)
 
+    # Useful for testing purposes, as PayPal will show funding sources based on the buyer's country;
+    # usually retrieved by their  ip geolocation. I.e. Venmo will show for US buyers, but not European.
+    preference(:force_buyer_country, :string)
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -62,6 +62,8 @@ module SolidusPaypalBraintree
     # usually retrieved by their  ip geolocation. I.e. Venmo will show for US buyers, but not European.
     preference(:force_buyer_country, :string)
 
+    preference(:enable_venmo_funding, :boolean, default: false)
+
     def partial_name
       "paypal_braintree"
     end

--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -8,6 +8,12 @@ module SolidusPaypalBraintree
     APPLE_PAY = "ApplePayCard"
     CREDIT_CARD = "CreditCard"
 
+    enum paypal_funding_source: {
+      applepay: 0, bancontact: 1, blik: 2, boleto: 3, card: 4, credit: 5, eps: 6, giropay: 7, ideal: 8,
+      itau: 9, maxima: 10, mercadopago: 11, mybank: 12, oxxo: 13, p24: 14, paylater: 15, paypal: 16, payu: 17,
+      sepa: 18, sofort: 19, trustly: 20, venmo: 21, verkkopankki: 22, wechatpay: 23, zimpler: 24
+    }, _suffix: :funding
+
     belongs_to :user, class_name: ::Spree::UserClassHandle.new, optional: true
     belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
     has_many :payments, as: :source, class_name: "Spree::Payment", dependent: :destroy
@@ -15,6 +21,8 @@ module SolidusPaypalBraintree
     belongs_to :customer, class_name: "SolidusPaypalBraintree::Customer", optional: true
 
     validates :payment_type, inclusion: [PAYPAL, APPLE_PAY, CREDIT_CARD]
+
+    before_save :clear_paypal_funding_source, unless: :paypal?
 
     scope(:with_payment_profile, -> { joins(:customer) })
     scope(:credit_card, -> { where(payment_type: CREDIT_CARD) })
@@ -84,6 +92,12 @@ module SolidusPaypalBraintree
       end
     end
 
+    def display_paypal_funding_source
+      I18n.t(paypal_funding_source,
+        scope: 'solidus_paypal_braintree.paypal_funding_sources',
+        default: paypal_funding_source)
+    end
+
     private
 
     def braintree_payment_method
@@ -99,6 +113,10 @@ module SolidusPaypalBraintree
 
     def braintree_client
       @braintree_client ||= payment_method.try(:braintree)
+    end
+
+    def clear_paypal_funding_source
+      self.paypal_funding_source = nil
     end
   end
 end

--- a/app/models/solidus_paypal_braintree/transaction.rb
+++ b/app/models/solidus_paypal_braintree/transaction.rb
@@ -6,7 +6,7 @@ module SolidusPaypalBraintree
   class Transaction
     include ActiveModel::Model
 
-    attr_accessor :nonce, :payment_method, :payment_type, :address, :email, :phone
+    attr_accessor :nonce, :payment_method, :payment_type, :paypal_funding_source, :address, :email, :phone
 
     validates :nonce, presence: true
     validates :payment_method, presence: true

--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -31,6 +31,7 @@ module SolidusPaypalBraintree
         nonce: transaction.nonce,
         payment_type: transaction.payment_type,
         payment_method: transaction.payment_method,
+        paypal_funding_source: transaction.paypal_funding_source,
         user: user
       )
     end

--- a/app/overrides/spree/payments/payment/add_paypal_funding_source_to_payment.rb
+++ b/app/overrides/spree/payments/payment/add_paypal_funding_source_to_payment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "payments/payment/add_paypal_funding_source_to_payment",
+  virtual_path: "spree/payments/_payment",
+  original: "0b5b5ae53626059cb3a202ef95d10827dd399925",
+  insert_after: "erb[loud]:contains('content_tag(:span, payment.payment_method.name)')",
+  partial: "solidus_paypal_braintree/payments/payment"
+)

--- a/app/views/spree/shared/_paypal_cart_button.html.erb
+++ b/app/views/spree/shared/_paypal_cart_button.html.erb
@@ -9,6 +9,7 @@
     amount: '<%= current_order.total %>',
     currency: '<%= current_order.currency %>',
     enableShippingAddress: true,
+    buyerCountry: '<%= SolidusPaypalBraintree::Gateway.first.preferred_force_buyer_country %>',
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>',
     locale: '<%= paypal_button_preference(:paypal_button_locale, store: current_store) %>',
     useDataCollector: <%= SolidusPaypalBraintree::Gateway.first.preferred_use_data_collector %>,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
     public_key: Public key
     token_generation_enabled: Token generation enabled?
     paypal_flow: PayPal flow
+    paypal_funding: 'PayPal Funding: %{funding}'
+    paypal_funding_source: 'PayPal Funding Source'
   solidus_paypal_braintree:
     braintree: Braintree
     nonce: Nonce
@@ -60,3 +62,29 @@ en:
       gateway_rejected: Gateway rejected this transaction.
       processor_declined: Processor declined this transaction.
       settlement_declined: Settlement was declined by processor.
+    paypal_funding_sources:
+       applepay: 'Apple Pay'
+       bancontact: 'Bancontact'
+       blik: 'BLIK'
+       boleto: 'Boleto'
+       card: 'Credit or debit card'
+       credit: 'PayPal Credit'
+       eps: 'eps'
+       giropay: 'giropay'
+       ideal: 'iDEAL'
+       itau: 'Itau'
+       maxima: 'Maxima'
+       mercadopago: 'Mercado Pago'
+       mybank: 'MyBank'
+       oxxo: 'Oxxo'
+       p24: 'Przelewy24'
+       paylater: 'Pay Later'
+       paypal: 'PayPal'
+       payu: 'PayU'
+       sepa: 'SEPA-Lastschrift'
+       sofort: 'Sofort'
+       trustly: 'Trustly'
+       venmo: 'Venmo'
+       verkkopankki: 'Verkkopankki'
+       wechatpay: 'WeChat Pay'
+       zimpler: 'Zimpler'

--- a/db/migrate/20211222170950_add_paypal_funding_source_to_solidus_paypal_braintree_sources.rb
+++ b/db/migrate/20211222170950_add_paypal_funding_source_to_solidus_paypal_braintree_sources.rb
@@ -1,0 +1,5 @@
+class AddPaypalFundingSourceToSolidusPaypalBraintreeSources < ActiveRecord::Migration[6.1]
+  def change
+    add_column :solidus_paypal_braintree_sources, :paypal_funding_source, :integer
+  end
+end

--- a/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
+++ b/lib/controllers/frontend/solidus_paypal_braintree/transactions_controller.rb
@@ -7,6 +7,7 @@ module SolidusPaypalBraintree
     PERMITTED_BRAINTREE_TRANSACTION_PARAMS = [
       :nonce,
       :payment_type,
+      :paypal_funding_source,
       :phone,
       :email,
       { address_attributes: [

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -20,7 +20,7 @@ module SolidusPaypalBraintree
 
     initializer "register_solidus_paypal_braintree_gateway", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
-      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type]
+      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type, :paypal_funding_source]
     end
 
     if SolidusSupport.frontend_available?

--- a/lib/solidus_paypal_braintree/factories.rb
+++ b/lib/solidus_paypal_braintree/factories.rb
@@ -6,6 +6,28 @@ FactoryBot.define do
   #
   # Example adding this to your spec_helper will load these Factories for use:
   # require 'solidus_paypal_braintree/factories'
+
+  factory :solidus_paypal_braintree_payment_method, class: SolidusPaypalBraintree::Gateway do
+    name 'Solidus PayPal Braintree Gateway'
+    active true
+  end
+
+  factory :solidus_paypal_braintree_source, class: SolidusPaypalBraintree::Source do
+    association(:payment_method, factory: :solidus_paypal_braintree_payment_method)
+    user
+
+    trait :credit_card do
+      payment_type SolidusPaypalBraintree::Source::CREDIT_CARD
+    end
+
+    trait :paypal do
+      payment_type SolidusPaypalBraintree::Source::PAYPAL
+    end
+
+    trait :apple_pay do
+      payment_type SolidusPaypalBraintree::Source::APPLE_PAY
+    end
+  end
 end
 
 FactoryBot.modify do

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_braintree.html.erb
@@ -28,6 +28,11 @@
           <dt><%= Spree::CreditCard.human_attribute_name(:last_digits) %>:</dt>
           <dd><%= payment.source.last_digits %></dd>
         <% end %>
+
+        <% if payment.source.paypal? %>
+          <dt><%= I18n.t('spree.paypal_funding_source') %>:</dt>
+          <dd><%= payment.source.display_paypal_funding_source %></dd>
+        <% end %>
       </dl>
     </div>
   </div>

--- a/lib/views/frontend/solidus_paypal_braintree/payments/_payment.html.erb
+++ b/lib/views/frontend/solidus_paypal_braintree/payments/_payment.html.erb
@@ -1,0 +1,4 @@
+<% if payment.source.respond_to?(:paypal_funding_source) && payment.source.paypal_funding_source.present? %>
+  <br />
+  <%= t('spree.paypal_funding', funding: payment.source.display_paypal_funding_source) %>
+<% end %>

--- a/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
+++ b/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
@@ -9,6 +9,7 @@
     amount: '<%= current_order.total %>',
     currency: '<%= current_order.currency %>',
     enableShippingAddress: true,
+    buyerCountry: '<%= SolidusPaypalBraintree::Gateway.first.preferred_force_buyer_country %>',
     shippingAddressOverride: address,
     shippingAddressEditable: false,
     environment: '<%= Rails.env.production? ? "production" : "sandbox" %>',

--- a/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
+++ b/lib/views/frontend/spree/shared/_paypal_checkout_button.html.erb
@@ -9,6 +9,7 @@
     amount: '<%= current_order.total %>',
     currency: '<%= current_order.currency %>',
     enableShippingAddress: true,
+    venmoFunding: <%= SolidusPaypalBraintree::Gateway.first.preferred_enable_venmo_funding %>,
     buyerCountry: '<%= SolidusPaypalBraintree::Gateway.first.preferred_force_buyer_country %>',
     shippingAddressOverride: address,
     shippingAddressEditable: false,

--- a/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
+++ b/spec/models/solidus_paypal_braintree/transaction_import_spec.rb
@@ -66,6 +66,12 @@ describe SolidusPaypalBraintree::TransactionImport do
       expect(subject.payment_method).to eq braintree_gateway
     end
 
+    it 'takes the paypal funding source from the transaction' do
+      transaction.paypal_funding_source = 'paypal'
+
+      expect(subject.paypal_funding_source).to eq('paypal')
+    end
+
     context 'when order has a user' do
       let(:user) { Spree.user_class.new }
       let(:order) { Spree::Order.new user: user }
@@ -199,6 +205,17 @@ describe SolidusPaypalBraintree::TransactionImport do
           expect(order.shipping_address.address1).to eq '350 5th Ave'
           expect(order.shipping_address.country).to eq country
           expect(order.shipping_address.state).to eq new_york
+        end
+
+        context 'when transaction has paypal funding source' do
+          it 'saves it to the payment source' do
+            transaction.paypal_funding_source = 'paypal'
+
+            subject
+
+            source = SolidusPaypalBraintree::Source.last
+            expect(source.paypal_funding_source).to eq('paypal')
+          end
         end
 
         context 'with a tax category' do


### PR DESCRIPTION
Resolves issues/tickets:
- https://github.com/solidusio/solidus_paypal_braintree/issues/304
- https://github.com/solidusio/solidus_paypal_braintree/issues/303

Setting the preference enable_venmo to true will now show a Venmo button
on checkout for customers to whom it is available.

For testing purposes, the string preference force_buyer_country was
added. You can use this to mock what country the buyer is from, allowing
you to see what funding sources are shown to customers in various
countries.

This preference does not affect checkout on production, environment.
Instead, PayPal will get this information from their IP geolocation.

More information:
https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#buyer-country