### PR TITLE
Fix sandbox generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,21 @@ PayPal looks at the buyer's IP geolocation to determine what funding sources sho
 
 This preference has no effect on production.
 
+### Running the sandbox
+
+To run this extension in a sandboxed Solidus application, you can run `bin/sandbox`. The path for
+the sandbox app is `./sandbox` and `bin/rails` will forward any Rails commands to
+`sandbox/bin/rails`.
+
+Here's an example:
+
+```
+$ bin/rails server
+=> Booting Puma
+=> Rails 7.0.4 application starting in development
+* Listening on tcp://127.0.0.1:3000
+Use Ctrl-C to stop
+
 ## License
 
 Copyright (c) 2016-2020 Stembolt and others contributors, released under the New BSD License

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -90,7 +90,7 @@ unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
-  --with-authentication=true \
+  --authentication="devise" \
   --payment-method=none \
   --frontend=${SOLIDUS_FRONTEND} \
   $@

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -70,6 +70,8 @@ gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
 
+# This Braintree extension contains a user decorator, so the user class must be loaded first.
+gem "solidus_auth_devise", "~> 2.5"
 gem '$extension_name', path: '..'
 
 group :test, :development do
@@ -83,6 +85,7 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
+# Still request "devise". Solidus will skip installing it again but will include its seeds.
 unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-if [ ! -z $DEBUG ]
+if [ -n "$DEBUG" ]
 then
   set -x
 fi
@@ -28,16 +28,14 @@ sqlite3|sqlite)
 esac
 echo "~~> Using $RAILSDB as the database engine"
 
-if [ -n $SOLIDUS_BRANCH ]
+if [ -z "$SOLIDUS_BRANCH" ]
 then
-  BRANCH=$SOLIDUS_BRANCH
-else
   echo "~~> Use 'export SOLIDUS_BRANCH=[master|v3.2|...]' to control the Solidus branch"
-  BRANCH="master"
+  SOLIDUS_BRANCH="master"
 fi
-echo "~~> Using branch $BRANCH of solidus"
+echo "~~> Using branch $SOLIDUS_BRANCH of solidus"
 
-if [ -z $SOLIDUS_FRONTEND ]
+if [ -z "$SOLIDUS_FRONTEND" ]
 then
   echo "~~> Use 'export SOLIDUS_FRONTEND=[solidus_frontend|solidus_starter_frontend]' to control the Solidus frontend"
   SOLIDUS_FRONTEND="solidus_frontend"
@@ -68,7 +66,7 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
+gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
 


### PR DESCRIPTION
## Summary
Before these changes, the sandbox generator was not working correctly. It would fail to seed data due to the authentication gem not being loaded before the extension. Also, the script was not defaulting to `master` for Solidus.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

~~- [ ] I have added automated tests to cover my changes.~~
~~- [ ] I have attached screenshots to demo visual changes.~~
~~- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~~
~~- [ ] I have updated the README to account for my changes.~~

<img width="1728" alt="Screenshot 2022-11-18 at 16 12 03" src="https://user-images.githubusercontent.com/76776099/202744519-e474bca7-7e57-4316-b482-7b570bd0e8ff.png">
