### PR TITLE
Drop compatibility with Solidus < 2.4

### DIFF
--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activemerchant', '~> 1.48'
   spec.add_dependency 'braintree', '~> 3.4'
-  spec.add_dependency 'solidus_api', ['>= 2.0.0', '< 4']
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_api', ['>= 2.4.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.4.0', '< 4']
   spec.add_dependency 'solidus_support', ['>= 0.8.1', '< 1']
 
   spec.add_development_dependency 'rails-controller-testing'


### PR DESCRIPTION
This drops support for Solidus version <= 2.3, and stops a deprecation warning from happening when running the Gem under current Solidus versions.