### PR TITLE
Bump Rubocop TargetRubyVersion from 2.5 to 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent


### PR DESCRIPTION
Ruby 2.5 is no longer supported by Rubocop.