### PR TITLE
Add skip_avs and skip_cvv AVS Result Mapping

### DIFF
--- a/app/models/solidus_paypal_braintree/avs_result.rb
+++ b/app/models/solidus_paypal_braintree/avs_result.rb
@@ -41,6 +41,9 @@ module SolidusPaypalBraintree
         'I' => 'I',
         'A' => 'I'
       },
+      'B' => {
+        'B' => 'B'
+      },
       nil => { nil => nil }
     }.freeze
 


### PR DESCRIPTION
This updates our `AVS_MAPPING` constant to be up-to-date with the
original mapping in ActiveMerchant, as per
https://github.com/activemerchant/active_merchant/pull/3241 .