### PR TITLE
Fix setup intructions on Rails 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Payment methods can accept preferences either directly entered in admin, or from
 1. Set static preferences in an initializer
   ```ruby
   # config/initializers/spree.rb
-  Spree::Config.config do |config|
-    config.static_model_preferences.add(
+  Rails.application.config.to_prepare do
+    Spree::Config.static_model_preferences.add(
       SolidusPaypalBraintree::Gateway,
       'braintree_credentials', {
         environment: Rails.env.production? ? 'production' : 'sandbox',


### PR DESCRIPTION
## Summary

Since Rails 7, it's [no longer possible to reference a loadable constant](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload) on the initialize phase [1]. We need to wrap the setup within a `to_prepare` block, as it's already [documented on our guides](https://guides.solidus.io/advanced-solidus/model-preferences#static-preferences).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
