### PR TITLE
Fix Rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - solidus_dev_support/rubocop
 
 AllCops:
-  NewCops: enable
+  NewCops: disable
   TargetRubyVersion: 2.6
 
 Layout/FirstArgumentIndentation:

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email     = 'braintree+gemfile@stembolt.com'
   s.homepage  = 'https://github.com/solidusio/solidus_paypal_braintree'
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
As linting warnings is included in the test suite, if introducing new
rules is not controlled, the suite will keep breaking upon new rules.
This is slowing down deploying as well as giving the repository a bad
appearance of breaking specs.