### PR TITLE
Lower ActiveRecord::Migration version in add_paypal_funding_source

### DIFF
--- a/db/migrate/20211222170950_add_paypal_funding_source_to_solidus_paypal_braintree_sources.rb
+++ b/db/migrate/20211222170950_add_paypal_funding_source_to_solidus_paypal_braintree_sources.rb
@@ -1,4 +1,4 @@
-class AddPaypalFundingSourceToSolidusPaypalBraintreeSources < ActiveRecord::Migration[6.1]
+class AddPaypalFundingSourceToSolidusPaypalBraintreeSources < ActiveRecord::Migration[5.0]
   def change
     add_column :solidus_paypal_braintree_sources, :paypal_funding_source, :integer
   end


### PR DESCRIPTION
The migration does not need any new features of Rails 6.1, so we can
safely use 5.0 and be backwards-compatible.