### PR TITLE
Require MFA for RubyGems actions

### DIFF
--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage
     s.metadata["source_code_uri"] = s.homepage if s.homepage
+    s.metadata["rubygems_mfa_required"] = 'true'
   end
 
   s.add_dependency 'activemerchant', '~> 1.48'


### PR DESCRIPTION
This setting tells RubyGems that MFA is required for accounts to be able
perform any of these privileged operations:
- gem push
- gem yank
- gem owner --add/remove
- adding or removing owners using gem ownership page

This helps make the gem more secure, as users can be more confident
that gem updates were pushed by maintainers.

More information:
https://guides.rubygems.org/mfa-requirement-opt-in/
https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa