### PR TITLE
Fix exception when other payment methods active

### DIFF
--- a/lib/views/frontend/solidus_paypal_braintree/payments/_payment.html.erb
+++ b/lib/views/frontend/solidus_paypal_braintree/payments/_payment.html.erb
@@ -1,12 +1,12 @@
 <br />
-<%= payment.source.display_payment_type %>
+<%= payment.source.try(:display_payment_type) %>
 
-<% if payment.source.paypal? %>
+<% if payment.source.try(:paypal?) %>
   <% if payment.source.respond_to?(:paypal_funding_source) && payment.source.paypal_funding_source.present? %>
     <br />
     <%= t('spree.paypal_funding', funding: payment.source.display_paypal_funding_source) %>
   <% end %>
-<% elsif payment.source.venmo? %>
+<% elsif payment.source.try(:venmo?) %>
   <br />
   <%= payment.source.source_description %>
 <% end %>


### PR DESCRIPTION
When other payment methods are active, specifically solidus_affirm, these methods are not available and cause an exception.