### PR TITLE
Do not safeguard including of Spree::Preferences::Persistable

### DIFF
--- a/app/models/solidus_paypal_braintree/configuration.rb
+++ b/app/models/solidus_paypal_braintree/configuration.rb
@@ -11,9 +11,7 @@ module SolidusPaypalBraintree
       messaging: { availables: %w[true false], default: 'false' }
     }.freeze
 
-    unless respond_to?(:preference)
-      include ::Spree::Preferences::Persistable
-    end
+    include ::Spree::Preferences::Persistable
 
     belongs_to :store, class_name: 'Spree::Store', optional: false
 


### PR DESCRIPTION
The safeguard prevents this module to be included because the
class responds to `preference` (it is included in `Spree::Base`).

My guess is that this safeguard was included to avoid including
`Spree::Preferences::Preferable` twice (it is included by `Spree::Preferences::Persistable`)

But Ruby will take care of not including the same module twice.

This will not effect user of Solidus >= 3.0, but helps to get rid of a (rather large) deprecation warning in Solidus 2.11