### PR TITLE
Fix specs to stub spree_current_user

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -11,9 +11,9 @@ module SolidusPaypalBraintree
     # Error message from Braintree that gets returned by a non voidable transaction
     NON_VOIDABLE_STATUS_ERROR_REGEXP = /can only be voided if status is authorized/.freeze
 
-    TOKEN_GENERATION_DISABLED_MESSAGE = 'Token generation is disabled.' \
-                                        ' To re-enable set the `token_generation_enabled` preference on the' \
-                                        ' gateway to `true`.'
+    TOKEN_GENERATION_DISABLED_MESSAGE = 'Token generation is disabled. ' \
+                                        'To re-enable set the `token_generation_enabled` preference on the ' \
+                                        'gateway to `true`.'
 
     ALLOWED_BRAINTREE_OPTIONS = [
       :device_data,

--- a/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
+++ b/spec/controllers/solidus_paypal_braintree/transactions_controller_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe SolidusPaypalBraintree::TransactionsController, type: :controller
 
         it "has a failed status" do
           post_create
-          expect(response.status).to eq 422
+          expect(response).to have_http_status :unprocessable_entity
         end
 
         it "returns the errors as JSON" do

--- a/spec/features/frontend/braintree_credit_card_checkout_spec.rb
+++ b/spec/features/frontend/braintree_credit_card_checkout_spec.rb
@@ -38,6 +38,7 @@ shared_context "with frontend checkout setup" do
 
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     allow_any_instance_of(Spree::Payment).to receive(:number).and_return("123ABC")
     allow_any_instance_of(SolidusPaypalBraintree::Source).to receive(:nonce).and_return("fake-valid-nonce")
 

--- a/spec/features/frontend/venmo_checkout_spec.rb
+++ b/spec/features/frontend/venmo_checkout_spec.rb
@@ -142,7 +142,11 @@ describe "Checkout", type: :feature, js: true do
     order.update!(user: user, number: order_number) # constant order number for VCRs
 
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-    allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: Spree::User.first)
+
+    first_user = Spree::User.first
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: first_user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: first_user)
+
     allow_any_instance_of(Spree::Payment).to receive(:gateway_order_id).and_return(order_number)
 
     visit spree.checkout_state_path(order.state)

--- a/spec/requests/spree/api/orders_controller_spec.rb
+++ b/spec/requests/spree/api/orders_controller_spec.rb
@@ -29,7 +29,7 @@ describe Spree::Api::OrdersController, type: :request do
       it "can be rendered correctly" do
         get "/api/orders/#{order.number}"
 
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
   end


### PR DESCRIPTION
Solidus recently migrated all migrated all uses of `try_spree_current_user` to `spree_current_user`. See
https://github.com/solidusio/solidus/commit/201d0e86b2bf97356735e1b90eea0e8df1402671.
