### PR TITLE
Fix broken factory

### DIFF
--- a/lib/solidus_paypal_braintree/factories.rb
+++ b/lib/solidus_paypal_braintree/factories.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   # require 'solidus_paypal_braintree/factories'
 
   factory :solidus_paypal_braintree_payment_method, class: SolidusPaypalBraintree::Gateway do
-    name 'Solidus PayPal Braintree Gateway'
-    active true
+    name { 'Solidus PayPal Braintree Gateway' }
+    active { true }
   end
 
   factory :solidus_paypal_braintree_source, class: SolidusPaypalBraintree::Source do
@@ -17,15 +17,15 @@ FactoryBot.define do
     user
 
     trait :credit_card do
-      payment_type SolidusPaypalBraintree::Source::CREDIT_CARD
+      payment_type { SolidusPaypalBraintree::Source::CREDIT_CARD }
     end
 
     trait :paypal do
-      payment_type SolidusPaypalBraintree::Source::PAYPAL
+      payment_type { SolidusPaypalBraintree::Source::PAYPAL }
     end
 
     trait :apple_pay do
-      payment_type SolidusPaypalBraintree::Source::APPLE_PAY
+      payment_type { SolidusPaypalBraintree::Source::APPLE_PAY }
     end
   end
 end


### PR DESCRIPTION
Factory uses static assignment, which was deprecated in FactoryBot v5,
so instantiating the factory raises an error for any project using a
recent release of FactoryBot.

Replaced static assignment with dynamic assignment to resolve this
issue.