### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,10 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 8
 
+# We don't use the FactoryBot mixin
+RSpec/FactoryBot/SyntaxMethods:
+  Enabled: false
+
 RSpec/VerifiedDoubles:
   # Sometimes you really need an "anything" double
   IgnoreSymbolicNames: true

--- a/app/models/solidus_paypal_braintree/configuration.rb
+++ b/app/models/solidus_paypal_braintree/configuration.rb
@@ -15,9 +15,7 @@ module SolidusPaypalBraintree
       include ::Spree::Preferences::Persistable
     end
 
-    belongs_to :store, class_name: 'Spree::Store'
-
-    validates :store, presence: true
+    belongs_to :store, class_name: 'Spree::Store', optional: false
 
     # Preferences for Paypal button
     PAYPAL_BUTTON_PREFERENCES.each do |name, desc|

--- a/app/models/solidus_paypal_braintree/transaction_import.rb
+++ b/app/models/solidus_paypal_braintree/transaction_import.rb
@@ -46,7 +46,7 @@ module SolidusPaypalBraintree
           order.shipping_address = order.billing_address = address
           # work around a bug in most solidus versions
           # about tax zone cachine between address changes
-          order.instance_variable_set("@tax_zone", nil)
+          order.instance_variable_set(:@tax_zone, nil)
         end
 
         payment = order.payments.new(


### PR DESCRIPTION
With recent updates of `rubocop-rspec` and `rubocop-rails`, we got a few new warnings that this PR addresses - some through following the cop's recommendations, some through disabling them. 